### PR TITLE
Fix for user.initials throwing exception on empty first_name

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,8 +17,10 @@ class User < ApplicationRecord
   end
 
   def initials
+    return nil if first_name.blank?
+
     [first_name, last_name]
-      .compact
+      .reject(&:blank?)
       .map { |name| name[0].capitalize }
       .join
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -34,8 +34,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "KS", users(:keith).initials
   end
 
-  test "initials returns 1 single letter when last name is blank" do
+  test "initials returns 1 single letter when last name is nil or blank" do
+    users(:rob).update!(last_name: nil)
     assert_equal "R", users(:rob).initials
+    users(:rob).update!(last_name: "")
+    assert_equal "R", users(:rob).initials
+  end
+
+  test "initials returns nil when first name is blank" do
+    users(:rob).update_columns(first_name: "", last_name: "Smith")
+    assert_nil users(:rob).initials
   end
 
   test "full_name returns nil if first_name and last_name are both blank" do


### PR DESCRIPTION
When first_name is "" rather than nil the app was throwing an exception.