### PR TITLE
Fix the background of the pinned assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 # Ignore files for development
 .byebug_history
 /.vscode
+/.ruby-version
 
 # Mac
 

--- a/app/views/assistants/_assistant.html.erb
+++ b/app/views/assistants/_assistant.html.erb
@@ -1,29 +1,58 @@
-<%# locals: (assistant:, settings: true, assistant_counter: -1) %> <% selected = assistant == @assistant %> <% first = assistant_counter == 0 %>
+<%# locals: (assistant:, settings: true, assistant_counter: -1) %>
+<% selected = assistant == @assistant %>
+<% first = assistant_counter == 0 %>
 
-<div class="bg-gray-50 <%= first && 'absolute top-[17px] left-0 pl-3 z-10 w-full' %>">
+<div class="bg-gray-50 <%= first && 'absolute top-[17px] left-0 pl-3 w-full z-10' %>">
   <%# This extra div ^ is needed because of the absolute positioning. It doesn't lay out properly if added to the div below. %>
-  <div
-    class="flex justify-between items-center mb-1 p-1 pl-2 pr-2 mr-5 hover:bg-gray-100 dark:hover:bg-gray-700 bg-gray-50 dark:bg-gray-900 group cursor-pointer text-sm rounded-lg <%= selected && 'relationship' %>"
-    data-role="assistant"
-    data-radio-behavior-target="radio"
-    data-action="radio-changed@window->radio-behavior#select"
-    data-radio-behavior-id-param="<%= assistant.id %>"
+  <div class="
+              flex justify-between items-center
+              mb-1 p-1 pl-2 pr-2 mr-5
+            hover:bg-gray-100 dark:hover:bg-gray-700
+            bg-gray-50 dark:bg-gray-900
+              group cursor-pointer
+              text-sm rounded-lg
+              <%= selected && 'relationship' %>
+            "
+      data-role="assistant"
+      data-radio-behavior-target="radio"
+      data-action="radio-changed@window->radio-behavior#select"
+      data-radio-behavior-id-param="<%= assistant.id %>"
   >
-    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate", data: { role: "name" } do %> <%= render partial: "layouts/assistant_avatar", locals: { assistant:
-    assistant, size: 7, classes: "mr-2" } %> <%= assistant.name %> <% end %>
+    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate", data: { role: "name" } do %>
+      <%= render partial: "layouts/assistant_avatar", locals: { assistant: assistant, size: 7, classes: "mr-2" } %>
+      <%= assistant.name %>
+    <% end %>
 
     <div class="hidden gap-3 pl-2 relationship:flex group-hover:flex">
       <% if settings %>
-      <div class="inline-flex outline-none dropdown dropdown-end">
-        <%= icon "ellipsis-horizontal", tabindex: 0, role: :button, variant: :micro, size: 18, class: "outline-none text-gray-950 dark:text-gray-100 invisible group-hover:visible cursor-pointer", 'data-controller': "nested-pointer", title: "More" %>
+        <div class="inline-flex outline-none dropdown dropdown-end">
+          <%= icon "ellipsis-horizontal",
+            tabindex: 0,
+            role: :button,
+            variant: :micro,
+            size: 18,
+            class: "outline-none text-gray-950 dark:text-gray-100 invisible group-hover:visible cursor-pointer",
+            'data-controller': "nested-pointer",
+            title: "More"
+          %>
 
-        <menu tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 -mr-10 mt-7 dark:!bg-gray-700" data-controller="nested-pointer">
-          <li><%= link_to edit_settings_assistant_path(assistant) do %><%= icon "cog-6-tooth", variant: :outline, size: 18 %>Settings<% end %></li>
-          <!-- <li><a><%= icon "arrow-up-tray", variant: :outline, size: 18 %>Share</a></li> -->
-        </menu>
-      </div>
-      <% end %> <%= link_to new_assistant_message_path(assistant), class: "inline-flex", data: { role: "new" } do %> <%= icon "pencil-square", variant: :outline, size: 18, class: "text-gray-950 dark:text-gray-100 cursor-pointer group-hover:visible
-      invisible relationship:visible relationship:text-gray-950 dark:relationship:text-gray-100", 'data-controller': "nested-pointer", title: "New" %> <% end %>
+          <menu tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 -mr-10 mt-7 dark:!bg-gray-700" data-controller="nested-pointer">
+            <li><%= link_to edit_settings_assistant_path(assistant) do %><%= icon "cog-6-tooth", variant: :outline, size: 18 %>Settings<% end %></li>
+            <!-- <li><a><%= icon "arrow-up-tray", variant: :outline, size: 18 %>Share</a></li> -->
+          </menu>
+        </div>
+      <% end %>
+
+      <%= link_to new_assistant_message_path(assistant), class: "inline-flex", data: { role: "new" } do %>
+        <%= icon "pencil-square",
+          variant: :outline,
+          size: 18,
+          class: "text-gray-950 dark:text-gray-100 cursor-pointer group-hover:visible invisible
+                  relationship:visible relationship:text-gray-950 dark:relationship:text-gray-100",
+          'data-controller': "nested-pointer",
+          title: "New"
+        %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/assistants/_assistant.html.erb
+++ b/app/views/assistants/_assistant.html.erb
@@ -1,58 +1,29 @@
-<%# locals: (assistant:, settings: true, assistant_counter: -1) %>
-<% selected = assistant == @assistant %>
-<% first = assistant_counter == 0 %>
+<%# locals: (assistant:, settings: true, assistant_counter: -1) %> <% selected = assistant == @assistant %> <% first = assistant_counter == 0 %>
 
-<div class="<%= first && 'absolute top-[17px] left-0 pl-3 w-full z-10' %>">
+<div class="bg-gray-50 <%= first && 'absolute top-[17px] left-0 pl-3 z-10 w-full' %>">
   <%# This extra div ^ is needed because of the absolute positioning. It doesn't lay out properly if added to the div below. %>
-  <div class="
-              flex justify-between items-center
-              mb-1 p-1 pl-2 pr-2 mr-5
-            hover:bg-gray-100 dark:hover:bg-gray-700
-            bg-gray-50 dark:bg-gray-900
-              group cursor-pointer
-              text-sm rounded-lg
-              <%= selected && 'relationship' %>
-            "
-      data-role="assistant"
-      data-radio-behavior-target="radio"
-      data-action="radio-changed@window->radio-behavior#select"
-      data-radio-behavior-id-param="<%= assistant.id %>"
+  <div
+    class="flex justify-between items-center mb-1 p-1 pl-2 pr-2 mr-5 hover:bg-gray-100 dark:hover:bg-gray-700 bg-gray-50 dark:bg-gray-900 group cursor-pointer text-sm rounded-lg <%= selected && 'relationship' %>"
+    data-role="assistant"
+    data-radio-behavior-target="radio"
+    data-action="radio-changed@window->radio-behavior#select"
+    data-radio-behavior-id-param="<%= assistant.id %>"
   >
-    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate", data: { role: "name" } do %>
-      <%= render partial: "layouts/assistant_avatar", locals: { assistant: assistant, size: 7, classes: "mr-2" } %>
-      <%= assistant.name %>
-    <% end %>
+    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate", data: { role: "name" } do %> <%= render partial: "layouts/assistant_avatar", locals: { assistant:
+    assistant, size: 7, classes: "mr-2" } %> <%= assistant.name %> <% end %>
 
     <div class="hidden gap-3 pl-2 relationship:flex group-hover:flex">
       <% if settings %>
-        <div class="inline-flex outline-none dropdown dropdown-end">
-          <%= icon "ellipsis-horizontal",
-            tabindex: 0,
-            role: :button,
-            variant: :micro,
-            size: 18,
-            class: "outline-none text-gray-950 dark:text-gray-100 invisible group-hover:visible cursor-pointer",
-            'data-controller': "nested-pointer",
-            title: "More"
-          %>
+      <div class="inline-flex outline-none dropdown dropdown-end">
+        <%= icon "ellipsis-horizontal", tabindex: 0, role: :button, variant: :micro, size: 18, class: "outline-none text-gray-950 dark:text-gray-100 invisible group-hover:visible cursor-pointer", 'data-controller': "nested-pointer", title: "More" %>
 
-          <menu tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 -mr-10 mt-7 dark:!bg-gray-700" data-controller="nested-pointer">
-            <li><%= link_to edit_settings_assistant_path(assistant) do %><%= icon "cog-6-tooth", variant: :outline, size: 18 %>Settings<% end %></li>
-            <!-- <li><a><%= icon "arrow-up-tray", variant: :outline, size: 18 %>Share</a></li> -->
-          </menu>
-        </div>
-      <% end %>
-
-      <%= link_to new_assistant_message_path(assistant), class: "inline-flex", data: { role: "new" } do %>
-        <%= icon "pencil-square",
-          variant: :outline,
-          size: 18,
-          class: "text-gray-950 dark:text-gray-100 cursor-pointer group-hover:visible invisible
-                  relationship:visible relationship:text-gray-950 dark:relationship:text-gray-100",
-          'data-controller': "nested-pointer",
-          title: "New"
-        %>
-      <% end %>
+        <menu tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 -mr-10 mt-7 dark:!bg-gray-700" data-controller="nested-pointer">
+          <li><%= link_to edit_settings_assistant_path(assistant) do %><%= icon "cog-6-tooth", variant: :outline, size: 18 %>Settings<% end %></li>
+          <!-- <li><a><%= icon "arrow-up-tray", variant: :outline, size: 18 %>Share</a></li> -->
+        </menu>
+      </div>
+      <% end %> <%= link_to new_assistant_message_path(assistant), class: "inline-flex", data: { role: "new" } do %> <%= icon "pencil-square", variant: :outline, size: 18, class: "text-gray-950 dark:text-gray-100 cursor-pointer group-hover:visible
+      invisible relationship:visible relationship:text-gray-950 dark:relationship:text-gray-100", 'data-controller': "nested-pointer", title: "New" %> <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
* fix/style(app/views/assistants/_assistant.html.erb): added bg to first assistant to fix #277
* feat(app/views/assistants/_assistant.html.erb): reformat code for readability and maintainability
* chore(.gitignore): add .ruby-version to the list of ignored files

**Before**
<img width="359" alt="Screenshot 2024-04-18 at 4 44 07 PM" src="https://github.com/allyourbot/hostedgpt/assets/11001042/f93f673c-97aa-4ccf-b2b3-7a4aa77257d7">
<img width="486" alt="Screenshot 2024-04-18 at 4 43 58 PM" src="https://github.com/allyourbot/hostedgpt/assets/11001042/af19c31c-dac8-491f-9d21-d0c512ecc3ea">
**After**
<img width="454" alt="Screenshot 2024-04-18 at 4 43 33 PM" src="https://github.com/allyourbot/hostedgpt/assets/11001042/bdc51acf-5c74-4be5-b6a5-587f85a60a53">