### PR TITLE
Deep fix for two flaky test assertions: toast & image-load scrolling

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -22,3 +22,5 @@ document.addEventListener('turbo:before-stream-render', (event) => {
   console.log(`stream render (${stream.getAttribute('action')} event) ${newTimestamp <= oldTimestamp ? 'REORDER!' : ''}`, stream)
   oldTimestamp = newTimestamp
 })
+
+window.imageLoadingForSystemTestsToCheck = {}

--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -42,7 +42,7 @@ export default class extends Controller {
     if (this.retryCount <= this.maxRetries) {
       this.imageTarget.classList.add("hidden")
       this.loaderTarget.classList.remove("hidden")
-      setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 0)
+      window.dispatchEvent(new CustomEvent('main-column-changed'))
 
       setTimeout(() => {
         let srcBase = this.urlValue.split("?")[0]

--- a/app/javascript/controllers/image_loader_controller.js
+++ b/app/javascript/controllers/image_loader_controller.js
@@ -25,14 +25,16 @@ export default class extends Controller {
     this.retryCount = 0
     this.maxRetries = 10
     this.retryAfterMs = 500
+    this.imageKey = Math.round(Math.random()*100000000000)
+
+    window.imageLoadingForSystemTestsToCheck ||= {}
+
+    if (this.imageTarget.src == "")
+      window.imageLoadingForSystemTestsToCheck[this.imageKey] = 'loading'
+    else
+      window.imageLoadingForSystemTestsToCheck[this.imageKey] = 'done'
 
     this.imageTarget.src = this.urlValue
-  }
-
-  show() {
-    this.imageTarget.classList.remove("hidden")
-    this.loaderTarget.classList.add("hidden")
-    setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 50)
   }
 
   retryAfterDelay() {
@@ -40,12 +42,26 @@ export default class extends Controller {
     if (this.retryCount <= this.maxRetries) {
       this.imageTarget.classList.add("hidden")
       this.loaderTarget.classList.remove("hidden")
-      setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 50)
+      setTimeout(() => window.dispatchEvent(new CustomEvent('main-column-changed')), 0)
 
       setTimeout(() => {
         let srcBase = this.urlValue.split("?")[0]
         this.imageTarget.src = `${srcBase}?disposition=-${this.retryCount}`
       }, this.retryAfterMs)
     }
+  }
+
+  show() {
+    this.imageTarget.classList.remove("hidden")
+    this.loaderTarget.classList.add("hidden")
+    window.imageLoadingForSystemTestsToCheck[this.imageKey] = 'loaded'
+    this.ensureImageLoaded()
+  }
+
+  ensureImageLoaded() {
+    if (this.imageTarget.parentElement.clientHeight > 25)
+      window.dispatchEvent(new CustomEvent('main-column-changed', { detail: this.imageKey}))
+    else
+      requestAnimationFrame(() => this.ensureImageLoaded())
   }
 }

--- a/app/javascript/controllers/message_scroller_controller.js
+++ b/app/javascript/controllers/message_scroller_controller.js
@@ -38,7 +38,8 @@ export default class extends Controller {
       this.scrollDownIfScrolledToBottom()
   }
 
-  throttledScrollDownIfScrolledToBottom = throttle((event) => this.scrollDownIfScrolledToBottom(event), 50, (event) => { if (window.imageLoadingForSystemTestsToCheck[event?.detail]) window.imageLoadingForSystemTestsToCheck[event.detail] = 'done' })
+  throttledScrollDownIfScrolledToBottom = throttle((event) => this.scrollDownIfScrolledToBottom(event), 50, this.discardScrollDown)
+  discardScrollDown = (event) => { if (window.imageLoadingForSystemTestsToCheck[event?.detail]) window.imageLoadingForSystemTestsToCheck[event.detail] = 'done' }
   scrollDownIfScrolledToBottom(event) {
     if (window.wasScrolledToBottom)
       this.throttledScrollDown(event)

--- a/app/javascript/controllers/message_scroller_controller.js
+++ b/app/javascript/controllers/message_scroller_controller.js
@@ -38,19 +38,24 @@ export default class extends Controller {
       this.scrollDownIfScrolledToBottom()
   }
 
-  throttledScrollDownIfScrolledToBottom = throttle(() => this.scrollDownIfScrolledToBottom(), 50)
-  scrollDownIfScrolledToBottom() {
-    if (window.wasScrolledToBottom) this.throttledScrollDown()
+  throttledScrollDownIfScrolledToBottom = throttle((event) => this.scrollDownIfScrolledToBottom(event), 50, (event) => { if (window.imageLoadingForSystemTestsToCheck[event?.detail]) window.imageLoadingForSystemTestsToCheck[event.detail] = 'done' })
+  scrollDownIfScrolledToBottom(event) {
+    if (window.wasScrolledToBottom)
+      this.throttledScrollDown(event)
+    else if (window.imageLoadingForSystemTestsToCheck[event?.detail])
+      window.imageLoadingForSystemTestsToCheck[event.detail] = 'loaded'
   }
 
-  throttledScrollDown = throttle(() => this.scrollDown(), 50)
-  scrollDown() {
+  throttledScrollDown = throttle((event) => this.scrollDown(event), 50)
+  scrollDown(event) {
     window.wasScrolledToBottom = true // even if we don't get the full way, it was the intention
 
     this.scrollableTarget.scrollTo({
       top: this.scrollableTarget.scrollHeight,
       behavior: this.instantlyValue ? "auto" : "smooth"
     })
+
+    if (event?.detail) setTimeout(() => { window.imageLoadingForSystemTestsToCheck[event.detail] = 'done' }, 1000)
 
     if (this.instantlyValue) {
       // This occurs immediately after page load; we jump to the bottom as fast as we can. However,

--- a/app/javascript/utils/throttle.js
+++ b/app/javascript/utils/throttle.js
@@ -9,20 +9,29 @@
 //
 // See debounce.js
 
-export default function(func, wait) {
-  let timeout, lastExecution = Date.now() - wait
+export default function(func, wait, onDiscard) {
+  let timeout, timeoutOnDiscard,  lastExecution = Date.now() - wait
 
   return function() {
     var context = this
     var elapsed = Date.now() - lastExecution // always positive but could be 0
 
-    clearTimeout(timeout)
+    if (timeout !== null) {
+      if (timeoutOnDiscard) {
+        timeoutOnDiscard()
+        timeoutOnDiscard = null
+      }
+      clearTimeout(timeout)
+      timeout = null
+    }
 
     if (elapsed >= wait) {
       func.apply(context, arguments)
       lastExecution = Date.now()
     } else {
+      if (onDiscard) timeoutOnDiscard = (() => { onDiscard.apply(context, arguments); }).bind(this, ...arguments)
       timeout = setTimeout(() => {
+        timeout = null
         func.apply(context, arguments)
         lastExecution = Date.now()
       }, wait - elapsed)

--- a/app/services/chat_completion_api.rb
+++ b/app/services/chat_completion_api.rb
@@ -14,7 +14,7 @@ class ChatCompletionAPI
     }]
 
     chat_messages.each_with_index do |msg, i|
-      role = (i % 2 == 0) ? 'user' : 'assistant'
+      role = (i % 2).zero? ? 'user' : 'assistant'
 
       message_payload << {
         role: role,

--- a/app/views/assistants/_assistant.html.erb
+++ b/app/views/assistants/_assistant.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (assistant:, settings: true, assistant_counter: -1) %>
 <% selected = assistant == @assistant %>
-<% first = assistant_counter == 0 %>
+<% first = assistant_counter.zero? %>
 
 <div class="bg-gray-50 dark:bg-gray-900 <%= first && 'absolute top-[17px] left-0 pl-3 w-full z-10' %>">
   <%# This extra div ^ is needed because of the absolute positioning. It doesn't lay out properly if added to the div below. %>

--- a/app/views/layouts/_toast.html.erb
+++ b/app/views/layouts/_toast.html.erb
@@ -1,5 +1,5 @@
 <% if flash.any? %>
-  <div class="toast toast-top toast-end transition-transform duration-100 ease-in"
+  <div id="toasts" class="toast toast-top toast-end transition-transform duration-100 ease-in"
         data-controller="transition"
         data-transition-toggle-class="translate-x-full"
         data-transition-target="transitionable"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -281,6 +281,14 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def assert_last_message(message)
     assert_selector "#messages > :last-child [data-role='content-text']", text: message.content_text
   end
+
+  def assert_toast(text)
+    toast = nil
+    assert_true "the toast element could not be found" do
+      toast = find("#toasts .alert span", visible: :all, wait: 0) rescue nil
+    end
+    assert_equal text, toast[:innerText]
+  end
 end
 
 class Capybara::Node::Element

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -251,6 +251,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     assert_false "all the image loaders should have disappeared", wait: 10 do
       all("[data-role='image-loader']", visible: :all).map(&:visible?).include?(true)
     end
+
+    assert_true "all the images should have been marked as complete" do
+      all("img[data-image-loader-target='image']", visible: :all).map do |img|
+        img.evaluate_script('this.complete && typeof this.naturalWidth != "undefined" && this.naturalWidth > 0')
+      end.all?
+    end
+
+    assert_false "all values in the loading object should have been 'loaded'" do
+      page.evaluate_script("Object.values(window.imageLoadingForSystemTestsToCheck).filter((v) => v != 'done') > 0")
+    end
   end
 
   def wait_for_initial_scroll_down

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -252,12 +252,6 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
       all("[data-role='image-loader']", visible: :all).map(&:visible?).include?(true)
     end
 
-    assert_true "all the images should have been marked as complete" do
-      all("img[data-image-loader-target='image']", visible: :all).map do |img|
-        img.evaluate_script('this.complete && typeof this.naturalWidth != "undefined" && this.naturalWidth > 0')
-      end.all?
-    end
-
     assert_false "all values in the loading object should have been 'loaded'" do
       page.evaluate_script("Object.values(window.imageLoadingForSystemTestsToCheck).filter((v) => v != 'done') > 0")
     end

--- a/test/system/conversations/messages/images_test.rb
+++ b/test/system/conversations/messages/images_test.rb
@@ -14,23 +14,28 @@ class ConversationMessagesImagesTest < ApplicationSystemTestCase
     image_msg = find_messages.third
 
     image_btn = image_msg.find_role("image-preview")
-    img = image_btn.find("img")
+    loader = image_btn.find_role("image-loader")
+    img = image_btn.find("img", visible: :all)
+
     modal = image_msg.find_role("image-modal")
+
+    wait_for_initial_scroll_down
 
     assert image_btn
     assert img
+    refute loader.visible?, "loader should NEVER be visible in this test"
     wait_for_images_to_load
 
     refute modal.visible?
 
     image_btn.click
 
-    assert_true "modal image should have been visible", wait: 0.6 do
+    assert_true "modal image should have been visible" do
       modal.visible?
     end
 
     send_keys "esc"
-    assert_false "modal image should have closed/hidden itself", wait: 0.6 do
+    assert_false "modal image should have closed/hidden itself" do
       modal.visible?
     end
   end

--- a/test/system/conversations/messages/images_test.rb
+++ b/test/system/conversations/messages/images_test.rb
@@ -19,9 +19,8 @@ class ConversationMessagesImagesTest < ApplicationSystemTestCase
 
     assert image_btn
     assert img
-    assert_true "img should have fully loaded", wait: 1 do
-      img.evaluate_script('this.complete && typeof this.naturalWidth != "undefined" && this.naturalWidth > 0')
-    end
+    wait_for_images_to_load
+
     refute modal.visible?
 
     image_btn.click
@@ -53,9 +52,7 @@ class ConversationMessagesImagesTest < ApplicationSystemTestCase
       end
       assert img.visible?
 
-      assert_true "img should have fully loaded" do
-        img.evaluate_script('this.complete && typeof this.naturalWidth != "undefined" && this.naturalWidth > 0')
-      end
+      wait_for_images_to_load
 
       refute modal.visible?
 
@@ -101,10 +98,7 @@ class ConversationMessagesImagesTest < ApplicationSystemTestCase
         loader.visible?
       end
       assert img.visible?
-
-      assert_true "img should have fully loaded" do
-        modal_img.evaluate_script('this.complete && typeof this.naturalWidth != "undefined" && this.naturalWidth > 0')
-      end
+      wait_for_images_to_load
 
       image_container.click
 

--- a/test/system/conversations_test.rb
+++ b/test/system/conversations_test.rb
@@ -61,7 +61,7 @@ class ConversationsTest < ApplicationSystemTestCase
     assert_true { confirm_delete.visible? }
     confirm_delete.click
 
-    assert_text "Deleted conversation"
+    assert_toast "Deleted conversation"
     assert_current_path(@starting_path)
   end
 
@@ -75,7 +75,7 @@ class ConversationsTest < ApplicationSystemTestCase
     assert_true { confirm_delete.visible? }
     confirm_delete.click
 
-    assert_text "Deleted conversation"
+    assert_toast "Deleted conversation"
     assert_current_path new_assistant_message_path(users(:keith).assistants.ordered.first)
   end
 

--- a/test/system/settings/assistants_test.rb
+++ b/test/system/settings/assistants_test.rb
@@ -14,7 +14,7 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
     fill_in "Instructions", with: @assistant.instructions
 
     click_text "Save"
-    assert_text "Saved"
+    assert_toast "Saved"
   end
 
   test "should update Assistant" do
@@ -26,17 +26,17 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
 
     click_text "Save"
 
-    assert_text "Saved"
+    assert_toast "Saved"
   end
 
   test "a second save to the Assistant update page should show the notification again and it should properly dismiss itself" do
     visit edit_settings_assistant_url(@assistant)
     click_text "Save"
-    assert_text "Saved"
+    assert_toast "Saved"
     refute_text "Saved"
 
     click_text "Save"
-    assert_text "Saved"
+    assert_toast "Saved"
     refute_text "Saved"
   end
 
@@ -45,7 +45,7 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
   #   accept_confirm do
   #     click_text "Delete", match: :first
   #   end
-  #   assert_text "Deleted"
+  #   assert_toast "Deleted"
 
   #   refute Assistant.exists?(id: @assistant.id)
   # end

--- a/test/system/settings/people_test.rb
+++ b/test/system/settings/people_test.rb
@@ -28,7 +28,7 @@ class Settings::PeopleTest < ApplicationSystemTestCase
 
     click_text "Save"
 
-    assert_text "Saved"
+    assert_toast "Saved"
     assert_current_path edit_settings_person_url
 
     assert_equal attr[:email], @person.reload.email


### PR DESCRIPTION
When tests are running slowly the toast may have disappeared before assert_text runs. This PR replaces it with a smart `assert_toast` assertion.

In addition, we still have flaky scroll-to-bottom after all images are loading. I do not think this is a flaky test, I think this is actually a flaky feature. I believe this is actually related to a race condition with the detection of image loading and the firing of scroll down. I added extra checks for after images load to decide when to fire the scroll down event. I also added extra checks for the test environment.