### PR TITLE
Surface a real explanation to users when API error occurs

### DIFF
--- a/config/initializers/extend_anthropic_client.rb
+++ b/config/initializers/extend_anthropic_client.rb
@@ -29,7 +29,7 @@ Rails.application.config.to_prepare do
       end
 
       if response&.status != 200
-        raise ::Faraday::ParsingError
+        raise StandardError.new("Anthropic #{response&.status} Error")
       else
         to_json(response&.body)
       end

--- a/config/initializers/extend_anthropic_client.rb
+++ b/config/initializers/extend_anthropic_client.rb
@@ -28,8 +28,18 @@ Rails.application.config.to_prepare do
         req.body = parameters.to_json
       end
 
+      error_codes = {
+        400 => "invalid_request_error: There was an issue with the format or content of your request.",
+        401 => "authentication_error: There's an issue with your API key.",
+        403 => "permission_error: Your API key does not have permission to use the specified resource.",
+        404 => "not_found_error: The requested resource was not found.",
+        429 => "rate_limit_error: Your account has hit a rate limit.",
+        500 => "api_error: An unexpected error has occurred internal to Anthropic's systems.",
+        529 => "overloaded_error: Anthropic's API is temporarily overloaded."
+      }
+
       if response&.status != 200
-        raise StandardError.new("Anthropic #{response&.status} Error")
+        raise StandardError.new("Anthropic #{response&.status} Error - #{error_codes[response&.status]}")
       else
         to_json(response&.body)
       end


### PR DESCRIPTION
Occasionally I get a forever blinking "thinking" cursor. This PR attempts to add universal logic for detecting bad API responses and giving a real explanation to users. Hopefully there will be no more infinite thinking cursors and as I start to see various error messages surface to me we can improve this even further.