### PR TITLE
Thinking now signals waiting on API not server

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -84,13 +84,18 @@ class MessagesController < ApplicationController
   end
 
   def message_params
-    params.require(:message).permit(
+    modified_params = params.require(:message).permit(
       :conversation_id,
       :content_text,
       :assistant_id,
       :cancelled_at,
       :rerequested_at,
-      documents_attributes: [:file])
+      documents_attributes: [:file]
+    )
+    if modified_params[:content_text].blank? # when we rerequest the content_text: nil is mistakenly getting converted to ""
+      modified_params[:content_text] = nil
+    end
+    modified_params
   end
 
   def redis

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -24,8 +24,8 @@ class GetNextAIMessageJob < ApplicationJob
     raise WaitForPrevious if @prev_message && @prev_message.content_text.blank? && @prev_message.processed?
 
     last_sent_at = Time.current
-    @message.processed!
-    @message.content_text ||= ""
+    @message.update!(processed_at: Time.current, content_text: "")
+    GetNextAIMessageJob.broadcast_updated_message(@message, thinking: true) # signal to user that we're waiting on API
 
     response = ai_backend.new(@conversation.user, @assistant, @conversation, @message)
       .get_next_chat_message do |content_chunk|

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,8 +6,8 @@
 <% initial_page_load = last_message && !scroll_down %>
 <% scroll_down = scroll_down || initial_page_load %>
 <% thinking = if thinking.nil?
-                (last_message && message.content_text.blank? && message.not_cancelled?) ||
-                (message.rerequested? && message.content_text.blank? && message.not_cancelled?)
+                (last_message && message.content_text == "" && message.not_cancelled?) ||
+                (message.rerequested? && message.content_text == "" && message.not_cancelled?)
               else
                 thinking
               end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -247,6 +247,13 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       all("[data-role='image-loader']", visible: :all).map(&:visible?).include?(true)
     end
   end
+
+  def assert_composer_blank(msg = nil)
+    msg ||= "Composer input did not clear"
+    assert_true msg do
+      find("#composer textarea").value.blank?
+    end
+  end
 end
 
 class Capybara::Node::Element

--- a/test/system/conversations/messages/images_test.rb
+++ b/test/system/conversations/messages/images_test.rb
@@ -130,13 +130,13 @@ end
     send_keys "hello?"
     send_keys "enter"
 
-    assert_true { find("#composer textarea").value.blank? }
+    assert_composer_blank
     assert img.visible?
 
     send_keys "hello?"
     send_keys "enter"
 
-    assert_true { find("#composer textarea").value.blank? }
+    assert_composer_blank
     assert img.visible?
   end
 

--- a/test/system/messages/composer/stop_streaming_test.rb
+++ b/test/system/messages/composer/stop_streaming_test.rb
@@ -26,6 +26,7 @@ class MessagesComposerStopStreamingTest < ApplicationSystemTestCase
     send_keys "You there?"
     send_keys "enter"
 
+    assert_composer_blank
     assert_selector "#composer #cancel"
 
     reply = @conversation.messages.ordered.last

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -84,7 +84,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     sleep 0.5
 
     assert_equal conversation_messages_path(@user.conversations.ordered.first), current_path, "Should have redirected to newly created conversation"
-    assert input.value.blank?
+    assert_composer_blank
   end
 
   test "enter works to submit but only when text has been entered" do
@@ -100,7 +100,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     sleep 0.3
 
     assert_equal conversation_messages_path(@user.conversations.ordered.first), current_path, "Should have redirected to newly created conversation"
-    assert input.value.blank?
+    assert_composer_blank
   end
 
   test "shift+enter inserts a newline and then enter submits" do
@@ -116,7 +116,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     sleep 0.5
 
     assert_equal conversation_messages_path(@user.conversations.ordered.first), current_path, "Should have redirected to newly created conversation"
-    assert input.value.blank?
+    assert_composer_blank
   end
 
   test "textarea grows in height as newlines are added and shrinks in height when they are removed" do
@@ -203,14 +203,14 @@ class MessagesComposerTest < ApplicationSystemTestCase
     sleep 0.5
 
     assert_equal path, current_path, "The page should not have changed urls"
-    assert input.value.blank?, "The composer should have cleared itself"
+    assert_composer_blank
 
     send_keys "This is a second message"
     send_keys "enter"
     sleep 1
 
     assert_equal path, current_path, "The page should not have changed urls"
-    assert input.value.blank?, "The composer should have cleared itself"
+    assert_composer_blank
   end
 
   test "submitting a couple messages to an existing conversation with CLICKING works" do
@@ -223,14 +223,14 @@ class MessagesComposerTest < ApplicationSystemTestCase
     sleep 1
 
     assert_equal path, current_path, "The page should not have changed urls"
-    assert input.value.blank?, "The composer should have cleared itself"
+    assert_composer_blank
 
     send_keys "This is a second message"
     click_element @submit
     sleep 0.3
 
     assert_equal path, current_path, "The page should not have changed urls"
-    assert input.value.blank?, "The composer should have cleared itself"
+    assert_composer_blank
   end
 
   private


### PR DESCRIPTION
Occasionally the AI has hung and never responded. I just get an endless thinking.

I don't know if this is the server that is hung (i.e. job not getting picked up) or if this is the API that's hung. I suspect it's the API and I need to figure out a way to detect it and gracefully abort or retry.

As a first this PR alters the thinking animation so it gives me a clear signal. When the assistant's reply first renders there is no thinking animation. The thinking dot only begins once the job begins so thinking dot now clearly signals that it's now our server's fault.