### PR TITLE
Turbo was executing the logout_path when the mouse entered the logout…

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,7 @@
 
               <menu tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
                 <li><%= link_to edit_settings_person_path do %><%= icon "cog-6-tooth", variant: :outline, size: 18 %>Settings<% end %></li>
-                <li><%= link_to logout_path do %><%= icon "arrow-right-start-on-rectangle", variant: :outline, size: 18 %>Logout<% end %></li>
+                <li><%= link_to logout_path, data: { turbo: false } do %><%= icon "arrow-right-start-on-rectangle", variant: :outline, size: 18 %>Logout<% end %></li>
               </menu>
             </div>
           </footer>


### PR DESCRIPTION
Turbo anticipates user actions by calling urls when the mouse enters the element. For the Logout button, Turbo was calling the logout_path and terminating the user's session.

Adding data: { turbo: false } to the button disables this behaviour on the logout button.