### PR TITLE
Improve formatting of composer (paste, html, newlines)

### DIFF
--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -2,8 +2,10 @@ require "./lib/markdown_renderer"
 
 module MessagesHelper
   def format(text, append_inside_tag:)
+    escaped_text = html_escape(text)
+
     html = ::MarkdownRenderer.render(
-      text,
+      escaped_text,
       block_code: block_code
     )
 

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -216,16 +216,22 @@
               controller: "textarea-autogrow",
               action: %|
                 new-message#toggleSubmitButton
+
                 keydown.enter->new-message#submitForm:prevent
                 keydown.meta+enter->new-message#submitForm
                 keydown.ctrl+enter->new-message#submitForm
+
                 keydown.shift+esc@document->new-message#focusKeydown
                 keydown.slash@document->new-message#focusKeydown
+
                 keydown.esc->new-message#unfocusKeydown
+
                 keydown.meta+shift+o->new-message#unfocusKeydown
                 keydown.ctrl+shift+o->new-message#unfocusKeydown
                 keydown.meta+j->new-message#unfocusKeydown
                 keydown.ctrl+j->new-message#unfocusKeydown
+
+                paste->new-message#smartPaste
               |
             },
             rows: 1,

--- a/lib/redcarpet/custom_html_renderer.rb
+++ b/lib/redcarpet/custom_html_renderer.rb
@@ -1,2 +1,6 @@
 class Redcarpet::CustomHtmlRenderer < Redcarpet::Render::HTML
+  def paragraph(text)
+    text.gsub!("\n", "<br>\n")
+    "\n<p>#{text}</p>\n"
+  end
 end

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -4,7 +4,7 @@ hear_me:
   assistant: samantha
   conversation: greeting
   role: user
-  content_text: Can you hear me?
+  content_text: Can you hear <b>me</b>?
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
@@ -22,7 +22,12 @@ identify_photo:
   assistant: samantha
   conversation: greeting
   role: user
-  content_text: Can you identify photos?
+  content_text: |
+    Can you identify photos?
+
+    jpg
+    png
+    gif
   content_document:
   run:
   created_at: 2023-12-30 1:02:00

--- a/test/lib/redcarpet/custom_html_renderer_test.rb
+++ b/test/lib/redcarpet/custom_html_renderer_test.rb
@@ -9,7 +9,7 @@ class CustomHtmlRendererTest < ActiveSupport::TestCase
     markdown = "This is `code` inline."
     formatted = "<p>This is <code>code</code> inline.</p>\n"
 
-    assert_equal formatted, @renderer.render(markdown)
+    assert_equal formatted.strip, @renderer.render(markdown).strip
   end
 
   test "block_code perfectly formatted" do
@@ -32,7 +32,7 @@ class CustomHtmlRendererTest < ActiveSupport::TestCase
       <p>Line after.</p>
     HTML
 
-    assert_equal formatted, @renderer.render(markdown)
+    assert_equal formatted.strip, @renderer.render(markdown).strip
   end
 
   test "block_code missing a blank line before and after - ensure_newline_before_code_block_start" do
@@ -53,7 +53,7 @@ class CustomHtmlRendererTest < ActiveSupport::TestCase
       <p>Line after.</p>
     HTML
 
-    assert_equal formatted, @renderer.render(markdown)
+    assert_equal formatted.strip, @renderer.render(markdown).strip
   end
 
   test "block_code can be provided with a proc" do
@@ -74,11 +74,11 @@ class CustomHtmlRendererTest < ActiveSupport::TestCase
       <p>Line after.</p>
     HTML
 
-    assert_equal formatted, @renderer.render(markdown,
-      block_code: -> (code, language) do
-        %(<CODE lang="#{language}">#{code}</CODE>)
-      end
-    )
+    block_code = -> (code, language) do
+      %(<CODE lang="#{language}">#{code}</CODE>)
+    end
+
+    assert_equal formatted.strip, @renderer.render(markdown, block_code: block_code).strip
   end
 
   test "newlines within paragraphs get converted into BRs" do

--- a/test/lib/redcarpet/custom_html_renderer_test.rb
+++ b/test/lib/redcarpet/custom_html_renderer_test.rb
@@ -80,4 +80,27 @@ class CustomHtmlRendererTest < ActiveSupport::TestCase
       end
     )
   end
+
+  test "newlines within paragraphs get converted into BRs" do
+    markdown = <<~MD
+      This is the first paragraph
+
+      This is a second paragraph
+      with a line break.
+
+      This is a third paragraph
+
+    MD
+
+    formatted = <<~HTML
+      <p>This is the first paragraph</p>
+
+      <p>This is a second paragraph<br>
+      with a line break.</p>
+
+      <p>This is a third paragraph</p>
+    HTML
+
+    assert_equal formatted.strip, @renderer.render(markdown).strip
+  end
 end

--- a/test/system/conversations/messages/html_test.rb
+++ b/test/system/conversations/messages/html_test.rb
@@ -1,0 +1,22 @@
+require "application_system_test_case"
+
+class ConversationMessagesHtmlTest < ApplicationSystemTestCase
+  setup do
+    @user = users(:keith)
+    login_as @user
+    @conversation = conversations(:greeting)
+    visit conversation_messages_path(@conversation)
+  end
+
+  test "html is escaped so that it renders to the user" do
+    orig_msg_text = @conversation.messages.ordered.first.content_text
+    displayed_msg_text = first_message.find_role("content-text").text
+    assert_equal orig_msg_text, displayed_msg_text, "The HTML tag was not escaped"
+  end
+
+  test "newlines within a paragraph are preserved" do
+    orig_msg_text = @conversation.messages.ordered.third.content_text
+    displayed_msg_text = find_messages.third.find_role("content-text").text
+    assert_equal orig_msg_text.gsub("\n\n", "\n").strip, displayed_msg_text, "Newlines within a paragraph are not preserved"
+  end
+end

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -233,6 +233,8 @@ class MessagesComposerTest < ApplicationSystemTestCase
     assert input.value.blank?, "The composer should have cleared itself"
   end
 
+  # TODO: We do not have a test for the smart paste. I'm not sure how to programmatically paste from within capybara
+
   private
 
   def input


### PR DESCRIPTION
Fixes #258 and #261 

* When pasting, if it's a multi-line paste and the cursor is not in the middle of a line then add code blocks around it
* When the user has manually inserted newlines into their message, preserve those within paragraphs
* When the user includes HTML be sure to escape it