### PR TITLE
Ensure copying to clipboard includes all markdown

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -53,9 +53,7 @@ module MessagesHelper
           end
         end +
         div_tag(class: "px-4 py-3") do
-          span_tag("\n```#{language}\n", class: "hidden") +
-          content_tag(:code, code, data: { clipboard_target: "text" }) +
-          span_tag("```\n", class: "hidden")
+          content_tag(:code, code, data: { clipboard_target: "text" })
         end
       end
     end

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -292,8 +292,8 @@
             <span>Copy last response <span class="whitespace-nowrap">(or code)</span></span>
           </figcaption>
           <kbd class="w-50 text-right flex flex-row gap-1">
-            <div class="key">Ctrl / ⌘</div>
             <div class="key">Shift</div>
+            <div class="key">Ctrl / ⌘</div>
             <div class="key">C</div>
           </kbd>
         </figure>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -45,9 +45,9 @@
         <%= image_tag message.documents.first.file, class: "w-full h-auto border-2 border-gray-100 rounded-md" %>
       <% end %>
 
+      <div class="hidden" data-clipboard-target="text"><%= message.content_text %></div>
       <div
         data-role="content-text"
-        data-clipboard-target="text"
         class="prose break-words leading-normal"
       >
         <%= formatted_text = format(message.content_text) %>

--- a/lib/redcarpet/custom_html_renderer.rb
+++ b/lib/redcarpet/custom_html_renderer.rb
@@ -1,5 +1,2 @@
 class Redcarpet::CustomHtmlRenderer < Redcarpet::Render::HTML
-  def codespan(code)
-    %(<code><span class="hidden">`</span>#{code}<span class="hidden">`</span></code>)
-  end
 end

--- a/test/lib/redcarpet/custom_html_renderer_test.rb
+++ b/test/lib/redcarpet/custom_html_renderer_test.rb
@@ -7,7 +7,7 @@ class CustomHtmlRendererTest < ActiveSupport::TestCase
 
   test "code_span" do
     markdown = "This is `code` inline."
-    formatted = "<p>This is <code><span class=\"hidden\">`</span>code<span class=\"hidden\">`</span></code> inline.</p>\n"
+    formatted = "<p>This is <code>code</code> inline.</p>\n"
 
     assert_equal formatted, @renderer.render(markdown)
   end


### PR DESCRIPTION
When copying a response which includes bulleted markdown (or other markdown like bold, italic, etc) the text that was copied to the clipboard was no longer including the markdown. This PR fixes it so that copied text to the clipboard is exactly as the LLM sent over.