### PR TITLE
Use attribute default to remove some callbacks

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,13 +10,13 @@ class Document < ApplicationRecord
 
   enum purpose: %w[fine-tune fine-tune-results assistants assistants_output].index_by(&:to_sym)
 
+  attribute :user, default: -> { message.conversation.user }
+  attribute :purpose, default: :assistants
+  attribute :filename, default: -> { file.filename.to_s }
+  attribute :bytes, default: -> { file.byte_size }
+
   validates :purpose, :filename, :bytes, presence: true
   validate :file_present
-
-  before_validation :set_default_user, on: :create
-  before_validation :set_default_purpose, on: :create
-  before_validation :set_default_filename, on: :create
-  before_validation :set_default_bytes, on: :create
 
   def file_data_url(variant = :large)
     return nil if !file.attached?
@@ -58,22 +58,6 @@ class Document < ApplicationRecord
 
   def file_present
     errors.add(:file, "must be attached") unless file.attached?
-  end
-
-  def set_default_user
-    self.user ||= message.conversation.user # this won't work when multiple people are in a conversation
-  end
-
-  def set_default_purpose
-    self.purpose ||= :assistants
-  end
-
-  def set_default_filename
-    self.filename ||= file.filename.to_s
-  end
-
-  def set_default_bytes
-    self.bytes ||= file.byte_size
   end
 
   def wait_for_file_variant_to_process!(variant)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -10,10 +10,11 @@ class Document < ApplicationRecord
 
   enum purpose: %w[fine-tune fine-tune-results assistants assistants_output].index_by(&:to_sym)
 
-  attribute :user, default: -> { message.conversation.user }
   attribute :purpose, default: :assistants
-  attribute :filename, default: -> { file.filename.to_s }
-  attribute :bytes, default: -> { file.byte_size }
+
+  before_validation :set_default_user, on: :create
+  before_validation :set_default_filename, on: :create
+  before_validation :set_default_bytes, on: :create
 
   validates :purpose, :filename, :bytes, presence: true
   validate :file_present
@@ -55,6 +56,18 @@ class Document < ApplicationRecord
   end
 
   private
+
+  def set_default_user
+    self.user ||= message.conversation.user
+  end
+
+  def set_default_filename
+    self.filename ||= file.filename.to_s
+  end
+
+  def set_default_bytes
+    self.bytes ||= file.byte_size
+  end
 
   def file_present
     errors.add(:file, "must be attached") unless file.attached?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -10,7 +10,8 @@ class Message < ApplicationRecord
 
   delegate :user, to: :conversation
 
-  before_validation :set_default_role, on: :create
+  attribute :role, default: :user
+
   before_validation :create_conversation, on: :create, if: -> { conversation.blank? }, prepend: true
 
   validates :role, presence: true
@@ -25,10 +26,6 @@ class Message < ApplicationRecord
   scope :ordered, -> { latest_version_for_conversation }
 
   private
-
-  def set_default_role
-    self.role ||= :user
-  end
 
   def create_conversation
     self.conversation = Conversation.create!(user: Current.user, assistant: assistant)

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -8,7 +8,6 @@ module Message::Version
   # See conversations.yml :versioned for a visual
   included do
     attribute :versions, :string, default: ""
-    attribute :version, default: 1
 
     before_validation :set_next_conversation_index_and_version, on: :create
 
@@ -88,11 +87,10 @@ module Message::Version
           errors.add(:version, "#{version} is invalid for this index")
         end
       end
-    else
-      if index.blank? && version.present?
+    elsif index.blank?
+      if version.present?
         errors.add(:version, "cannot be set without also setting index")
-      end
-      if index.blank? && version.blank?
+      elsif version.blank?
         latest_msg = self.conversation.latest_message_for_version(:latest)
         self.index    = (latest_msg&.index   || -1) + 1
         self.version  =  latest_msg&.version || 1

--- a/app/models/message/version.rb
+++ b/app/models/message/version.rb
@@ -8,9 +8,9 @@ module Message::Version
   # See conversations.yml :versioned for a visual
   included do
     attribute :versions, :string, default: ""
+    attribute :version, default: 1
 
     before_validation :set_next_conversation_index_and_version, on: :create
-    before_validation :set_default_version,                     on: :create
 
     validate :branched_and_version_both_set,      if: -> { branched? || branched_from_version.present? }, on: :create
 
@@ -98,10 +98,6 @@ module Message::Version
         self.version  =  latest_msg&.version || 1
       end
     end
-  end
-
-  def set_default_version
-    self.version ||= 1
   end
 
   def branched_and_version_both_set


### PR DESCRIPTION
This is the old way:
```
before_validation :set_some_attr, on: :create
```

This is the new way (this PR updates to this):
```
attribute :attr, default: 123
```