### PR TITLE
Fix docker tmp/server.pid & docker DB connections

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -35,6 +35,7 @@ services:
     ports: ["3000:3000"]
     volumes:
       - .:/rails
+      - /rails/tmp
 
   worker:
     <<: *base

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -7,7 +7,9 @@
 # Any libraries that use thread pools should be configured to match
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS") {
+  ENV.fetch("RAILS_ENV", "development") == "development" ? 2 : 5
+}
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 


### PR DESCRIPTION
Two changes to docker:

1. Occasionally exits and it leaves a `tmp/pids/server.pid` file in the host's app/tmp directory. This causes problems when you restart docker. The solution to fix this was discussed in [this thread](https://github.com/allyourbot/hostedgpt/discussions/187#discussioncomment-8751255). We are blacklisting the host's tmp from being visible to the docker image. The docker's ephemeral tmp will disappear when docker exists. In my limited testing, this appears to have fixed it but I can't reliably repro the situation so I'm not certain.
2. Occasionally my docker worker will stop picking up jobs. I'll see `[SolidQueue] Claimed 1 jobs` and then after a few seconds I'll see an error about "all database connections are taken up." I'm guessing that puma may be using all the connections so I've changed puma to only use 2 threads, by default, within development. I hope this fixes but I can't reliably repro.