### PR TITLE
Update Docker with PG 16

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
       test: ["CMD", "redis-cli","ping"]
 
   postgres:
-    image: postgres:15
+    image: postgres:16
     ports: ['5432:5432']
     restart: always
     environment:


### PR DESCRIPTION
Noticed that CI relies on PG 16, therefore aligning both versions.