### PR TITLE
Ensure composer maintains focus

### DIFF
--- a/app/javascript/controllers/new_message_controller.js
+++ b/app/javascript/controllers/new_message_controller.js
@@ -66,6 +66,6 @@ export default class extends Controller {
 
   boundEnableComposer = () => { this.enableComposer() }
   enableComposer() {
-    this.inputTarget.reset()
+    this.element.reset()
   }
 }

--- a/app/javascript/controllers/new_message_controller.js
+++ b/app/javascript/controllers/new_message_controller.js
@@ -66,6 +66,6 @@ export default class extends Controller {
 
   boundEnableComposer = () => { this.enableComposer() }
   enableComposer() {
-    this.inputTarget.value = ''
+    this.inputTarget.reset()
   }
 }

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -289,16 +289,6 @@
       <section class="flex-1 pl-0 md:pl-5">
         <figure class="flex py-2">
           <figcaption class="flex-grow flex items-center">
-            Copy last code block or response
-          </figcaption>
-          <kbd class="w-40 text-right">
-            <div class="key">Ctrl / ⌘</div>
-            <div class="key">Shift</div>
-            <div class="key">C</div>
-          </kbd>
-        </figure>
-        <figure class="flex py-2">
-          <figcaption class="flex-grow flex items-center">
             Toggle sidebar
           </figcaption>
           <kbd class="w-40 text-right">
@@ -321,4 +311,3 @@
     <button id="modal-backdrop">close</button>
   </form>
 </dialog>
-

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -231,6 +231,13 @@
               <%= icon "arrow-up-circle", variant: :solid, size: 39, title: 'Send message', tooltip: :top %>
             <% end %>
           </div>
+
+          <div
+            id="composer-overlay"
+            data-new-message-target="overlay"
+            class="absolute inset-0 bg-white bg-opacity-65 hidden">
+          </div>
+
         <% end %>
       </div>
 
@@ -280,6 +287,16 @@
 
       </section>
       <section class="flex-1 pl-0 md:pl-5">
+        <figure class="flex py-2">
+          <figcaption class="flex-grow flex items-center">
+            Copy last code block or response
+          </figcaption>
+          <kbd class="w-40 text-right">
+            <div class="key">Ctrl / ⌘</div>
+            <div class="key">Shift</div>
+            <div class="key">C</div>
+          </kbd>
+        </figure>
         <figure class="flex py-2">
           <figcaption class="flex-grow flex items-center">
             Toggle sidebar


### PR DESCRIPTION
This PR #190 created a visible indication to the user that the browser is waiting for the server to acknowledge the chat you are submitting. But it had a side effect: since `disable=true` alters the HTML of the textarea, when the server replies the textarea is morphed back to be enabled. This morph causes the textarea to lose keyboard focus. It's quite annoying.

This PR fixes it by not using `textarea.disabled = true`. Instead, it creates the illusion of disabling by putting a semi-transparent overlay on the composer. It listens for the server's acknowledgement and then resets the form state.