### PR TITLE
Toggle registration via feature flag

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,7 @@ class UsersController < ApplicationController
 
   layout "public"
 
-  before_action :ensure_registration, only: %i[new create]
+  before_action :ensure_registration, only: [:new, :create]
   before_action :set_user, only: [:update]
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   layout "public"
 
+  before_action :ensure_registration, only: %i[new create]
   before_action :set_user, only: [:update]
 
   def new
@@ -47,5 +48,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(preferences: [:nav_closed])
+  end
+
+  def ensure_registration
+    redirect_to root_path unless Feature.enabled?(:registration)
   end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Feature
+  class << self
+    def configuration
+      Rails.configuration.features
+    end
+
+    def enabled?(feature)
+      ActiveModel::Type::Boolean.new.cast(
+        configuration.fetch(feature&.to_sym, false)
+      )
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,7 @@ module HostedGPT
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.features = config_for(:features)
   end
 end

--- a/config/features.yml
+++ b/config/features.yml
@@ -1,0 +1,2 @@
+shared:
+  registration: <%= ENV.fetch("REGISTRATON_FEATURE", true) %>

--- a/test/models/feature_test.rb
+++ b/test/models/feature_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class FeatureTest < ActiveSupport::TestCase
+  test "configuration should be an instance of ActiveSupport::OrderedOptions" do
+    assert Feature.configuration.is_a?(ActiveSupport::OrderedOptions)
+  end
+
+  test "should return value of feature" do
+    Feature.stub :configuration, {my_feature: true} do
+      assert Feature.enabled?(:my_feature)
+    end
+
+    Feature.stub :configuration, {my_feature: false} do
+      refute Feature.enabled?(:my_feature)
+    end
+  end
+
+  test "should default to false when feature not found" do
+    Feature.stub :configuration, {my_feature: true} do
+      refute Feature.enabled?(:fake)
+    end
+  end
+end


### PR DESCRIPTION
Added a simple feature flag mechanism to toggle public registration (ON by default).

The idea is to prevent unauthorized access/spam.

Of course, it could be simpler and the controller could check the value of an env. variable but I was thinking that eventually it will grow (limit model access,...)