### PR TITLE
Add support for versioned messages within the Message model

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -100,8 +100,8 @@ class MessagesController < ApplicationController
       :branched_from_version,
       documents_attributes: [:file]
     )
-    if modified_params.has_key?(:content_text) && modified_params[:content_text].blank? # when we rerequest the content_text: nil is mistakenly getting converted to ""
-      modified_params[:content_text] = nil
+    if modified_params.has_key?(:content_text) && modified_params[:content_text].blank?
+      modified_params[:content_text] = nil # nil and "" have different meanings
     end
     modified_params
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -11,14 +11,6 @@ class MessagesController < ApplicationController
   before_action :set_conversation_starters, only: [:new]
 
   def index
-    if @version.blank?
-      version = @conversation.messages.order(:created_at).last&.version
-      redirect_to conversation_messages_path(
-        params[:conversation_id],
-        version: version
-      ) if version
-    end
-
     @messages = @conversation.messages.for_conversation_version(@version)
     @new_message = @assistant.messages.new(conversation: @conversation)
     @streaming_message = Message.where(

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -32,7 +32,7 @@ class MessagesController < ApplicationController
     @message = @assistant.messages.new(message_params)
 
     if @message.save
-      GetNextAIMessageJob.perform_later(@message.conversation.latest_message.id, @assistant.id)
+      GetNextAIMessageJob.perform_later(@message.conversation.latest_message_for_version(:latest).id, @assistant.id)
       redirect_to conversation_messages_path(@message.conversation)
     else
       # what's the right flow for a failed message create? it's not this, but hacking it so tests pass until we have a plan

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,7 @@ class MessagesController < ApplicationController
   before_action :set_conversation_starters, only: [:new]
 
   def index
-    @messages = @conversation.messages.ordered
+    @messages = @conversation.messages.latest_version_for_conversation
     @new_message = @assistant.messages.new(conversation: @conversation)
     @streaming_message = Message.where(
       content_text: nil,
@@ -68,7 +68,7 @@ class MessagesController < ApplicationController
 
   def set_assistant
     @assistant = Current.user.assistants.find_by(id: params[:assistant_id])
-    @assistant ||= @conversation.messages.ordered.last.assistant
+    @assistant ||= @conversation.messages.latest_version_for_conversation.last.assistant
   end
 
   def set_message

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -37,7 +37,7 @@ class MessagesController < ApplicationController
         @message.conversation.latest_message_for_version(@message.version).id,
         @assistant.id
       )
-      redirect_to conversation_messages_path(@message.conversation, version: @message.version)
+      redirect_to conversation_messages_path(@message.conversation
     else
       # what's the right flow for a failed message create? it's not this, but hacking it so tests pass until we have a plan
       set_nav_conversations
@@ -51,7 +51,7 @@ class MessagesController < ApplicationController
   def update
     if @message.update(message_params)
       GetNextAIMessageJob.perform_later(@message.id, @message.assistant.id) if @message.previous_changes.any?
-      redirect_to conversation_messages_path(@message.conversation, version: @version || @message.version)
+      redirect_to conversation_messages_path(@message.conversation)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -37,7 +37,7 @@ class MessagesController < ApplicationController
         @message.conversation.latest_message_for_version(@message.version).id,
         @assistant.id
       )
-      redirect_to conversation_messages_path(@message.conversation
+      redirect_to conversation_messages_path(@message.conversation)
     else
       # what's the right flow for a failed message create? it's not this, but hacking it so tests pass until we have a plan
       set_nav_conversations

--- a/app/models/concerns/scopes/lib/boolean.rb
+++ b/app/models/concerns/scopes/lib/boolean.rb
@@ -9,6 +9,14 @@ module Scopes::Lib::Boolean
     boolean_columns.each do |column|
       auto_scope "#{column.name}", -> { where(column.name => true) }, column: column.name
       auto_scope "not_#{column.name}", -> { where(column.name => false) }, column: column.name
+
+      define_method "not_#{column.name}" do
+        !send("#{column.name}?")
+      end
+
+      define_method "not_#{column.name}?" do
+        !send("#{column.name}?")
+      end
     end
   end
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,4 +1,6 @@
 class Conversation < ApplicationRecord
+  include Version
+
   belongs_to :user
   belongs_to :assistant
 
@@ -11,10 +13,6 @@ class Conversation < ApplicationRecord
   scope :ordered, -> { order(updated_at: :desc) }
 
   broadcasts_refreshes
-
-  def latest_message
-    messages.ordered.last
-  end
 
   # Builds a hash of date interval keys and queries which fetch the records for that internal.
   #
@@ -57,7 +55,6 @@ class Conversation < ApplicationRecord
       .to_h
       .delete_if { |_, v| v.empty? }
   end
-
 
   private
 

--- a/app/models/conversation/version.rb
+++ b/app/models/conversation/version.rb
@@ -1,0 +1,11 @@
+module Conversation::Version
+  extend ActiveSupport::Concern
+
+  def latest_message
+    messages.latest_version_for_conversation.last
+  end
+
+  def latest_version_for_message_index(index)
+    messages.where(index: index).maximum(:version)
+  end
+end

--- a/app/models/conversation/version.rb
+++ b/app/models/conversation/version.rb
@@ -2,7 +2,11 @@ module Conversation::Version
   extend ActiveSupport::Concern
 
   def latest_message
-    messages.latest_version_for_conversation.last
+    raise "would have returned #{msg&.id} - Change to latest_message_for_version"
+  end
+
+  def latest_message_for_version(version = nil)
+    messages.for_conversation_version(version).last
   end
 
   def latest_version_for_message_index(index)

--- a/app/models/conversation/version.rb
+++ b/app/models/conversation/version.rb
@@ -1,10 +1,6 @@
 module Conversation::Version
   extend ActiveSupport::Concern
 
-  def latest_message
-    raise "would have returned #{msg&.id} - Change to latest_message_for_version"
-  end
-
   def latest_message_for_version(version = nil)
     messages.for_conversation_version(version).last
   end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,7 +18,6 @@ class Message < ApplicationRecord
   validate  :validate_conversation,  if: -> { conversation.present? && Current.user }
   validate  :validate_assistant,     if: -> { assistant.present? && Current.user }
 
-
   after_create :start_assistant_reply, if: :user?
   after_create :set_latest_assistant_message, if: :assistant?
   after_save :update_assistant_on_conversation, if: -> { assistant.present? && conversation.present? }
@@ -54,7 +53,7 @@ class Message < ApplicationRecord
   end
 
   def set_latest_assistant_message
-    redis.set("conversation-#{conversation_id}-latest_message-id", id)
+    redis.set("conversation-#{conversation_id}-latest-assistant_message-id", id)
   end
 
   def update_assistant_on_conversation

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,7 +18,7 @@ class Message < ApplicationRecord
   validate  :validate_conversation,  if: -> { conversation.present? && Current.user }
   validate  :validate_assistant,     if: -> { assistant.present? && Current.user }
 
-  scope :ordered, -> { order(:created_at) }
+  scope :ordered, -> { latest_version_for_conversation }
 
   after_create :start_assistant_reply, if: -> { user? }
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  include DocumentImage, Cancellable
+  include DocumentImage, Version, Cancellable
 
   belongs_to :assistant
   belongs_to :conversation

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,52 +1,28 @@
 class Message < ApplicationRecord
+  include DocumentImage, Cancellable
+
   belongs_to :assistant
   belongs_to :conversation
   belongs_to :content_document, class_name: "Document", optional: true
   belongs_to :run, optional: true
 
-  has_many :documents, dependent: :destroy
-
   enum role: %w[user assistant].index_by(&:to_sym)
 
   delegate :user, to: :conversation
 
-  accepts_nested_attributes_for :documents
-
   before_validation :set_default_role, on: :create
-  before_validation :create_conversation, on: :create, if: -> { conversation.blank? }
+  before_validation :create_conversation, on: :create, if: -> { conversation.blank? }, prepend: true
 
   validates :role, presence: true
   validates :content_text, presence: true, unless: :assistant?
-  validate :validate_conversation, if: -> { conversation.present? && Current.user }
-  validate :validate_assistant, if: -> { assistant.present? && Current.user }
+  validate  :validate_conversation,  if: -> { conversation.present? && Current.user }
+  validate  :validate_assistant,     if: -> { assistant.present? && Current.user }
 
   scope :ordered, -> { order(:created_at) }
 
   after_create :start_assistant_reply, if: -> { user? }
 
   after_save :update_assistant_on_conversation, if: -> { assistant.present? && conversation.present? }
-  after_save :save_cancelled_id_to_redis, if: :saved_change_to_cancelled_at?
-
-  def has_document_image?(variant = nil)
-    has_image = documents.present? && documents.first.file.attached?
-    if has_image && variant
-      has_image = documents.first.has_file_variant_processed?(variant)
-    end
-
-    !!has_image
-  end
-
-  def document_image_path(variant, fallback: nil)
-    return nil unless has_document_image?
-
-    if documents.first.has_file_variant_processed?(variant)
-      documents.first.fully_processed_url(variant)
-    elsif fallback.nil?
-      documents.first.redirect_to_processed_path(variant)
-    else
-      fallback
-    end
-  end
 
   private
 
@@ -74,15 +50,5 @@ class Message < ApplicationRecord
   def update_assistant_on_conversation
     return if conversation.assistant == assistant
     conversation.update!(assistant: assistant)
-  end
-
-  def save_cancelled_id_to_redis
-    redis.set("message-cancelled-id", id)
-  end
-
-  private
-
-  def redis
-    RedisConnection.client
   end
 end

--- a/app/models/message/cancellable.rb
+++ b/app/models/message/cancellable.rb
@@ -1,0 +1,17 @@
+module Message::Cancellable
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :save_cancelled_id_to_redis, if: :saved_change_to_cancelled_at?
+  end
+
+  private
+
+  def save_cancelled_id_to_redis
+    redis.set("message-cancelled-id", id)
+  end
+
+  def redis
+    RedisConnection.client
+  end
+end

--- a/app/models/message/document_image.rb
+++ b/app/models/message/document_image.rb
@@ -1,0 +1,30 @@
+module Message::DocumentImage
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :documents, dependent: :destroy
+
+    accepts_nested_attributes_for :documents
+  end
+
+  def has_document_image?(variant = nil)
+    has_image = documents.present? && documents.first.file.attached?
+    if has_image && variant
+      has_image = documents.first.has_file_variant_processed?(variant)
+    end
+
+    !!has_image
+  end
+
+  def document_image_path(variant, fallback: nil)
+    return nil unless has_document_image?
+
+    if documents.first.has_file_variant_processed?(variant)
+      documents.first.fully_processed_url(variant)
+    elsif fallback.nil?
+      documents.first.redirect_to_processed_path(variant)
+    else
+      fallback
+    end
+  end
+end

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -48,7 +48,10 @@ module Message::Version
       if index > 0 && !conversation.messages.exists?(index: index-1)
         errors.add(:index, "cannot skip a number")
       else # index is valid
-        v =   conversation.latest_version_for_message_index(index)
+        v = conversation.latest_version_for_message_index(index)
+        if v && conversation.latest_message && v < conversation.latest_message.version
+          v = conversation.latest_message&.version
+        end
         v ||= conversation.latest_message&.version&.-1
 
         if version.blank?

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -41,7 +41,6 @@ module Message::Version
         select("DISTINCT ON (index) messages.*").
         select("CASE WHEN mB.version IS NOT NULL THEN mB.version ELSE messages.version END as max_branched_to").
         select("CASE WHEN messages.branched THEN STRING_AGG(mV.version::text, ',') OVER (PARTITION BY messages.index,messages.version ORDER BY mV.version ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) ELSE null END AS versions").
-        select("ROW_NUMBER() OVER (ORDER BY messages.index ASC, messages.version DESC) AS subq_position").
         order("messages.index").order(max_branched_to: :desc).order("messages.version DESC").
         where("messages.index <= ? AND messages.version <= ?", index, version)
     end

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -5,10 +5,16 @@ module Message::Version
   # a set of callbacks that let you create messages without having to explicitly set the message version or
   # index. But if explicitly set version and index then validations will check them.
   #
-  # See conversations.yml versioned for a visual
+  # See conversations.yml :versioned for a visual
   included do
-    before_validation :set_next_conversation_index, on: :create
-    before_validation :set_default_version,         on: :create
+    attribute :versions, :string, default: ""
+
+    before_validation :set_next_conversation_index_and_version, on: :create
+    before_validation :set_default_version,                     on: :create
+
+    validate :branched_and_version_both_set,      if: -> { branched? || branched_from_version.present? }, on: :create
+
+    after_create :set_branched_on_other_message,  if: :branched?
 
     scope :latest_version_for_conversation, -> { for_conversation_version(:latest) }
 
@@ -17,7 +23,7 @@ module Message::Version
       c_id = all.where_clause.send(:predicates).find { |p| p.left.name == "conversation_id" }&.right&.value
       raise "latest_version_for_conversation needs to be used on a conversation's messages" if c_id.nil?
 
-      if version == :latest
+      if version.to_s == "latest"
         # Find the message which is the highest index for the highest version
         last_msg_for_version = Message.select(:index, :version).where(conversation_id: c_id).
           order(version: :desc).order(index: :desc).first
@@ -26,15 +32,23 @@ module Message::Version
           order(version: :desc).order(index: :desc).first
       end
 
-      select("DISTINCT ON (index) *").
-        select("MAX(index) OVER (PARTITION BY version) AS max_index_for_version").
-        select("ROW_NUMBER() OVER (ORDER BY index ASC, version DESC) AS subq_position").
-        order(:index).order(max_index_for_version: :desc).order(version: :desc).
-        where("version <= ? AND index <= ?",
-          (last_msg_for_version&.version || 1),
-          (last_msg_for_version&.index || 0)
-        )
+      version = last_msg_for_version&.version || 1
+      index = last_msg_for_version&.index || 0
+
+      joins("LEFT JOIN messages mB ON mB.branched_from_version = messages.version AND mB.conversation_id = messages.conversation_id AND mB.version <= #{version}").
+      joins("INNER JOIN messages mV ON mV.index = messages.index AND mV.conversation_id = messages.conversation_id").
+        select("DISTINCT ON (index) messages.*").
+        select("CASE WHEN mB.version IS NOT NULL THEN mB.version ELSE messages.version END as max_branched_to").
+        select("CASE WHEN messages.branched THEN STRING_AGG(mV.version::text, ',') OVER (PARTITION BY messages.index,messages.version ORDER BY mV.version ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) ELSE null END AS versions").
+        select("ROW_NUMBER() OVER (ORDER BY messages.index ASC, messages.version DESC) AS subq_position").
+        order("messages.index").order(max_branched_to: :desc).order("messages.version DESC").
+        where("messages.index <= ? AND messages.version <= ?", index, version)
     end
+  end
+
+  def versions
+    return [] if not_branched?
+    super.to_s.split(",").map(&:to_i).uniq.sort
   end
 
   def full_version
@@ -43,15 +57,18 @@ module Message::Version
 
   private
 
-  def set_next_conversation_index
+  def set_next_conversation_index_and_version
     if index.present?
       versions = conversation.messages.where(index: index).pluck(:version).sort
-      latest_msg = conversation.latest_message
+      latest_msg = conversation.latest_message_for_version(:latest)
       max_version = 1
-      if latest_msg && index <= latest_msg.index
-        max_version = [versions.last.to_i, latest_msg.version].max + 1
-      elsif latest_msg && index > latest_msg.index
-        max_version = conversation.latest_message&.version
+      if latest_msg
+        if branched
+          max_version = conversation.messages.maximum(:version) + 1
+        else
+          # didn't specify the version & didn't indicate branching so assume we're continuing the latest conversation
+          max_version = conversation.latest_message_for_version(:latest)&.version
+        end
       end
 
       self.version ||= max_version
@@ -74,7 +91,7 @@ module Message::Version
         errors.add(:version, "cannot be set without also setting index")
       end
       if index.blank? && version.blank?
-        latest_msg = self.conversation.latest_message
+        latest_msg = self.conversation.latest_message_for_version(:latest)
         self.index    = (latest_msg&.index   || -1) + 1
         self.version  =  latest_msg&.version || 1
       end
@@ -83,5 +100,14 @@ module Message::Version
 
   def set_default_version
     self.version ||= 1
+  end
+
+  def branched_and_version_both_set
+    errors.add(:branched, 'must be set when branched_from_version is specified') if not_branched?
+    errors.add(:branched_from_version, 'must be set when branched is true') if branched_from_version.nil?
+  end
+
+  def set_branched_on_other_message
+    conversation.messages.find_by(index: index, version: branched_from_version).update_columns(branched: true)
   end
 end

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -20,6 +20,7 @@ module Message::Version
 
     scope :for_conversation_version, ->(version) do
       version ||= :latest
+      raise "for_conversation_version(version) takes a numerical version or :latest" if version != :latest && version.to_s.to_i.to_s != version.to_s
       c_id = all.where_clause.send(:predicates).find { |p| p.left.name == "conversation_id" }&.right&.value
       raise "latest_version_for_conversation needs to be used on a conversation's messages" if c_id.nil?
 

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -1,0 +1,79 @@
+module Message::Version
+  extend ActiveSupport::Concern
+
+  # Scopes for retrieving all the messages in a conversation by latest version or a specific version. Plus,
+  # a set of callbacks that let you create messages without having to explicitly set the message version or
+  # index. But if explicitly set version and index then validations will check them.
+  #
+  # See conversations.yml versioned for a visual
+  included do
+    before_validation :set_next_conversation_index, on: :create
+    before_validation :set_default_version,         on: :create
+
+    before_create     :clear_preexisting_version_of_conversation, if: :conversation
+
+    scope :latest_version_for_conversation, -> { for_conversation_version(:latest) }
+
+    scope :for_conversation_version, ->(v) do
+      c_id = all.where_clause.send(:predicates).find { |p| p.left.name == "conversation_id" }&.right&.value
+      raise "latest_version_for_conversation needs to be used on a conversation's messages" if c_id.nil?
+
+      if v == :latest
+        # Find the message which is the highest index for the highest version
+        m = Message.select(:index, :version).where(conversation_id: c_id).
+          order(version: :desc).order(index: :desc).first
+      else
+        m = Message.select(:index, :version).where(conversation_id: c_id).where("version <= ?", v).
+          order(version: :desc).order(index: :desc).first
+      end
+
+      select("DISTINCT ON (index) *").
+        select("ROW_NUMBER() OVER (ORDER BY index ASC, version DESC) AS subq_position").
+        order(:index).order(version: :desc).
+        where("index <= ? AND version <= ?",
+          (m&.index || 0),
+          (m&.version || 1),
+        )
+    end
+  end
+
+  def full_version
+    "#{index}.#{version}".to_f
+  end
+
+  private
+
+  def set_next_conversation_index
+    if index.present?
+      if index > 0 && !conversation.messages.exists?(index: index-1)
+        errors.add(:index, "cannot skip a number")
+      else # index is valid
+        v =   conversation.latest_version_for_message_index(index)
+        v ||= conversation.latest_message&.version&.-1
+
+        if version.blank?
+          self.version = (v || 0) + 1
+        elsif version != (v || 0) + 1
+          errors.add(:version, "is invalid for this index")
+        end
+      end
+    else
+      if index.blank? && version.present?
+        errors.add(:version, "cannot be set without also setting index")
+      end
+      if index.blank? && version.blank?
+        latest_msg = self.conversation.latest_message
+        self.index    = (latest_msg&.index   || -1) + 1
+        self.version  =  latest_msg&.version || 1
+      end
+    end
+  end
+
+  def set_default_version
+    self.version ||= 1
+  end
+
+  def clear_preexisting_version_of_conversation
+    conversation.messages.where("version >= ?", version).where("index > ?", index).destroy_all
+  end
+end

--- a/app/services/ai_backends/anthropic.rb
+++ b/app/services/ai_backends/anthropic.rb
@@ -51,7 +51,7 @@ class AIBackends::Anthropic
       response = @client.messages(
         model: @assistant.model,
         system: @assistant.instructions,
-        messages: existing_messages,
+        messages: preceding_messages,
         parameters: {
           max_tokens: 2000, # we should really set this dynamically, based on the model, to the max
           stream: response_handler,
@@ -76,8 +76,8 @@ class AIBackends::Anthropic
 
   private
 
-  def existing_messages
-    @conversation.messages.ordered.where("created_at < ?", @message.created_at).collect do |message|
+  def preceding_messages
+    @conversation.messages.for_conversation_version(@message.version).where("messages.index < ?", @message.index).collect do |message|
       if @assistant.images && message.documents.present?
 
         content = [{ type: "text", text: message.content_text }]

--- a/app/services/ai_backends/open_ai.rb
+++ b/app/services/ai_backends/open_ai.rb
@@ -50,7 +50,7 @@ class AIBackends::OpenAI
     begin
       response = @client.chat(parameters: {
         model: @assistant.model,
-        messages: system_message + existing_messages,
+        messages: system_message + preceding_messages,
         stream: response_handler,
         max_tokens: 2000, # we should really set this dynamically, based on the model, to the max
       })
@@ -82,8 +82,8 @@ class AIBackends::OpenAI
     }]
   end
 
-  def existing_messages
-    @conversation.messages.ordered.where("created_at < ?", @message.created_at).collect do |message|
+  def preceding_messages
+    @conversation.messages.for_conversation_version(@message.version).where("messages.index < ?", @message.index).collect do |message|
       if @assistant.images && message.documents.present?
 
         content = [{ type: "text", text: message.content_text }]

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -6,8 +6,7 @@
 <% initial_page_load = last_message && !scroll_down %>
 <% scroll_down = scroll_down || initial_page_load %>
 <% thinking = if thinking.nil?
-                (last_message && message.content_text == "" && message.not_cancelled?) ||
-                (message.rerequested? && message.content_text == "" && message.not_cancelled?)
+                last_message && message.content_text == "" && message.not_cancelled?
               else
                 thinking
               end

--- a/config/initializers/extend_active_record.rb
+++ b/config/initializers/extend_active_record.rb
@@ -1,0 +1,22 @@
+module ExtendActiveRecord
+  def last(*args)
+    if to_sql.include?("DISTINCT ON")
+      limit = args.first
+      result = unscoped.from("(#{to_sql}) AS subq").select("subq.*").order(subq_position: :desc).limit(limit)
+
+      limit ? result.reverse : result.first
+    else
+      super(*args)
+    end
+  end
+
+  def count(*args)
+    if to_sql.include?("DISTINCT ON")
+      unscoped.from("(#{reorder(nil).to_sql}) AS subq").select("count(*)").to_a.first['count'].to_i
+    else
+      super(*args)
+    end
+  end
+end
+
+ActiveRecord::Relation.prepend(ExtendActiveRecord)

--- a/config/initializers/extend_active_record.rb
+++ b/config/initializers/extend_active_record.rb
@@ -2,7 +2,7 @@ module ExtendActiveRecord
   def last(*args)
     if to_sql.include?("DISTINCT ON")
       limit = args.first
-      result = unscoped.from("(#{to_sql}) AS subq").select("subq.*").order(subq_position: :desc).limit(limit)
+      result = unscoped.from("(#{to_sql}) AS subq").select("subq.*").order("subq.index DESC").limit(limit)
 
       limit ? result.reverse : result.first
     else

--- a/db/migrate/20240412205836_add_index_and_version_to_messages.rb
+++ b/db/migrate/20240412205836_add_index_and_version_to_messages.rb
@@ -1,0 +1,23 @@
+class AddIndexAndVersionToMessages < ActiveRecord::Migration[7.1]
+  def up
+    add_column :messages, :index, :integer
+    add_column :messages, :version, :integer
+
+    Conversation.all.find_each do |conversation|
+      conversation.messages.order(:created_at).each_with_index do |message, index|
+        message.update(index: index, version: 1)
+      end
+    end
+
+    change_column :messages, :index, :integer, null: false
+    change_column :messages, :version, :integer, null: false
+
+    add_index :messages, :index
+    add_index :messages, :version
+  end
+
+  def down
+    remove_column :messages, :index
+    remove_column :messages, :version
+  end
+end

--- a/db/migrate/20240418162137_prepare_messages_for_forking.rb
+++ b/db/migrate/20240418162137_prepare_messages_for_forking.rb
@@ -1,0 +1,15 @@
+class PrepareMessagesForForking < ActiveRecord::Migration[7.1]
+  def up
+    add_column :messages, :branched, :boolean, default: false, null: false
+    add_column :messages, :branched_from_version, :integer
+    remove_column :messages, :rerequested_at
+    add_index :messages, [:conversation_id, :index, :version], unique: true
+  end
+
+  def down
+    remove_index :messages, column: [:conversation_id, :index, :version]
+    remove_column :messages, :branched
+    remove_column :messages, :branched_from_version
+    add_column :messages, :rerequested_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_205836) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_18_162137) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,13 +103,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_205836) do
     t.bigint "content_document_id"
     t.bigint "run_id"
     t.bigint "assistant_id", null: false
-    t.datetime "rerequested_at"
-    t.datetime "cancelled_at"
     t.datetime "processed_at", precision: nil
     t.integer "index", null: false
     t.integer "version", null: false
+    t.datetime "cancelled_at"
+    t.boolean "branched", default: false, null: false
+    t.integer "branched_from_version"
     t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
+    t.index ["conversation_id", "index", "version"], name: "index_messages_on_conversation_id_and_index_and_version", unique: true
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["index"], name: "index_messages_on_index"
     t.index ["run_id"], name: "index_messages_on_run_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_200516) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_12_205836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -106,11 +106,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_200516) do
     t.datetime "rerequested_at"
     t.datetime "cancelled_at"
     t.datetime "processed_at", precision: nil
+    t.integer "index", null: false
+    t.integer "version", null: false
     t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
+    t.index ["index"], name: "index_messages_on_index"
     t.index ["run_id"], name: "index_messages_on_run_id"
     t.index ["updated_at"], name: "index_messages_on_updated_at"
+    t.index ["version"], name: "index_messages_on_version"
   end
 
   create_table "notes", force: :cascade do |t|

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -62,23 +62,6 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update message with a re-request" do
-    rerequested_at = Time.current.round
-    new_assistant_id = @user.assistants.where.not(id: @assistant.id).first.id
-
-    patch message_url(@conversation.latest_message), params: { message: {
-      content_text: nil,
-      rerequested_at: rerequested_at,
-      assistant_id: new_assistant_id,
-    }}
-    @conversation.latest_message.reload
-
-    assert_redirected_to conversation_messages_url(@conversation)
-    assert_nil @conversation.latest_message.content_text
-    assert_equal rerequested_at, @conversation.latest_message.rerequested_at
-    assert_equal new_assistant_id, @conversation.latest_message.assistant_id
-  end
-
   test "should destroy message" do
     assert_difference("Message.count", -1) do
       delete message_url(@message)

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -33,17 +33,30 @@ debugging:
   assistant: rob_gpt4
   title: Verifying Ruby syntax
 
-
-# 0.1
-# 1.1
-# 2.1 2.2
-# 3.1 3.2
-#     4.2  (4.3)
-#     5.2  (5.3)
-#    (6.2) (6.3)
+#  0.1
+#  1.1
+#  2.1  2.2  (2.3)
+#  3.1  3.2
+# (4.1) 4.2  (4.3)
+#       5.2  (5.3)
+#      (6.2) (6.3)
 #
-# messages in in parens are not pre-created
+# messages in parens do not exist in fixtures
+
 versioned:
   user: keith
   assistant: samantha
   title: Versioned conversation
+
+#  0.1
+#  1.1
+#  2.1  2.2  2.3       2.5        (2.7)
+# (3.1) 3.2  3.3           (3.6)  (3.7)
+#       4.2       4.4      (4.6)
+#
+# messages in parens do not exist in fixtures
+
+versioned2:
+  user: keith
+  assistant: samantha
+  title: Versioned v2 conversation

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -32,3 +32,18 @@ debugging:
   user: rob
   assistant: rob_gpt4
   title: Verifying Ruby syntax
+
+
+# 0.1
+# 1.1
+# 2.1 2.2
+# 3.1 3.2
+#     4.2  (4.3)
+#     5.2  (5.3)
+#    (6.2) (6.3)
+#
+# messages in in parens are not pre-created
+versioned:
+  user: keith
+  assistant: samantha
+  title: Versioned conversation

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -387,7 +387,7 @@ filter_map_example:
 
 # Next conversation
 
-message0:
+message0_v1:
   assistant: samantha
   conversation: versioned
   role: user
@@ -398,13 +398,13 @@ message0:
   index: 0
   version: 1
 
-message1:
+message1_v1:
   assistant: samantha
   conversation: versioned
   role: assistant
   content_text: My favorite color is blue.
   content_document:
-  run: message0_response
+  run: message0_v1_response
   created_at: 2023-1-1 1:01:00
   index: 1
   version: 1
@@ -419,6 +419,8 @@ message2_v1:
   created_at: 2023-1-1 1:02:00
   index: 2
   version: 1
+  branched: true
+  branched_from_version: 2
 
 message3_v1:
   assistant: samantha
@@ -441,6 +443,7 @@ message2_v2:
   created_at: 2023-1-1 1:04:00
   index: 2
   version: 2
+  branched: true
 
 message3_v2:
   assistant: samantha
@@ -474,3 +477,128 @@ message5_v2:
   created_at: 2023-1-1 1:07:00
   index: 5
   version: 2
+
+
+# Next conversation
+
+msg0_v1:
+  assistant: samantha
+  conversation: versioned2
+  role: user
+  content_text: What's your favorite color?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:00:00
+  index: 0
+  version: 1
+
+msg1_v1:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: My favorite color is blue.
+  content_document:
+  run: msg0_v1_response
+  created_at: 2023-1-1 1:01:00
+  index: 1
+  version: 1
+
+msg2_v1:
+  assistant: samantha
+  conversation: versioned2
+  role: user
+  content_text: What do you eat?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:02:00
+  index: 2
+  version: 1
+  branched: true
+
+msg2_v2:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: I was born in San Francisco.
+  content_document:
+  run: msg2_v1_response
+  created_at: 2023-1-1 1:05:00
+  index: 2
+  version: 2
+  branched: true
+  branched_from_version: 1
+
+msg3_v2:
+  assistant: samantha
+  conversation: versioned2
+  role: user
+  content_text: What do you think of the city?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:06:00
+  index: 3
+  version: 2
+
+msg4_v2:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: It is a beautiful city.
+  content_document:
+  run: msg3_v2_response
+  created_at: 2023-1-1 1:07:00
+  index: 4
+  version: 2
+  branched: true
+
+
+msg2_v3:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: It is a beautiful city.
+  content_document:
+  run: message4_v2_response
+  created_at: 2023-1-1 1:07:00
+  index: 2
+  version: 3
+  branched: true
+  branched_from_version: 2
+
+msg3_v3:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: It is a beautiful city.
+  content_document:
+  run: msg2_v3_response
+  created_at: 2023-1-1 1:07:00
+  index: 3
+  version: 3
+
+
+msg4_v4:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: It is a beautiful city.
+  content_document:
+  run: message4_v2_response
+  created_at: 2023-1-1 1:07:00
+  index: 4
+  version: 4
+  branched: true
+  branched_from_version: 2
+
+msg2_v5:
+  assistant: samantha
+  conversation: versioned2
+  role: assistant
+  content_text: I don't eat food.
+  content_document:
+  run: msg4_v4_response
+  created_at: 2023-1-1 1:03:00
+  index: 2
+  version: 5
+  branched: true
+  branched_from_version: 3

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -556,9 +556,9 @@ msg2_v3:
   assistant: samantha
   conversation: versioned2
   role: assistant
-  content_text: It is a beautiful city.
+  content_text: I was born in the city of San Francisco
   content_document:
-  run: message4_v2_response
+  run: msg2_v1_response
   created_at: 2023-1-1 1:07:00
   index: 2
   version: 3
@@ -568,10 +568,10 @@ msg2_v3:
 msg3_v3:
   assistant: samantha
   conversation: versioned2
-  role: assistant
-  content_text: It is a beautiful city.
+  role: user
+  content_text: Do you like it there?
   content_document:
-  run: msg2_v3_response
+  run:
   created_at: 2023-1-1 1:07:00
   index: 3
   version: 3
@@ -581,9 +581,9 @@ msg4_v4:
   assistant: samantha
   conversation: versioned2
   role: assistant
-  content_text: It is a beautiful city.
+  content_text: It is a nice city.
   content_document:
-  run: message4_v2_response
+  run: msg3_v2_response
   created_at: 2023-1-1 1:07:00
   index: 4
   version: 4
@@ -593,10 +593,10 @@ msg4_v4:
 msg2_v5:
   assistant: samantha
   conversation: versioned2
-  role: assistant
-  content_text: I don't eat food.
+  role: user
+  content_text: Do you like the food?
   content_document:
-  run: msg4_v4_response
+  run:
   created_at: 2023-1-1 1:03:00
   index: 2
   version: 5

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -8,6 +8,8 @@ hear_me:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 yes_i_do:
   assistant: samantha
@@ -17,6 +19,8 @@ yes_i_do:
   content_document:
   run: hear_me_response
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
 
 identify_photo:
   assistant: samantha
@@ -31,6 +35,8 @@ identify_photo:
   content_document:
   run:
   created_at: 2023-12-30 1:02:00
+  index: 2
+  version: 1
 
 photo_identified:
   assistant: samantha
@@ -40,6 +46,8 @@ photo_identified:
   content_document:
   run: identify_photo_response
   created_at: 2023-12-30 1:03:00
+  index: 3
+  version: 1
 
 what_day:
   assistant: samantha
@@ -49,6 +57,8 @@ what_day:
   content_document:
   run:
   created_at: 2023-12-30 1:04:00
+  index: 4
+  version: 1
 
 dont_know_day:
   assistant: samantha
@@ -58,6 +68,8 @@ dont_know_day:
   content_document:
   run: what_day_response
   created_at: 2023-12-30 1:05:00
+  index: 5
+  version: 1
 
 alive:
   assistant: samantha
@@ -67,6 +79,8 @@ alive:
   content_document:
   run:
   created_at: 2023-12-30 1:06:00
+  index: 6
+  version: 1
 
 im_a_bot:
   assistant: samantha
@@ -83,6 +97,8 @@ im_a_bot:
   content_document:
   run: alive_response
   created_at: 2023-12-30 1:07:00
+  index: 7
+  version: 1
 
 
 # Next conversation
@@ -95,6 +111,8 @@ your_name:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 listening:
   assistant: samantha
@@ -104,6 +122,8 @@ listening:
   content_document:
   run: your_name_response
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
 
 examine_this:
   assistant: samantha
@@ -113,6 +133,8 @@ examine_this:
   content_document: # the cat photo is not attached in this field, currently it's attached at the document level. info: https://platform.openai.com/docs/assistants/tools/knowledge-retrieval and https://platform.openai.com/docs/guides/vision
   run:
   created_at: 2023-12-30 1:02:00
+  index: 2
+  version: 1
 
 photo_examined:
   assistant: samantha
@@ -122,6 +144,8 @@ photo_examined:
   content_document:
   run: examine_this_response
   created_at: 2023-12-30 1:03:00
+  index: 3
+  version: 1
 
 what_month:
   assistant: samantha
@@ -131,6 +155,8 @@ what_month:
   content_document:
   run:
   created_at: 2023-12-30 1:04:00
+  index: 4
+  version: 1
 
 dont_know_month:
   assistant: samantha
@@ -140,6 +166,8 @@ dont_know_month:
   content_document:
   run: what_month_response
   created_at: 2023-12-30 1:05:00
+  index: 5
+  version: 1
 
 human:
   assistant: samantha
@@ -149,6 +177,8 @@ human:
   content_document:
   run:
   created_at: 2023-12-30 1:06:00
+  index: 6
+  version: 1
 
 not_human:
   assistant: samantha
@@ -158,6 +188,8 @@ not_human:
   content_document:
   run: human_response
   created_at: 2023-12-30 1:07:00
+  index: 7
+  version: 1
 
 
 # Next conversation
@@ -170,6 +202,8 @@ can_you_hear:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 yes_i_can:
   assistant: samantha
@@ -179,6 +213,8 @@ yes_i_can:
   content_document:
   run: can_you_hear_response
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
 
 one_attachment:
   assistant: samantha
@@ -188,6 +224,8 @@ one_attachment:
   content_document:
   run:
   created_at: 2023-12-30 1:02:00
+  index: 2
+  version: 1
 
 its_a_cat:
   assistant: samantha
@@ -197,6 +235,8 @@ its_a_cat:
   content_document:
   run: one_attachment_response
   created_at: 2023-12-30 1:03:00
+  index: 3
+  version: 1
 
 two_attachments:
   assistant: samantha
@@ -206,6 +246,8 @@ two_attachments:
   content_document:
   run:
   created_at: 2023-12-30 1:04:00
+  index: 4
+  version: 1
 
 yes_cat_and_dog:
   assistant: samantha
@@ -215,6 +257,8 @@ yes_cat_and_dog:
   content_document:
   run: two_attachments_response
   created_at: 2023-12-30 1:05:00
+  index: 5
+  version: 1
 
 # Next conversation
 
@@ -226,6 +270,8 @@ popstate:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 popstate_event:
   assistant: keith_gpt4
@@ -238,6 +284,8 @@ popstate_event:
   content_document:
   run: popstate_response
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
 
 
 # Next conversation
@@ -250,6 +298,8 @@ ruby_version:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 latest_ruby_version:
   assistant: samantha
@@ -259,6 +309,8 @@ latest_ruby_version:
   content_document:
   run: ruby_version_response
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
 
 
 # Next conversation
@@ -271,6 +323,8 @@ hello_claude:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 claude_replying:
   assistant: keith_claude3
@@ -280,6 +334,8 @@ claude_replying:
   content_document:
   run:
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
 
 claude_age:
   assistant: keith_claude3
@@ -289,6 +345,8 @@ claude_age:
   content_document:
   run:
   created_at: 2023-12-30 1:02:00
+  index: 2
+  version: 1
 
 claude_age_replying:
   assistant: keith_claude3
@@ -298,6 +356,8 @@ claude_age_replying:
   content_document:
   run:
   created_at: 2023-12-30 1:03:00
+  index: 3
+  version: 1
 
 
 # Next conversation
@@ -310,6 +370,8 @@ filter_map:
   content_document:
   run:
   created_at: 2023-12-30 1:00:00
+  index: 0
+  version: 1
 
 filter_map_example:
   assistant: rob_gpt4
@@ -319,3 +381,96 @@ filter_map_example:
   content_document:
   run: filter_map_response
   created_at: 2023-12-30 1:01:00
+  index: 1
+  version: 1
+
+
+# Next conversation
+
+message0:
+  assistant: samantha
+  conversation: versioned
+  role: user
+  content_text: What's your favorite color?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:00:00
+  index: 0
+  version: 1
+
+message1:
+  assistant: samantha
+  conversation: versioned
+  role: assistant
+  content_text: My favorite color is blue.
+  content_document:
+  run: message0_response
+  created_at: 2023-1-1 1:01:00
+  index: 1
+  version: 1
+
+message2_v1:
+  assistant: samantha
+  conversation: versioned
+  role: user
+  content_text: What do you eat?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:02:00
+  index: 2
+  version: 1
+
+message3_v1:
+  assistant: samantha
+  conversation: versioned
+  role: assistant
+  content_text: I don't eat food.
+  content_document:
+  run: message2_v1_response
+  created_at: 2023-1-1 1:03:00
+  index: 3
+  version: 1
+
+message2_v2:
+  assistant: samantha
+  conversation: versioned
+  role: user
+  content_text: Where were you born?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:04:00
+  index: 2
+  version: 2
+
+message3_v2:
+  assistant: samantha
+  conversation: versioned
+  role: assistant
+  content_text: I was born in San Francisco.
+  content_document:
+  run: message2_v2_response
+  created_at: 2023-1-1 1:05:00
+  index: 3
+  version: 2
+
+message4_v2:
+  assistant: samantha
+  conversation: versioned
+  role: user
+  content_text: What do you think of the city?
+  content_document:
+  run:
+  created_at: 2023-1-1 1:06:00
+  index: 4
+  version: 2
+
+message5_v2:
+  assistant: samantha
+  conversation: versioned
+  role: assistant
+  content_text: It is a beautiful city.
+  content_document:
+  run: message4_v2_response
+  created_at: 2023-1-1 1:07:00
+  index: 5
+  version: 2

--- a/test/fixtures/runs.yml
+++ b/test/fixtures/runs.yml
@@ -306,7 +306,7 @@ msg0_v1_response:
   additional_instructions:
   tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
-msg2_v1_response
+msg2_v1_response:
   assistant: samantha
   conversation: versioned2
   status: completed
@@ -322,39 +322,7 @@ msg2_v1_response
   additional_instructions:
   tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
-msg3_v2_response
-  assistant: samantha
-  conversation: versioned2
-  status: completed
-  required_action:
-  last_error:
-  started_at: 2023-1-1 1:07:00
-  completed_at: 2023-1-1 1:07:00
-  expired_at: 2023-1-1 1:07:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
-
-msg3_v3_response
-  assistant: samantha
-  conversation: versioned2
-  status: completed
-  required_action:
-  last_error:
-  started_at: 2023-1-1 1:07:00
-  completed_at: 2023-1-1 1:07:00
-  expired_at: 2023-1-1 1:07:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
-
-msg4_v4_response
+msg3_v2_response:
   assistant: samantha
   conversation: versioned2
   status: completed

--- a/test/fixtures/runs.yml
+++ b/test/fixtures/runs.yml
@@ -226,7 +226,7 @@ filter_map_response:
   additional_instructions:
   tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
-message0_response:
+message0_v1_response:
   assistant: samantha
   conversation: versioned
   status: completed
@@ -277,6 +277,86 @@ message2_v2_response:
 message4_v2_response:
   assistant: samantha
   conversation: versioned
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:07:00
+  completed_at: 2023-1-1 1:07:00
+  expired_at: 2023-1-1 1:07:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+msg0_v1_response:
+  assistant: samantha
+  conversation: versioned2
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:07:00
+  completed_at: 2023-1-1 1:07:00
+  expired_at: 2023-1-1 1:07:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+msg2_v1_response
+  assistant: samantha
+  conversation: versioned2
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:07:00
+  completed_at: 2023-1-1 1:07:00
+  expired_at: 2023-1-1 1:07:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+msg3_v2_response
+  assistant: samantha
+  conversation: versioned2
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:07:00
+  completed_at: 2023-1-1 1:07:00
+  expired_at: 2023-1-1 1:07:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+msg3_v3_response
+  assistant: samantha
+  conversation: versioned2
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:07:00
+  completed_at: 2023-1-1 1:07:00
+  expired_at: 2023-1-1 1:07:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+msg4_v4_response
+  assistant: samantha
+  conversation: versioned2
   status: completed
   required_action:
   last_error:

--- a/test/fixtures/runs.yml
+++ b/test/fixtures/runs.yml
@@ -225,3 +225,67 @@ filter_map_response:
   instructions:
   additional_instructions:
   tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+message0_response:
+  assistant: samantha
+  conversation: versioned
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:01:00
+  completed_at: 2023-1-1 1:01:00
+  expired_at: 2023-1-1 1:01:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+message2_v1_response:
+  assistant: samantha
+  conversation: versioned
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:03:00
+  completed_at: 2023-1-1 1:03:00
+  expired_at: 2023-1-1 1:03:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+message2_v2_response:
+  assistant: samantha
+  conversation: versioned
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:05:00
+  completed_at: 2023-1-1 1:05:00
+  expired_at: 2023-1-1 1:05:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
+
+message4_v2_response:
+  assistant: samantha
+  conversation: versioned
+  status: completed
+  required_action:
+  last_error:
+  started_at: 2023-1-1 1:07:00
+  completed_at: 2023-1-1 1:07:00
+  expired_at: 2023-1-1 1:07:00
+  cancelled_at:
+  failed_at:
+  model: gpt-4
+  instructions: You are a helpful assistant
+  additional_instructions:
+  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -13,7 +13,7 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
 
   test "sets conversation title automatically even if there is only one message" do
     conversation = conversations(:javascript)
-    conversation.latest_message.destroy!
+    conversation.latest_message_for_version(:latest).destroy!
 
     ChatCompletionAPI.stub :get_next_response, {"topic" => "Javascript popState"} do
       AutotitleConversationJob.perform_now(conversation.id)

--- a/test/jobs/get_next_ai_message_job_openai_test.rb
+++ b/test/jobs/get_next_ai_message_job_openai_test.rb
@@ -4,7 +4,7 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
   setup do
     @conversation = conversations(:greeting)
     @conversation.messages.create! role: :user, content_text: "Still there?", assistant: @conversation.assistant
-    @message = @conversation.latest_message
+    @message = @conversation.latest_message_for_version(:latest)
     @test_client = TestClients::OpenAI.new(access_token: 'abc')
   end
 
@@ -14,31 +14,7 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
     end
 
     message_text = @test_client.chat
-    assert_equal message_text, @conversation.latest_message.content_text
-  end
-
-  test "re-populates an earlier message from the assistant if it was provided and marked as re-requested" do
-    messages(:yes_i_do).update!(rerequested_at: Time.current, content_text: nil)
-
-    assert_no_difference "@conversation.messages.reload.length" do
-      assert GetNextAIMessageJob.perform_now(messages(:yes_i_do).id, @conversation.assistant.id)
-    end
-
-    message_text = @test_client.chat
-    assert_equal message_text, messages(:yes_i_do).reload.content_text
-    assert_not_equal message_text, @conversation.latest_message.content_text
-  end
-
-  test "returns early if attempting to re-populate an earlier message from the assistant was provided but it was NOT marked as re-requested" do
-    messages(:yes_i_do).update!(content_text: nil)
-
-    assert_no_difference "@conversation.messages.reload.length" do
-      refute GetNextAIMessageJob.perform_now(messages(:yes_i_do).id, @conversation.assistant.id)
-    end
-
-    message_text = @test_client.chat
-    assert_not_equal message_text, messages(:yes_i_do).reload.content_text
-    assert_not_equal message_text, @conversation.latest_message.content_text
+    assert_equal message_text, @conversation.latest_message_for_version(:latest).content_text
   end
 
   test "returns early if the message id was invalid" do
@@ -64,13 +40,13 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
     user.update!(openai_key: "")
 
     assert GetNextAIMessageJob.perform_now(@message.id, @conversation.assistant.id)
-    assert_includes @conversation.latest_message.content_text, "need to enter a valid API key for OpenAI"
+    assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for OpenAI"
   end
 
   test "when API response key is, a nice error message is displayed" do
     TestClients::OpenAI.stub :text, "" do
       assert GetNextAIMessageJob.perform_now(@message.id, @conversation.assistant.id)
-      assert_includes @conversation.latest_message.content_text, "a blank response"
+      assert_includes @conversation.latest_message_for_version(:latest).content_text, "a blank response"
     end
   end
 end

--- a/test/jobs/get_next_ai_message_job_test.rb
+++ b/test/jobs/get_next_ai_message_job_test.rb
@@ -4,7 +4,7 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
   setup do
     @conversation = conversations(:greeting)
     @conversation.messages.create! role: :user, content_text: "Are you still there?", assistant: @conversation.assistant
-    @message = @conversation.latest_message
+    @message = @conversation.latest_message_for_version(:latest)
     @test_client = TestClients::OpenAI.new(access_token: 'abc')
   end
 

--- a/test/models/conversation/version_test.rb
+++ b/test/models/conversation/version_test.rb
@@ -1,8 +1,9 @@
 require "test_helper"
 
 class Conversation::VersionTest < ActiveSupport::TestCase
-  test "latest_message works" do
-    assert_equal messages(:im_a_bot), conversations(:greeting).latest_message
+  test "latest_message_for_version" do
+    assert_equal messages(:message3_v1), conversations(:versioned).latest_message_for_version(1)
+    assert_equal messages(:message5_v2), conversations(:versioned).latest_message_for_version(2)
   end
 
   test "latest_version_for_message_index" do

--- a/test/models/conversation/version_test.rb
+++ b/test/models/conversation/version_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class Conversation::VersionTest < ActiveSupport::TestCase
+  test "latest_message works" do
+    assert_equal messages(:im_a_bot), conversations(:greeting).latest_message
+  end
+
+  test "latest_version_for_message_index" do
+    assert_equal 1, conversations(:versioned).latest_version_for_message_index(1)
+    assert_equal 2, conversations(:versioned).latest_version_for_message_index(3)
+  end
+end

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -62,7 +62,7 @@ class ConversationTest < ActiveSupport::TestCase
 
         conversation.messages.create!(assistant: conversation.assistant, role: :user, content_text: "Can you hear me?")
 
-        latest_message = conversation.latest_message
+        latest_message = conversation.latest_message_for_version(:latest)
         assert latest_message.assistant?
 
         GetNextAIMessageJob.perform_now(latest_message.id, assistants(:samantha).id)

--- a/test/models/conversation_test.rb
+++ b/test/models/conversation_test.rb
@@ -21,10 +21,6 @@ class ConversationTest < ActiveSupport::TestCase
     assert_instance_of Step, conversations(:greeting).steps.first
   end
 
-  test "latest_message works" do
-    assert_equal messages(:im_a_bot), conversations(:greeting).latest_message
-  end
-
   test "simple create works" do
     assert_nothing_raised do
       Conversation.create!(

--- a/test/models/message/cancellable_test.rb
+++ b/test/models/message/cancellable_test.rb
@@ -4,11 +4,11 @@ class Message::CancellableTest < ActiveSupport::TestCase
   setup do
     @conversation = conversations(:greeting)
     @previous_id = @conversation.latest_message.id
-    redis.set("conversation-#{@conversation.id}-latest_message-id", @previous_id)
+    redis.set("conversation-#{@conversation.id}-latest-assistant_message-id", @previous_id)
   end
 
   teardown do
-    redis.set("conversation-#{@conversation.id}-latest_message-id", @previous_id) # cleanup
+    redis.set("conversation-#{@conversation.id}-latest-assistant_message-id", @previous_id) # cleanup
   end
 
   test "when a message is cancelled the redis key gets set" do
@@ -24,7 +24,7 @@ class Message::CancellableTest < ActiveSupport::TestCase
   end
 
   test "creating a new message on a conversation updates the redis key for that conversation" do
-    assert_changes "redis.get('conversation-#{@conversation.id}-latest_message-id')&.to_i", from: @previous_id do
+    assert_changes "redis.get('conversation-#{@conversation.id}-latest-assistant_message-id')&.to_i", from: @previous_id do
       assert_difference "@conversation.messages.count", 2 do
         @conversation.messages.create!(
           assistant: @conversation.assistant,
@@ -33,7 +33,7 @@ class Message::CancellableTest < ActiveSupport::TestCase
       end
     end
 
-    assert_equal @conversation.latest_message.reload.id, redis.get("conversation-#{@conversation.id}-latest_message-id")&.to_i
+    assert_equal @conversation.latest_message.reload.id, redis.get("conversation-#{@conversation.id}-latest-assistant_message-id")&.to_i
   end
 
   private

--- a/test/models/message/cancellable_test.rb
+++ b/test/models/message/cancellable_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Message::CancellableTest < ActiveSupport::TestCase
+  setup do
+    @conversation = conversations(:greeting)
+    @previous_id = @conversation.latest_message.id
+    redis.set("conversation-#{@conversation.id}-latest_message-id", @previous_id)
+  end
+
+  teardown do
+    redis.set("conversation-#{@conversation.id}-latest_message-id", @previous_id) # cleanup
+  end
+
+  test "when a message is cancelled the redis key gets set" do
+    redis.set("message-cancelled-id", nil)
+
+    assert_changes "messages(:im_a_bot).cancelled_at", from: nil do
+      assert_changes "redis.get('message-cancelled-id')&.to_i", to: messages(:im_a_bot).id do
+        messages(:im_a_bot).cancelled!
+      end
+    end
+
+    redis.set("message-cancelled-id", nil)
+  end
+
+  test "creating a new message on a conversation updates the redis key for that conversation" do
+    assert_changes "redis.get('conversation-#{@conversation.id}-latest_message-id')&.to_i", from: @previous_id do
+      assert_difference "@conversation.messages.count", 2 do
+        @conversation.messages.create!(
+          assistant: @conversation.assistant,
+          content_text: "A new message"
+        )
+      end
+    end
+
+    assert_equal @conversation.latest_message.reload.id, redis.get("conversation-#{@conversation.id}-latest_message-id")&.to_i
+  end
+
+  private
+
+  def redis
+    RedisConnection.client
+  end
+end

--- a/test/models/message/cancellable_test.rb
+++ b/test/models/message/cancellable_test.rb
@@ -3,7 +3,8 @@ require "test_helper"
 class Message::CancellableTest < ActiveSupport::TestCase
   setup do
     @conversation = conversations(:greeting)
-    @previous_id = @conversation.latest_message.id
+    @previous_id = @conversation.latest_message_for_version(:latest).id
+
     redis.set("conversation-#{@conversation.id}-latest-assistant_message-id", @previous_id)
   end
 
@@ -32,8 +33,8 @@ class Message::CancellableTest < ActiveSupport::TestCase
         )
       end
     end
-
-    assert_equal @conversation.latest_message.reload.id, redis.get("conversation-#{@conversation.id}-latest-assistant_message-id")&.to_i
+    id = @conversation.latest_message_for_version(:latest).reload.id
+    assert_equal id, redis.get("conversation-#{@conversation.id}-latest-assistant_message-id")&.to_i
   end
 
   private

--- a/test/models/message/document_image_test.rb
+++ b/test/models/message/document_image_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class Message::DocumentImageTest < ActiveSupport::TestCase
+  test "has associated documents" do
+    assert_instance_of Document, messages(:examine_this).documents.first
+  end
+
+  test "documents are deleted upon destroy" do
+    assert_difference "Document.count", -1 do
+      messages(:examine_this).destroy
+    end
+  end
+
+  test "has_document_image?" do
+    assert messages(:examine_this).has_document_image?
+    refute messages(:examine_this).has_document_image?(:small)
+  end
+
+  test "document_image_path" do
+    assert messages(:examine_this).document_image_path(:small).is_a?(String)
+    assert messages(:examine_this).document_image_path(:small).starts_with?("/rails/active_storage/representations/redirect")
+  end
+
+  test "document_image_path with fallback" do
+    assert_equal "", messages(:examine_this).document_image_path(:small, fallback: "")
+  end
+end

--- a/test/models/message/version_test.rb
+++ b/test/models/message/version_test.rb
@@ -10,6 +10,56 @@ class Message::VersionTest < ActiveSupport::TestCase
       conversations(:versioned).messages.for_conversation_version(2).map(&:full_version)
   end
 
+  test "for_conversation_version" do
+    assert_equal [0.1, 1.1, 2.1, 3.1], conversations(:versioned).messages.for_conversation_version(1).map(&:full_version)
+    assert_equal [0.1, 1.1, 2.2, 3.2, 4.2, 5.2], conversations(:versioned).messages.for_conversation_version(2).map(&:full_version)
+  end
+
+  test "creating a message with branched true FAILS if branched_from_version is null" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 2, version: 3, branched: true)
+    end
+  end
+
+  test "creating a message with branched_from_version specified FAILS if branched is not true" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 2, version: 3, branched_from_version: 2)
+    end
+  end
+
+  test "creating a message with branched true AND branched_from_version specified SUCCEEDS" do
+    Current.user = users(:keith)
+    conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 2, version: 3, branched: true, branched_from_version: 2)
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the VERSION is SKIPPING a number" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(index: 2, version: 4, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the VERSION is EARLIER than it should be" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(index: 5, version: 1, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the INDEX is skipping a number" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(index: 7, version: 2, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+
   test "creating a message for a new conversation autosets the version & index properly" do
     Current.user = users(:keith)
     m0 = Message.create!(assistant: assistants(:samantha), content_text: "Hello")
@@ -22,7 +72,7 @@ class Message::VersionTest < ActiveSupport::TestCase
     assert_equal 1, m1.version
   end
 
-  test "creating a new message WITHOUT INDEX and WITHOUT VERSION on an existing multi-versioned conversation autosets version & index properly" do
+  test "creating a new message WITHOUT INDEX and WITHOUT VERSION on an existing multi-versioned conversation autosets version & index properly — adding to end of last conversation" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
     m = conversations(:versioned).messages.latest_version_for_conversation.last
@@ -55,12 +105,7 @@ class Message::VersionTest < ActiveSupport::TestCase
   test "creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - creating a new version where one does not exist" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
-    m = conversations(:versioned).messages.latest_version_for_conversation.last
-
-    assert_equal 5, m.index
-    assert_equal 2, m.version
-
-    m = conversations(:versioned).messages.create!(index: 4, assistant: assistants(:samantha), content_text: "Do you like living in this city?")
+    m = conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "Do you like living in this city?", index: 4, branched: true, branched_from_version: 2)
 
     assert_equal 4, m.index
     assert_equal 3, m.version
@@ -94,12 +139,7 @@ class Message::VersionTest < ActiveSupport::TestCase
   test "Take 2 of - creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - creating a new version where a branch already occurred" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
-    m = conversations(:versioned).messages.latest_version_for_conversation.last
-
-    assert_equal 5, m.index
-    assert_equal 2, m.version
-
-    m = conversations(:versioned).messages.create!(index: 2, assistant: assistants(:samantha), content_text: "What is your name?")
+    m = conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 2, branched: true, branched_from_version: 2)
 
     assert_equal 2, m.index
     assert_equal 3, m.version
@@ -131,12 +171,7 @@ class Message::VersionTest < ActiveSupport::TestCase
   test "Take 3 of - creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - at the end so don't create a new version" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
-    m = conversations(:versioned).messages.latest_version_for_conversation.last
-
-    assert_equal 5, m.index
-    assert_equal 2, m.version
-
-    m = conversations(:versioned).messages.create!(index: 6, assistant: assistants(:samantha), content_text: "What is your name?")
+    m = conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 6)
 
     assert_equal 6, m.index
     assert_equal 2, m.version
@@ -169,12 +204,7 @@ class Message::VersionTest < ActiveSupport::TestCase
 
     # We're about to edit message #1 and what should get created is version 3 even though there is no version 2
     Current.user = users(:keith)
-    m = conversations(:versioned).messages.latest_version_for_conversation.last
-
-    assert_equal 5, m.index
-    assert_equal 2, m.version
-
-    m = conversations(:versioned).messages.create!(index: 1, assistant: assistants(:samantha), content_text: "What is your name?")
+    m = conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 1, branched: true, branched_from_version: 1)
 
     assert_equal 1, m.index
     assert_equal 3, m.version
@@ -213,12 +243,7 @@ class Message::VersionTest < ActiveSupport::TestCase
   test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - the point it branches" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
-    m = conversations(:versioned).messages.latest_version_for_conversation.last
-
-    assert_equal 5, m.index
-    assert_equal 2, m.version
-
-    m = conversations(:versioned).messages.create!(index: 2, version: 3, assistant: assistants(:samantha), content_text: "What is your name?")
+    m = conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "What is your name?", index: 2, version: 3, branched: true, branched_from_version: 1)
 
     assert_equal 2, m.index
     assert_equal 3, m.version
@@ -250,11 +275,6 @@ class Message::VersionTest < ActiveSupport::TestCase
   test "Take 2 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - at end of LATEST version branch" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
-    m = conversations(:versioned).messages.latest_version_for_conversation.last
-
-    assert_equal 5, m.index
-    assert_equal 2, m.version
-
     m = conversations(:versioned).messages.create!(index: 6, version: 2, assistant: assistants(:samantha), content_text: "What is your name?")
 
     assert_equal 6, m.index
@@ -320,7 +340,6 @@ class Message::VersionTest < ActiveSupport::TestCase
   end
 
   test "Take 4 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - its the first message in a conversation" do
-    # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
     c = Conversation.create!(user: users(:keith), assistant: assistants(:samantha))
 
@@ -332,27 +351,64 @@ class Message::VersionTest < ActiveSupport::TestCase
     assert_equal [0.1, 1.1], c.messages.latest_version_for_conversation.map(&:full_version)
   end
 
-  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the VERSION is SKIPPING a number" do
-    Current.user = users(:keith)
-
-    assert_raises ActiveRecord::RecordInvalid do
-      conversations(:versioned).messages.create!(index: 2, version: 4, assistant: assistants(:samantha), content_text: "What is your name?")
-    end
+  test "versions is empty at non-branch nodes ABOVE any branchess" do
+    assert conversations(:versioned).messages.for_conversation_version(1).first.versions.empty?
+    assert conversations(:versioned).messages.for_conversation_version(2).first.versions.empty?
+    assert conversations(:versioned).messages.for_conversation_version(1).second.versions.empty?
+    assert conversations(:versioned).messages.for_conversation_version(2).second.versions.empty?
   end
 
-  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the VERSION is EARLIER than it should be" do
-    Current.user = users(:keith)
-
-    assert_raises ActiveRecord::RecordInvalid do
-      conversations(:versioned).messages.create!(index: 5, version: 1, assistant: assistants(:samantha), content_text: "What is your name?")
-    end
+  test "versions is empty at non-branch nodes BELOW any branchess" do
+    assert conversations(:versioned).messages.for_conversation_version(1).fourth.versions.empty?
+    assert conversations(:versioned).messages.for_conversation_version(2).fourth.versions.empty?
   end
 
-  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the INDEX is skipping a number" do
-    Current.user = users(:keith)
+  test "versions is populated correctly at branch nodes" do
+    assert_equal [1,2], conversations(:versioned).messages.for_conversation_version(1).third.versions
+    assert_equal [1,2], conversations(:versioned).messages.for_conversation_version(2).third.versions
+  end
 
-    assert_raises ActiveRecord::RecordInvalid do
-      conversations(:versioned).messages.create!(index: 7, version: 2, assistant: assistants(:samantha), content_text: "What is your name?")
-    end
+  test "versioned2 - traverse a complex path in which an older branch was continued" do
+    # See comment block in conversations.yml for :versioned2 to visualize the messages
+    Current.user = users(:keith)
+    c = conversations(:versioned2).messages.for_conversation_version(4)
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+                4.4,
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "versioned2 - continue a conversation on an older branch" do
+    # See comment block in conversations.yml for :versioned2 to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned2).messages.create!(assistant: assistants(:samantha), content_text: "hello", role: :assistant, index: 3, version: 1)
+
+    assert_equal 3, m.index
+    assert_equal 1, m.version
+
+    m2 = conversations(:versioned2).messages.create!(assistant: assistants(:samantha), content_text: "hello edited", role: :user, index: 3, branched: true, branched_from_version: 1)
+
+    assert_equal 3, m2.index
+    assert_equal 6, m2.version
+
+    c = conversations(:versioned2).messages.for_conversation_version(6)
+    msg_versions = [
+      0.1,
+      1.1,
+      2.1,
+                          3.6,
+                          4.6,
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    m3 = conversations(:versioned2).messages.create!(assistant: assistants(:samantha), content_text: "hello edited", role: :user, index: 2, branched: true, branched_from_version: 5)
+
+    assert_equal 2, m3.index
+    assert_equal 7, m3.version
+    assert_equal msg_versions, c.reload.map(&:full_version)
   end
 end

--- a/test/models/message/version_test.rb
+++ b/test/models/message/version_test.rb
@@ -1,0 +1,309 @@
+require "test_helper"
+
+class Message::VersionTest < ActiveSupport::TestCase
+  test "latest_version_for_conversation" do
+    assert_equal 8, conversations(:versioned).messages.count
+    assert_equal 6, conversations(:versioned).messages.latest_version_for_conversation.count
+    assert_equal [0.1, 1.1, 2.2, 3.2, 4.2, 5.2],
+      conversations(:versioned).messages.latest_version_for_conversation.map(&:full_version)
+    assert_equal [0.1, 1.1, 2.2, 3.2, 4.2, 5.2],
+      conversations(:versioned).messages.for_conversation_version(2).map(&:full_version)
+  end
+
+  test "creating a message for a new conversation autosets the version & index properly" do
+    Current.user = users(:keith)
+    m0 = Message.create!(assistant: assistants(:samantha), content_text: "Hello")
+
+    assert_equal 0, m0.index
+    assert_equal 1, m0.version
+
+    m1 = m0.conversation.messages.latest_version_for_conversation.last
+    assert_equal 1, m1.index
+    assert_equal 1, m1.version
+  end
+
+  test "creating a new message WITHOUT INDEX and WITHOUT VERSION on an existing multi-versioned conversation autosets version & index properly" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(assistant: assistants(:samantha), content_text: "Do you like the food?")
+
+    assert_equal 6, m.index
+    assert_equal 2, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2,
+           6.2,
+           7.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(2)
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - creating a new version where one does not exist" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: 4, assistant: assistants(:samantha), content_text: "Do you like living in this city?")
+
+    assert_equal 4, m.index
+    assert_equal 3, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+                4.3,
+                5.3
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(3)
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(2)
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "Take 2 of - creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - creating a new version where a branch already occurred" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: 2, assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 2, m.index
+    assert_equal 3, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+                2.3,
+                3.3
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(3)
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(2)
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "Take 3 of - creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - not creating a new version" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: 6, assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 6, m.index
+    assert_equal 2, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2,
+           6.2,
+           7.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(1)
+    msg_versions = [
+      0.1,
+      1.1,
+      2.1,
+      3.1
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "Take 4 of - creating a new messages for a SPECIFIC INDEX but WITHOUT VERSION autosets version properly - overwriting a previous version" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: 1, assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 1, m.index
+    assert_equal 2, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+           1.2,
+           2.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(2)
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "creating a new message WITHOUT INDEX but SPECIFIED VERSION raises an error" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(version: 3, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: 2, version: 3, assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 2, m.index
+    assert_equal 3, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+                2.3,
+                3.3
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(3)
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(2)
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "Take 2 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - its hanging at the end" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: 6, version: 2, assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 6, m.index
+    assert_equal 2, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2,
+           6.2,
+           7.2
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(1)
+    msg_versions = [
+      0.1,
+      1.1,
+      2.1,
+      3.1
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "Take 3 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - its the first one" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    c = Conversation.create!(user: users(:keith), assistant: assistants(:samantha))
+
+    m = c.messages.create!(index: 0, version: 1, assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 0, m.index
+    assert_equal 1, m.version
+
+    assert_equal [0.1, 1.1], c.messages.latest_version_for_conversation.map(&:full_version)
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the VERSION is SKIPPING a number" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(index: 2, version: 4, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the VERSION is EARLIER than it should be" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(index: 4, version: 1, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION fails if the INDEX is skipping a number" do
+    Current.user = users(:keith)
+
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:versioned).messages.create!(index: 7, version: 2, assistant: assistants(:samantha), content_text: "What is your name?")
+    end
+  end
+end

--- a/test/models/message/version_test.rb
+++ b/test/models/message/version_test.rb
@@ -210,7 +210,7 @@ class Message::VersionTest < ActiveSupport::TestCase
     end
   end
 
-  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds" do
+  test "creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - the point it branches" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
     m = conversations(:versioned).messages.latest_version_for_conversation.last
@@ -247,7 +247,7 @@ class Message::VersionTest < ActiveSupport::TestCase
     assert_equal msg_versions, c.map(&:full_version)
   end
 
-  test "Take 2 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - its hanging at the end" do
+  test "Take 2 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - at end of LATEST version branch" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
     m = conversations(:versioned).messages.latest_version_for_conversation.last
@@ -283,7 +283,43 @@ class Message::VersionTest < ActiveSupport::TestCase
     assert_equal msg_versions, c.map(&:full_version)
   end
 
-  test "Take 3 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - its the first one" do
+  test "Take 3 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - at end of PREVIOUS version branch" do
+    # See comment block in conversations.yml for :versioned to visualize the messages
+    Current.user = users(:keith)
+    m = conversations(:versioned).messages.latest_version_for_conversation.last
+
+    assert_equal 5, m.index
+    assert_equal 2, m.version
+
+    m = conversations(:versioned).messages.create!(index: "4", version: "1", assistant: assistants(:samantha), content_text: "What is your name?")
+
+    assert_equal 4, m.index
+    assert_equal 1, m.version
+
+    c = conversations(:versioned).messages.latest_version_for_conversation
+    msg_versions = [
+      0.1,
+      1.1,
+           2.2,
+           3.2,
+           4.2,
+           5.2,
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+
+    c = conversations(:versioned).messages.for_conversation_version(1)
+    msg_versions = [
+      0.1,
+      1.1,
+      2.1,
+      3.1,
+      4.1,
+      5.1,
+    ]
+    assert_equal msg_versions, c.map(&:full_version)
+  end
+
+  test "Take 4 - creating a new messages for a SPECIFIC INDEX and SPECIFIC VERSION succeeds - its the first message in a conversation" do
     # See comment block in conversations.yml for :versioned to visualize the messages
     Current.user = users(:keith)
     c = Conversation.create!(user: users(:keith), assistant: assistants(:samantha))
@@ -308,7 +344,7 @@ class Message::VersionTest < ActiveSupport::TestCase
     Current.user = users(:keith)
 
     assert_raises ActiveRecord::RecordInvalid do
-      conversations(:versioned).messages.create!(index: 4, version: 1, assistant: assistants(:samantha), content_text: "What is your name?")
+      conversations(:versioned).messages.create!(index: 5, version: 1, assistant: assistants(:samantha), content_text: "What is your name?")
     end
   end
 

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -17,10 +17,6 @@ class MessageTest < ActiveSupport::TestCase
   #   assert_instance_of Document, messages(:examine_this).content_document
   # end
 
-  test "has associated documents" do
-    assert_instance_of Document, messages(:examine_this).documents.first
-  end
-
   test "has an associated run" do
     assert_instance_of Run, messages(:yes_i_do).run
   end
@@ -45,12 +41,6 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal assistants(:samantha), Message.last.assistant
     assert_not_nil Message.last.conversation
     assert_equal users(:keith), Message.last.conversation.user
-  end
-
-  test "documents are deleted upon destroy" do
-    assert_difference "Document.count", -1 do
-      messages(:examine_this).destroy
-    end
   end
 
   test "creating a message with a conversation and Current.user set fails if conversation is not owned by the user" do
@@ -141,61 +131,11 @@ class MessageTest < ActiveSupport::TestCase
     end
   end
 
-  test "creating a new message on a conversation updates the redis key for that conversation" do
-    conversation = conversations(:greeting)
-    previous_id = conversation.latest_message.id
-    redis.set("conversation-#{conversation.id}-latest_message-id", previous_id)
-
-    assert_changes "redis.get('conversation-#{conversation.id}-latest_message-id')&.to_i", from: previous_id do
-      assert_difference "conversation.messages.count", 2 do
-        conversation.messages.create!(
-          assistant: conversation.assistant,
-          content_text: "A new message"
-        )
-      end
-    end
-
-    assert_equal conversation.latest_message.reload.id, redis.get("conversation-#{conversation.id}-latest_message-id")&.to_i
-    redis.set("conversation-#{conversation.id}-latest_message-id", previous_id)
-  end
-
   test "when a conversation gets a message from a new assistant this propogates to the conversation" do
     old_assistant = conversations(:greeting).assistant
     new_assistant = assistants(:keith_claude3)
 
     conversations(:greeting).messages.create!(assistant: new_assistant, content_text: "Hello")
     assert_equal new_assistant, conversations(:greeting).reload.assistant
-  end
-
-  test "when a message is cancelled the redis key gets set" do
-    redis.set("message-cancelled-id", nil)
-
-    assert_changes "messages(:im_a_bot).cancelled_at", from: nil do
-      assert_changes "redis.get('message-cancelled-id')&.to_i", to: messages(:im_a_bot).id do
-        messages(:im_a_bot).cancelled!
-      end
-    end
-
-    redis.set("message-cancelled-id", nil)
-  end
-
-  test "has_document_image?" do
-    assert messages(:examine_this).has_document_image?
-    refute messages(:examine_this).has_document_image?(:small)
-  end
-
-  test "document_image_path" do
-    assert messages(:examine_this).document_image_path(:small).is_a?(String)
-    assert messages(:examine_this).document_image_path(:small).starts_with?("/rails/active_storage/representations/redirect")
-  end
-
-  test "document_image_path with fallback" do
-    assert_equal "", messages(:examine_this).document_image_path(:small, fallback: "")
-  end
-
-  private
-
-  def redis
-    RedisConnection.client
   end
 end

--- a/test/services/ai_backends/anthropic_test.rb
+++ b/test/services/ai_backends/anthropic_test.rb
@@ -4,7 +4,11 @@ module AIBackends
   class AnthropicTest < ActiveSupport::TestCase
     setup do
       @conversation = conversations(:attachments)
-      @anthropic = Anthropic.new(users(:keith), assistants(:samantha), @conversation, @conversation.latest_message)
+      @anthropic = Anthropic.new(users(:keith),
+        assistants(:samantha),
+        @conversation,
+        @conversation.latest_message_for_version(:latest)
+      )
       @test_client = TestClients::Anthropic.new(access_token: 'abc')
     end
 
@@ -16,30 +20,30 @@ module AIBackends
       assert_equal @test_client.messages, @anthropic.get_next_chat_message
     end
 
-    test "existing_messages constructs a proper response and pivots on images" do
-      existing_messages = @anthropic.send(:existing_messages)
+    test "preceding_messages constructs a proper response and pivots on images" do
+      preceding_messages = @anthropic.send(:preceding_messages)
 
-      assert_equal @conversation.messages.length-1, existing_messages.length
+      assert_equal @conversation.messages.length-1, preceding_messages.length
 
       @conversation.messages.ordered.each_with_index do |message, i|
         next if @conversation.messages.length == i+1
 
         if message.documents.present?
-          assert_instance_of Array, existing_messages[i][:content]
-          assert_equal message.documents.length+1, existing_messages[i][:content].length
+          assert_instance_of Array, preceding_messages[i][:content]
+          assert_equal message.documents.length+1, preceding_messages[i][:content].length
         else
-          assert_equal existing_messages[i][:content], message.content_text
+          assert_equal preceding_messages[i][:content], message.content_text
         end
       end
     end
 
-    test "existing_messages only considers messages up to the assistant message being generated" do
+    test "preceding_messages only considers messages up to the assistant message being generated" do
       @anthropic = Anthropic.new(users(:keith), assistants(:samantha), @conversation, messages(:yes_i_can))
 
-      existing_messages = @anthropic.send(:existing_messages)
+      preceding_messages = @anthropic.send(:preceding_messages)
 
-      assert_equal 1, existing_messages.length
-      assert_equal existing_messages[0][:content], messages(:can_you_hear).content_text
+      assert_equal 1, preceding_messages.length
+      assert_equal preceding_messages[0][:content], messages(:can_you_hear).content_text
     end
   end
 end


### PR DESCRIPTION
This PR is my attempt to isolate all the backend logic changes to begin supporting versioned messages. All of the messages in a conversation now have:

* `index` attribute and indicates what number message in the sequence
* `version` indicates which message version this is for a given index
* `versions` is a dynamic attribute that lets you know all of the versions for a message, at this given index, assuming this index is a point where the conversation branched (i.e. `branched` = true) 

With those model changes, a bunch of query logic was updated so that it's pretty easy to create messages and not have to think too hard about what the index and version are.

An old conversation looks like this:

```
0.1
1.1
2.1
3.1
```
The first number is the message index, the second number after the decimal is the version of that message. In this start case it's the first version of every message. Now, message index 2 is going to be edited creating a new version and the assistant will reply. Now the messages for this conversation look like this:

```
0.1
1.1
2.1 2.2
3.1 3.2
```

The messages at `index` of 2 both have `branched` = true and if you check the `versions` attribute for those you'll get `[1,2]`. Even though there are two versions of message index 3 it was not branched there so versions will be an empty array. In other words, message 2 is where the UI is going to let you do next/previous and not at message 3.

By default, when you do `conversation.messages.for_conversation_version(1)` you will get the original message sequence back. But when you do `...(2)` or the shorthand `conversation.messages.latest_version_for_conversation` you get the following message sequence back:

```
0.1
1.1
2.2
3.2
```

And it supports more complicated branching such as this. In this example, the user went back to message 1 and branched again from there so there are now 3 different versions of this conversation and the message at index 0 is the only message that is shared between all three versions.

```
0.1        
1.1       1.3
2.1  2.2  2.3
3.1. 3.2
```