### PR TITLE
Register route

### DIFF
--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -5,7 +5,6 @@
     <main class="flex h-screen bg-white dark:bg-gray-800">
       <%= content_for?(:main) ? yield(:main) : yield %>
     </main>
-
     <%= render "layouts/toast" %>
   </body>
 </html>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <h2 class='text-3xl font-semibold'>Welcome back</h2>
 
   <span class='text-sm text-center'>
-    Don't have an account? <%= link_to "Sign up", new_user_path, class: "underline" %>
+    Don't have an account? <%= link_to "Sign up", register_path, class: "underline" %>
   </span>
 
   <%= form_with(url: login_path, method: :post, class: "flex flex-col space-y-4 w-80") do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
   resources :documents
   resources :users, only: [:new, :create, :update]
 
-  get "up" => "rails/health#show", :as => :rails_health_check
+  get "up" => "rails/health#show", as: :rails_health_check
 
   # routes to still be cleaned up:
 
@@ -26,5 +26,6 @@ Rails.application.routes.draw do
 
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
+  get "/register", to: "users#new"
   get "/logout", to: "sessions#destroy"
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UsersControllerTest < ActionDispatch::IntegrationTest
   test "should get new" do
-    get new_user_url
+    get register_url
     assert_response :success
   end
 


### PR DESCRIPTION
Since `login` exists I went with a named route for registration.