### PR TITLE
Add an explicit stop icon within composer to end streaming

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
       direction = opts.delete(:tooltip) || 'bottom'
       data = opts.delete(:data) || {}
 
-      content_tag(:div,
+      content_tag(:span,
         class: classes + " tooltip tooltip-#{direction} hover:tooltip-open",
         style: "width: #{size}px; height: #{size}px;",
         data: { tip: title.to_s }.merge(data),
@@ -31,7 +31,7 @@ module ApplicationHelper
         heroicon name, **opts.slice(:size, :variant)
       end
     else
-      content_tag(:div,
+      content_tag(:span,
         class: classes,
         style: "width: #{size}px; height: #{size}px;",
         **opts.except(:class, :size, :variant)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -8,6 +8,10 @@ import "controllers"
 
 let oldTimestamp
 
+console.log('refresh document')
+document.addEventListener('turbo:visit', (event) => console.log(`visit ${event.detail.action}`))
+document.addEventListener('turbo:morph', () => console.log('morph render'))
+document.addEventListener('turbo:frame-render', () => console.log('frame render'))
 document.addEventListener('turbo:before-stream-render', (event) => {
   const stream = event.target
   const newElement = stream.children[0].content.children[0]
@@ -15,12 +19,6 @@ document.addEventListener('turbo:before-stream-render', (event) => {
   //const oldElement = document.getElementById(newElement.id.toString())
   if (newElement) newTimestamp = parseInt(newElement.getAttribute('data-timestamp'))
 
-  console.log(`${stream.getAttribute('action')} event - ${newTimestamp} ${newTimestamp <= oldTimestamp ? 'REORDER!' : ''}`, stream)
+  console.log(`stream render (${stream.getAttribute('action')} event) ${newTimestamp <= oldTimestamp ? 'REORDER!' : ''}`, stream)
   oldTimestamp = newTimestamp
 })
-
-console.log('refresh document')
-document.addEventListener('turbo:visit', (event) => console.log(`visit ${event.detail.action}`))
-document.addEventListener('turbo:morph', () => console.log('morph render'))
-document.addEventListener('turbo:frame-render', () => console.log('frame render'))
-document.addEventListener('turbo:before-stream-render', () => console.log('stream render'))

--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
   show() {
     this.imageTarget.classList.remove("hidden")
     this.loaderTarget.classList.add("hidden")
-    setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 200)
+    setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 50)
   }
 
   retryAfterDelay() {
@@ -40,7 +40,7 @@ export default class extends Controller {
     if (this.retryCount <= this.maxRetries) {
       this.imageTarget.classList.add("hidden")
       this.loaderTarget.classList.remove("hidden")
-      setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 200)
+      setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 50)
 
       setTimeout(() => {
         let srcBase = this.urlValue.split("?")[0]

--- a/app/javascript/controllers/new_message_controller.js
+++ b/app/javascript/controllers/new_message_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "input", "submit", "overlay" ]
+  static targets = [ "form", "input", "submit", "overlay", "cancel" ]
 
   get cleanInputValue() {
     return this.inputTarget.value.trim()
@@ -10,7 +10,7 @@ export default class extends Controller {
   connect() {
     this.inputTarget.focus()
     this.cursorToEnd()
-    this.disableSubmitButton()
+    this.toggleSubmitButton()
   }
 
   cursorToEnd() {
@@ -20,18 +20,20 @@ export default class extends Controller {
   }
 
   // Disable the submit button if the input is empty.
-  disableSubmitButton() {
+  toggleSubmitButton() {
     if (this.cleanInputValue.length < 1) {
       this.submitTarget.disabled = true
+      if (this.hasCancelTarget) this.cancelTarget.classList.remove('hidden')
     } else {
       this.submitTarget.disabled = false
+      if (this.hasCancelTarget) this.cancelTarget.classList.add('hidden')
     }
   }
 
   submitForm() {
     if (this.cleanInputValue.length > 0) {
       this.disableComposerUntilSubmit()
-      this.element.requestSubmit()
+      this.formTarget.requestSubmit()
       window.dispatchEvent(new CustomEvent('main-column-changed'))
     }
   }
@@ -66,6 +68,6 @@ export default class extends Controller {
 
   boundEnableComposer = () => { this.enableComposer() }
   enableComposer() {
-    this.element.reset()
+    this.formTarget.reset()
   }
 }

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -181,16 +181,27 @@
         </div>
 
         <% if @streaming_message %>
-          <%= form_with(model: @streaming_message, data: { new_message_target: "cancel", turbo_frame: "_top" }, class: "absolute top-2 right-8 z-10") do |form| %>
+          <%= form_with(
+            model: @streaming_message,
+            class: "absolute top-2 right-8 z-10",
+            data: {
+              new_message_target: "cancel",
+              turbo_frame: "_top" # this causes the page to morph, without this it does a frame replace
+          }) do |form| %>
             <%= form.hidden_field :cancelled_at, value: Time.current %>
-            <%= form.button type: "submit", class: "relative" do %>
+            <%= form.button id: "cancel", type: "submit", class: "relative" do %>
               <%= icon "stop", variant: :solid, size: 15, class: "absolute top-[6px] left-[6px]" %>
               <%= icon "stop-circle", variant: :outline, size: 39, title: 'Stop', tooltip: :top %>
             <% end %>
           <% end %>
         <% end %>
 
-        <%= form_with(model: [@assistant, @new_message], data: { new_message_target: "form", turbo_frame: "_top" }) do |form| %>
+        <%= form_with(
+          model: [@assistant, @new_message],
+          data: {
+            new_message_target: "form",
+            turbo_frame: "_top" # this causes the page to morph, without this it does a frame replace
+        }) do |form| %>
           <%= form.hidden_field :conversation_id %>
           <%= form.fields_for :documents, @new_message.documents.build do |document_form| %>
             <%= document_form.file_field :file, class: "hidden", data: { image_upload_target: "file" } %>

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -123,7 +123,7 @@
 
       <div  id="composer"
             class="flex-1 pl-6 pr-6 w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px] mx-auto relative leading-relaxed <%= @assistant.images.blank? && 'relationship' %>"
-            data-controller="image-upload"
+            data-controller="new-message image-upload"
       >
         <%= button_tag type: "button",
               id: "attach-button",
@@ -143,36 +143,54 @@
         <% end %>
 
         <div id="document-previews" class="absolute hidden space-x-3 left-7 top-3 show-previews:preview-container" data-image-upload-target="preview">
-            <div  class="flex flex-col items-stretch w-16 h-16 overflow-hidden border-2 border-gray-100 rounded-xl group"
-                  data-role="preview"
-            >
-              <%= button_tag type: "button",
-                  class: "rounded-full absolute -top-2 -right-2 border border-gray-300 bg-gray-200 hidden group-hover:block",
-                  data: {
-                    action: "image-upload#remove",
-                    role: "preview-remove"
-                  } do
+          <div class="
+              flex flex-col
+              items-stretch
+              w-16 h-16
+              overflow-hidden
+              border-2 border-gray-100
+              rounded-xl
+              group
+            "
+            data-role="preview"
+          >
+            <%= button_tag type: "button",
+              class: "rounded-full absolute -top-2 -right-2 border border-gray-300 bg-gray-200 hidden group-hover:block",
+              data: {
+                action: "image-upload#remove",
+                role: "preview-remove"
+              } do
+            %>
+              <%= icon "x-mark",
+                variant: :mini,
+                class: %|
+                  text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white
+                  cursor-pointer stroke-2
+                |,
+                title: 'Remove file',
+                tooltip: :top
               %>
-                <%= icon "x-mark",
-                      variant: :mini,
-                      class: %|
-                        text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white
-                        cursor-pointer stroke-2
-                      |,
-                      title: 'Remove file',
-                      tooltip: :top
-                %>
-              <% end %>
+            <% end %>
 
-              <%= button_tag type: "button",
-                    class: "w-full h-full flex-1 p-0" do
-              %>
+            <%= button_tag type: "button",
+              class: "w-full h-full flex-1 p-0" do
+            %>
               <%= image_tag "", class: "w-full h-full object-cover" %>
             <% end %>
           </div>
         </div>
 
-        <%= form_with(model: [@assistant, @new_message], data: { controller: "new-message", turbo_frame: "_top" }) do |form| %>
+        <% if @streaming_message %>
+          <%= form_with(model: @streaming_message, data: { new_message_target: "cancel", turbo_frame: "_top" }, class: "absolute top-2 right-8 z-10") do |form| %>
+            <%= form.hidden_field :cancelled_at, value: Time.current %>
+            <%= form.button type: "submit", class: "relative" do %>
+              <%= icon "stop", variant: :solid, size: 15, class: "absolute top-[6px] left-[6px]" %>
+              <%= icon "stop-circle", variant: :outline, size: 39, title: 'Stop', tooltip: :top %>
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <%= form_with(model: [@assistant, @new_message], data: { new_message_target: "form", turbo_frame: "_top" }) do |form| %>
           <%= form.hidden_field :conversation_id %>
           <%= form.fields_for :documents, @new_message.documents.build do |document_form| %>
             <%= document_form.file_field :file, class: "hidden", data: { image_upload_target: "file" } %>
@@ -185,7 +203,7 @@
               application_target: "newMessageField",
               controller: "textarea-autogrow",
               action: %|
-                new-message#disableSubmitButton
+                new-message#toggleSubmitButton
                 keydown.enter->new-message#submitForm:prevent
                 keydown.meta+enter->new-message#submitForm
                 keydown.ctrl+enter->new-message#submitForm

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,8 +6,8 @@
 <% initial_page_load = last_message && !scroll_down %>
 <% scroll_down = scroll_down || initial_page_load %>
 <% thinking = if thinking.nil?
-                (last_message && message.content_text.blank?) ||
-                (message.rerequested? && message.content_text.blank?)
+                (last_message && message.content_text.blank? && message.not_cancelled?) ||
+                (message.rerequested? && message.content_text.blank? && message.not_cancelled?)
               else
                 thinking
               end
@@ -50,7 +50,6 @@
       <div
         data-role="content-text"
         class="prose break-words leading-normal"
-        <%= thinking && "data-turbo-permanent" %>
       >
         <% if message.has_document_image? %>
           <%= button_tag type: "button",
@@ -80,7 +79,15 @@
                 inline-block
                 ml-1
                 #{!thinking && 'hidden'}
-              |)
+              |) +
+              span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
+              icon("stop",
+                variant: :solid,
+                size: 17,
+                title: "Stopped",
+                tooltip: :top,
+                class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
+              )
         %>
       </div>
 
@@ -131,6 +138,7 @@
                     params: { message: {
                       content_text: nil,
                       rerequested_at: Time.current,
+                      cancelled_at: nil,
                       assistant_id: assistant.id
                     } } do
                   %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -98,6 +98,7 @@
                 size: 17,
                 title: "Stopped",
                 tooltip: :top,
+                data: { role: "cancelled" },
                 class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
               )
         %>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,6 +7,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   fixtures :all
 
+  parallelize(workers: [4, Etc.nprocessors].min) # otherwise tests fail on a new Macbook Air b/c max_processors is too much
+
   def login_as(user_or_person, password = "secret")
     user = if user_or_person.is_a?(Person)
       user_or_person.user

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,7 +7,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   fixtures :all
 
-  parallelize(workers: [4, Etc.nprocessors].min) # otherwise tests fail on a new Macbook Air b/c max_processors is too much
+  parallelize(workers: [3, Etc.nprocessors].min) # otherwise tests fail on a new Macbook Air b/c max_processors is too much
 
   def login_as(user_or_person, password = "secret")
     user = if user_or_person.is_a?(Person)

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -210,7 +210,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     timeout = opts[:wait] || Capybara.default_max_wait_time
 
     Timeout.timeout(timeout) do
-      sleep 0.1 until block.call
+      sleep 0.25 until block.call
     end
   rescue Timeout::Error
     assert false, msg || "Expected block to return true, but it did not"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,8 +7,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   fixtures :all
 
-  parallelize(workers: [3, Etc.nprocessors].min) # otherwise tests fail on a new Macbook Air b/c max_processors is too much
-
   def login_as(user_or_person, password = "secret")
     user = if user_or_person.is_a?(Person)
       user_or_person.user
@@ -127,35 +125,46 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     raise "No block given" unless block_given?
 
     scroll_position_first_element_relative_viewport = page.evaluate_script("document.querySelector('#{selector}').children[1].getBoundingClientRect().top")
-    yield
-    new_scroll_position_first_element_relative_viewport = page.evaluate_script("document.querySelector('#{selector}').children[1].getBoundingClientRect().top")
 
-    assert_equal scroll_position_first_element_relative_viewport,
-      new_scroll_position_first_element_relative_viewport,
-      "The #{selector} should not have scrolled"
+    yield
+
+    assert_true "The #{selector} should not have scrolled", wait: 10 do
+      new_scroll_position_first_element_relative_viewport = page.evaluate_script("document.querySelector('#{selector}').children[1].getBoundingClientRect().top")
+
+      scroll_position_first_element_relative_viewport == new_scroll_position_first_element_relative_viewport
+    end
   end
 
   def assert_scrolled_up(selector = "section #messages")
     raise "No block given" unless block_given?
 
     scroll_position = get_scroll_position(selector)
+
     yield
-    assert get_scroll_position(selector) > scroll_position, "The #{selector} should have scrolled up"
+
+    assert_true "The #{selector} should have scrolled up", wait: 10 do
+      get_scroll_position(selector) > scroll_position
+    end
   end
 
   def assert_scrolled_down(selector = "section #messages")
     raise "No block given" unless block_given?
 
     scroll_position = get_scroll_position(selector)
+
     yield
-    assert get_scroll_position(selector) > scroll_position, "The #{selector} should have scrolled down"
+
+    assert_true "The #{selector} should have scrolled down", wait: 10 do
+      get_scroll_position(selector) > scroll_position
+    end
   end
 
   def assert_at_bottom(selector = "section #messages")
-    sleep 0.1
+    sleep Capybara.default_max_wait_time
     new_scroll_position = get_scroll_position(selector)
     scroll_to_bottom(selector)
-    assert_equal new_scroll_position, get_scroll_position(selector), "The #{selector} did not scroll to the bottom."
+    sleep Capybara.default_max_wait_time
+    assert_equal new_scroll_position, get_scroll_position(selector), "The #{selector} was able to move down so it was not at the bottom"
   end
 
   def assert_scrolled_to_bottom(selector = "section #messages")
@@ -173,6 +182,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     assert_at_bottom(selector)
     yield
+    sleep Capybara.default_max_wait_time
     assert_at_bottom(selector)
   end
 
@@ -194,6 +204,26 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
   def clipboard
     page.evaluate_script('window.clipboard')
+  end
+
+  def assert_true(msg = nil, opts = {}, &block)
+    timeout = opts[:wait] || Capybara.default_max_wait_time
+
+    Timeout.timeout(timeout) do
+      sleep 0.1 until block.call
+    end
+  rescue Timeout::Error
+    assert false, msg || "Expected block to return true, but it did not"
+  end
+
+  def assert_false(msg = nil, opts = {}, &block)
+    timeout = opts[:wait] || Capybara.default_max_wait_time
+
+    Timeout.timeout(timeout) do
+      sleep 0.1 until !block.call
+    end
+  rescue Timeout::Error
+    refute true, msg || "Expected block to return false, but it did not"
   end
 end
 

--- a/test/system/conversations/messages/images_test.rb
+++ b/test/system/conversations/messages/images_test.rb
@@ -103,7 +103,7 @@ class ConversationMessagesImagesTest < ApplicationSystemTestCase
       end
 
       assert img.visible?
-      sleep 0.5
+      sleep 1
       assert_at_bottom
     end
   end

--- a/test/system/conversations/messages/stop_streaming_test.rb
+++ b/test/system/conversations/messages/stop_streaming_test.rb
@@ -17,7 +17,7 @@ class ConversationMessagesStopStreamingTest < ApplicationSystemTestCase
     assert msg.find_role("cancelled").visible?
   end
 
-  test "an cancelled message with some text shows the stopped icon with ..." do
+  test "a cancelled message with some text shows the stopped icon with ..." do
     messages(:dont_know_day).update!(content_text: "But I", cancelled_at: Time.current)
     visit conversation_messages_path(@conversation)
 

--- a/test/system/conversations/messages/stop_streaming_test.rb
+++ b/test/system/conversations/messages/stop_streaming_test.rb
@@ -1,0 +1,29 @@
+require "application_system_test_case"
+
+class ConversationMessagesStopStreamingTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:keith)
+    login_as @user
+    @conversation = conversations(:greeting)
+  end
+
+  test "an empty cancelled message shows the stopped icon without ..." do
+    messages(:dont_know_day).update!(content_text: nil, cancelled_at: Time.current)
+    visit conversation_messages_path(@conversation)
+
+    msg = find("#message_#{messages(:dont_know_day).id}")
+
+    assert_equal "", msg.find_role("content-text").text
+    assert msg.find_role("cancelled").visible?
+  end
+
+  test "an cancelled message with some text shows the stopped icon with ..." do
+    messages(:dont_know_day).update!(content_text: "But I", cancelled_at: Time.current)
+    visit conversation_messages_path(@conversation)
+
+    msg = find("#message_#{messages(:dont_know_day).id}")
+
+    assert msg.find_role("content-text").text.include?("...")
+    assert msg.find_role("cancelled").visible?
+  end
+end

--- a/test/system/conversations/messages_test.rb
+++ b/test/system/conversations/messages_test.rb
@@ -134,6 +134,7 @@ class ConversationMessagesTest < ApplicationSystemTestCase
 
     assert_stays_at_bottom do
       resize_browser_to(1400, 700)
+      sleep 0.5
     end
   end
 
@@ -143,7 +144,7 @@ class ConversationMessagesTest < ApplicationSystemTestCase
 
     assert_did_not_scroll do
       resize_browser_to(1400, 700)
-      sleep 0.1
+      sleep 0.5
     end
   end
 

--- a/test/system/conversations/messages_test.rb
+++ b/test/system/conversations/messages_test.rb
@@ -134,7 +134,6 @@ class ConversationMessagesTest < ApplicationSystemTestCase
 
     assert_stays_at_bottom do
       resize_browser_to(1400, 700)
-      sleep 0.5
     end
   end
 
@@ -144,7 +143,6 @@ class ConversationMessagesTest < ApplicationSystemTestCase
 
     assert_did_not_scroll do
       resize_browser_to(1400, 700)
-      sleep 0.5
     end
   end
 

--- a/test/system/conversations/messages_test.rb
+++ b/test/system/conversations/messages_test.rb
@@ -47,7 +47,7 @@ class ConversationMessagesTest < ApplicationSystemTestCase
     assert_equal existing_assistant.name, last_message.find_role("from").text
 
     click_text "Using #{new_assistant.name}"
-    sleep 0.3
+    sleep 1
     assert_equal new_assistant.name, last_message.find_role("from").text
   end
 
@@ -58,18 +58,19 @@ class ConversationMessagesTest < ApplicationSystemTestCase
 
   test "the scroll appears and disappears based on scroll position" do
     scroll_to find_messages.second
-    assert_visible "#scroll-button", wait: 0.01
+    assert_visible "#scroll-button", wait: 1
 
     scroll_to first_message
-    assert_visible "#scroll-button", wait: 0.2
+    assert_visible "#scroll-button", wait: 1
 
     assert_scrolled_to_bottom do
       scroll_to last_message
-      assert_hidden "#scroll-button", wait: 0.2
+      assert_hidden "#scroll-button", wait: 1
     end
   end
 
   test "clicking scroll down button scrolls the page to the bottom" do
+    sleep 0.5
     scroll_to first_message
     assert_visible "#scroll-button", wait: 0.5
 
@@ -101,7 +102,7 @@ class ConversationMessagesTest < ApplicationSystemTestCase
   test "when the AI replies with a message it appears with morphing and scrolls down" do
     new_message = @long_conversation.messages.create! assistant: @long_conversation.assistant, content_text: "Stub: ", role: :assistant
     click_text @long_conversation.title
-    sleep 0.5
+    sleep 1
 
     assert last_message.text.include?("Stub:"), "The last message should have contained the submitted text"
 
@@ -162,6 +163,20 @@ class ConversationMessagesTest < ApplicationSystemTestCase
     msg
   end
 
+  def assert_page_morphed
+    raise "No block given" unless block_given?
+    watch_page_for_morphing
+
+    yield
+
+    sleep 1 # this delay is so long b/c we wait 0.5s before scrolling the page down
+    assert get_scroll_position("section #messages") > @messages_scroll_position, "The page should have scrolled down further"
+    assert_hidden "#scroll-button", "The page did not scroll all the way down"
+    assert tagged?("nav"), "The page did not morph; a tagged element got replaced."
+    assert tagged?(first_message), "The page did not morph; a tagged element got replaced."
+    assert_equal @nav_scroll_position, get_scroll_position("nav"), "The left column lost it's scroll position"
+  end
+
   def watch_page_for_morphing
     # Within automated system tests, it's difficult to know if a page morphed or not. When a page does morph
     # it should only replace the DOM elements which changed. This has the side effect of preserving scroll position.
@@ -187,20 +202,6 @@ class ConversationMessagesTest < ApplicationSystemTestCase
     end
 
     page.execute_script("arguments[0]._morphMonitor = true", element)
-  end
-
-  def assert_page_morphed
-    raise "No block given" unless block_given?
-    watch_page_for_morphing
-
-    yield
-
-    sleep 1 # this delay is so long b/c we wait 0.5s before scrolling the page down
-    assert get_scroll_position("section #messages") > @messages_scroll_position, "The page should have scrolled down further"
-    assert_hidden "#scroll-button", "The page did not scroll all the way down"
-    assert tagged?("nav"), "The page did not morph; a tagged element got replaced."
-    assert tagged?(first_message), "The page did not morph; a tagged element got replaced."
-    assert_equal @nav_scroll_position, get_scroll_position("nav"), "The left column lost it's scroll position"
   end
 
   def tagged?(selector_or_element)

--- a/test/system/conversations_test.rb
+++ b/test/system/conversations_test.rb
@@ -35,7 +35,7 @@ class ConversationsTest < ApplicationSystemTestCase
 
     fill_in "edit-conversation", with: "Meeting Samantha Jones"
     find("body").click
-    sleep 0.2
+    sleep 1
 
     assert_equal "Meeting Samantha Jones", convo.text
     assert_equal "Meeting Samantha Jones", conversations(:greeting).reload.title

--- a/test/system/messages/composer/stop_streaming_test.rb
+++ b/test/system/messages/composer/stop_streaming_test.rb
@@ -1,0 +1,56 @@
+require "application_system_test_case"
+
+class MessagesComposerStopStreamingTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:keith)
+    login_as @user
+    @conversation = conversations(:greeting)
+    visit conversation_messages_path(@conversation)
+  end
+
+  test "stop button shows in composer while replying and disappears when done" do
+    send_keys "You there?"
+    send_keys "enter"
+    sleep 0.2
+
+    assert_selector "#composer #cancel"
+
+    reply = @conversation.messages.ordered.last
+    reply.update!(content_text: "Yes")
+    stream_ai_message(reply)
+    finish_streaming
+
+    assert_no_selector "#composer #cancel"
+  end
+
+  test "stop button shows in composer while replying and clicking cancel stops it" do
+    send_keys "You there?"
+    send_keys "enter"
+    sleep 0.2
+
+    assert_selector "#composer #cancel"
+
+    reply = @conversation.messages.ordered.last
+    reply.update!(content_text: "Yes")
+    stream_ai_message(reply)
+    sleep 0.2
+
+    assert_changes "reply.reload.cancelled?", from: false, to: true do
+      click_element "#composer #cancel"
+      sleep 0.3
+    end
+
+    assert_no_selector "#composer #cancel"
+  end
+
+  private
+
+  def stream_ai_message(msg)
+    GetNextAIMessageJob.broadcast_updated_message(msg)
+  end
+
+  def finish_streaming
+    @conversation.broadcast_refresh
+    sleep 0.2
+  end
+end

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -55,7 +55,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     assert_active input
   end
 
-  test "when not in text input, ? opens the keyboard shortcuts and CLICKING OUTSIZDE dismisses it and keyboard shortcuts work normally" do
+  test "when not in text input, ? opens the keyboard shortcuts and CLICKING OUTSIDE dismisses it and keyboard shortcuts work normally" do
     send_keys "esc"
     assert_active "body"
     refute_text "Keyboard shortcuts"
@@ -228,7 +228,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
 
     send_keys "This is a second message"
     send_keys "enter"
-    sleep 0.5
+    sleep 1
 
     assert_equal path, current_path, "The page should not have changed urls"
     assert input.value.blank?, "The composer should have cleared itself"

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -178,12 +178,12 @@ class MessagesComposerTest < ApplicationSystemTestCase
     END
 
     click_text @long_conversation.title
-    sleep 0.2
+    sleep 0.4
 
     height = input.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys text.gsub(/\n/, ' ')
-      sleep 0.2
+      sleep 0.4
     end
     assert input.native.property('clientHeight') > height, "Input should have grown taller"
   end

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -206,10 +206,12 @@ class MessagesComposerTest < ApplicationSystemTestCase
     click_text @long_conversation.title
     sleep 0.2
     scroll_to find_messages.second
+    sleep 0.5
 
     height = input.native.property('clientHeight')
     assert_did_not_scroll do
       send_keys text.gsub(/\n/, ' ')
+      sleep 0.5
     end
     assert input.native.property('clientHeight') > height, "Input should have grown taller"
   end

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -10,6 +10,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
   end
 
   test "the cursor is auto-focused in the text input for a new conversation and selecting existing conversation and ESC unfocuses" do
+    sleep 0.2
     assert_active @input_selector
     send_keys "esc"
     assert_active "body"
@@ -17,7 +18,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     sleep 0.2
 
     click_text @long_conversation.title
-    sleep 0.2
+    sleep 0.4
     assert_active @input_selector
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,6 +17,8 @@ end
 class ActionDispatch::IntegrationTest
   include Rails.application.routes.url_helpers
 
+  Capybara.default_max_wait_time = 4
+
   def login_as(user_or_person)
     user = if user_or_person.is_a?(Person)
       user_or_person.user


### PR DESCRIPTION
Fixes #259 

Add tests:

- [x] Aborted messages show an icon at the end with a "..."
- [x] Empty aborted messages show an icon but without "..."
- [x] Stop icon appears immediately after creating a message and waiting for reply
- [x] Clicking stop icon morphs the page