### PR TITLE
Issue 298: Layout Fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,9 @@ group :development do
 
   gem "pgreset"
   gem "htmlbeautifier"
+
+  # https://github.com/kirillplatonov/hotwire-livereload
+  gem "hotwire-livereload", "~> 1.3"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,10 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hotwire-livereload (1.3.2)
+      actioncable (>= 6.0.0)
+      listen (>= 3.0.0)
+      railties (>= 6.0.0)
     htmlbeautifier (1.4.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
@@ -136,6 +140,9 @@ GEM
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     lint_roller (1.1.0)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -233,6 +240,9 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
     redcarpet (3.6.0)
@@ -359,6 +369,7 @@ DEPENDENCIES
   byebug
   capybara
   debug
+  hotwire-livereload (~> 1.3)
   htmlbeautifier
   image_processing (~> 1.2)
   importmap-rails

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,26 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 
-
 /* Make clickable elements push inward */
 
-.menu li>:not(ul):not(.menu-title):not(details).active,
-.menu li>:not(ul):not(.menu-title):not(details):active,
-.menu li>details>summary:active {
-  background-color: var(--fallback-bc,oklch(var(--bc)/.1)) !important;
+.menu li > :not(ul):not(.menu-title):not(details).active,
+.menu li > :not(ul):not(.menu-title):not(details):active,
+.menu li > details > summary:active {
+  background-color: var(--fallback-bc, oklch(var(--bc) / 0.1)) !important;
   color: inherit !important;
-  @apply scale-98 ease-in-out duration-300
+  @apply scale-98 ease-in-out duration-300;
 }
 
-
 .cursor-pointer:active {
-  @apply scale-98 ease-in-out duration-300
+  @apply scale-98 ease-in-out duration-300;
 }
 
 .icon.cursor-pointer:active {
-  @apply scale-90 ease-in-out duration-300
+  @apply scale-90 ease-in-out duration-300;
 }
-
 
 /* Parent utility classes which activate children */
 /*
@@ -34,66 +31,65 @@
 
 .relationship .relationship\:flex,
 .relationship.relationship\:flex {
-  @apply !flex
+  @apply !flex;
 }
 
 .relationship .relationship\:visible,
 .relationship.relationship\:visible {
-  @apply !visible
+  @apply !visible;
 }
 
 .relationship .relationship\:text-white,
 .relationship.relationship\:text-white {
-  @apply !text-white
+  @apply !text-white;
 }
 
 .relationship .relationship\:bg-gray-700,
 .relationship.relationship\:bg-gray-700 {
-  @apply bg-gray-700
+  @apply bg-gray-700;
 }
 
 .relationship .relationship\:bg-gray-200,
 .relationship.relationship\:bg-gray-200 {
-  @apply bg-gray-200
+  @apply bg-gray-200;
 }
 
 @media (prefers-color-scheme: dark) {
   .relationship .dark\:relationship\:bg-gray-700,
   .relationship.dark\:relationship\:bg-gray-700 {
-    @apply bg-gray-700
+    @apply bg-gray-700;
   }
 }
 
 .relationship .relationship\:hidden,
 .relationship.relationship\:hidden {
-  @apply !hidden
+  @apply !hidden;
 }
 
 .relationship .relationship\:pl-4,
 .relationship.relationship\:pl-4 {
-  @apply !pl-4
+  @apply !pl-4;
 }
 
 .nav-closed .nav-closed\:hidden {
-  @apply hidden
+  @apply hidden;
 }
 
 .nav-closed .nav-closed\:z-auto {
-  @apply z-auto
+  @apply z-auto;
 }
 
 .nav-closed .nav-closed\:relative {
-  @apply relative
+  @apply relative;
 }
 
 .show-previews .show-previews\:preview-container {
-  @apply !flex
+  @apply !flex;
 }
 
 .show-previews .show-previews\:pt-24 {
-  @apply pt-24
+  @apply pt-24;
 }
-
 
 /* Override the style change that chrome brings when it autofills fields */
 
@@ -116,7 +112,8 @@ input:focus {
 }
 
 @keyframes blink {
-  0%, 40% {
+  0%,
+  40% {
     opacity: 0;
   }
   100% {
@@ -129,11 +126,13 @@ input:focus {
 }
 
 @keyframes breathe {
-  0%, 80%, 100% {
-    transform: scale(1)
+  0%,
+  80%,
+  100% {
+    transform: scale(1);
   }
   40% {
-    transform: scale(1.3)
+    transform: scale(1.3);
   }
 }
 
@@ -145,14 +144,27 @@ input:focus {
 
 /* Prose styling */
 
-.prose :where(pre):not(:where([class~=not-prose] *)) {
-  @apply mx-0 mt-5 mb-3
+.prose :where(pre):not(:where([class~='not-prose'] *)) {
+  @apply mx-0 mt-5 mb-3;
 }
 
-.prose :where(.prose>:first-child):not(:where([class~=not-prose] *)) {
-  @apply mt-0
+.prose :where(.prose > :first-child):not(:where([class~='not-prose'] *)) {
+  @apply mt-0;
 }
 
-.prose :where(p):not(:where([class~=not-prose] *)) {
-  @apply mb-3
+.prose :where(p):not(:where([class~='not-prose'] *)) {
+  @apply mb-3;
+}
+
+@layer base {
+  html {
+    @apply h-full overscroll-none;
+  }
+  body {
+    /* @apply h-full font-sans text-gray-950 dark:text-gray-100 flex; */
+    @apply h-full font-sans text-gray-950 dark:text-gray-100 flex overflow-y-auto;
+    -webkit-overflow-scrolling: touch;
+    min-height: -webkit-fill-available;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  }
 }

--- a/app/assets/stylesheets/includes/daisyui_tooltip.css
+++ b/app/assets/stylesheets/includes/daisyui_tooltip.css
@@ -1,6 +1,8 @@
 /* DaisyUI tooltip overrides */
 
-*, ::before, ::after {
+*,
+::before,
+::after {
   --tooltip-tail: 7px;
   --tooltip-tail-offset: calc(100% + 6px - var(--tooltip-tail));
   --tooltip-offset: calc(100% + 7px + var(--tooltip-tail, 0px));
@@ -11,7 +13,7 @@
 
 .tooltip-bottom:before {
   padding: 0.4rem 0.7rem;
-  box-shadow: 0px 0px 0px 1px #28282A;
+  box-shadow: 0px 0px 0px 1px #28282a;
   z-index: 8;
   pointer-events: none;
 }
@@ -35,7 +37,7 @@
 
 .tooltip-top:before {
   padding: 0.4rem 0.7rem;
-  box-shadow: 0px 0px 0px 1px #28282A;
+  box-shadow: 0px 0px 0px 1px #28282a;
   z-index: 8;
   pointer-events: none;
 }
@@ -59,7 +61,7 @@
 
 .tooltip-right:before {
   padding: 0.4rem 0.7rem;
-  box-shadow: 0px 0px 0px 1px #28282A;
+  box-shadow: 0px 0px 0px 1px #28282a;
   z-index: 8;
   pointer-events: none;
 }
@@ -83,7 +85,7 @@
 
 .tooltip-left:before {
   padding: 0.4rem 0.7rem;
-  box-shadow: 0px 0px 0px 1px #28282A;
+  box-shadow: 0px 0px 0px 1px #28282a;
   z-index: 8;
   pointer-events: none;
 }
@@ -124,20 +126,21 @@
 }
 
 @keyframes slide-in {
-  0%, 20% {
-      transform: translateX(100%);
-      opacity: 0;
+  0%,
+  20% {
+    transform: translateX(100%);
+    opacity: 0;
   }
   80% {
-      transform: translateX(-10%);
-      opacity: 1;
+    transform: translateX(-10%);
+    opacity: 1;
   }
   90% {
-      transform: translateX(8%);
+    transform: translateX(8%);
   }
   95% {
-      transform: translateX(-5%);
-      opacity: 1;
+    transform: translateX(-5%);
+    opacity: 1;
   }
   100% {
     transform: translateX(0);
@@ -173,14 +176,14 @@ dialog button:focus-visible {
 
 /* Code overrides — undoing */
 
-.prose :where(code):not(:where([class~=not-prose] *,pre *)) {
+.prose :where(code):not(:where([class~='not-prose'] *, pre *)) {
   padding: 0;
   border-radius: 0;
   background-color: transparent;
 }
 
-.prose :where(code):not(pre code):not(:where([class~=not-prose] *)):before,
-.prose :where(code):not(pre code):not(:where([class~=not-prose] *)):after {
+.prose :where(code):not(pre code):not(:where([class~='not-prose'] *)):before,
+.prose :where(code):not(pre code):not(:where([class~='not-prose'] *)):after {
   content: '`';
   display: inline-block;
 }
@@ -193,5 +196,15 @@ dialog button:focus-visible {
 @media (prefers-color-scheme: dark) {
   :root .prose {
     --tw-prose-body: rgb(236, 236, 236);
+  }
+}
+
+/* show only on touch devices */
+@media (hover: none), (hover: on-demand), (-moz-touch-enabled: 1), (pointer: coarse) {
+  .tooltip:hover:after,
+  .tooltip:hover:active:before,
+  .tooltip:hover:active:after,
+  .tooltip:hover:before {
+    display: none;
   }
 }

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -28,4 +28,5 @@
   <%= render 'application/head/favicons' %>
   <%= render 'application/head/meta_tags' %>
   <%= content_for :head %>
+  <%= hotwire_livereload_tags if Rails.env.development? %> <!-- Hotwire LiveReload -->
 </head>

--- a/app/views/application/head/_meta_tags.html.erb
+++ b/app/views/application/head/_meta_tags.html.erb
@@ -4,5 +4,6 @@
   <%= meta_tag('apple-mobile-web-app-capable','yes') %>
   <%= meta_tag('apple-mobile-web-app-status-bar-style','default') %>
   <%= meta_tag('apple-touch-fullscreen','yes') %>
+  <%= meta_tag('viewport', 'width=device-width, initial-scale=1, viewport-fit=cover') %>
 <% end %>
 <%= yield :meta_tags %>

--- a/app/views/assistants/_assistant.html.erb
+++ b/app/views/assistants/_assistant.html.erb
@@ -11,6 +11,7 @@
             bg-gray-50 dark:bg-gray-900
               group cursor-pointer
               text-sm rounded-lg
+              select-none
               <%= selected && 'relationship' %>
             "
       data-role="assistant"
@@ -18,7 +19,7 @@
       data-action="radio-changed@window->radio-behavior#select"
       data-radio-behavior-id-param="<%= assistant.id %>"
   >
-    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate", data: { role: "name" } do %>
+    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate ", data: { role: "name" } do %>
       <%= render partial: "layouts/assistant_avatar", locals: { assistant: assistant, size: 7, classes: "mr-2" } %>
       <%= assistant.name %>
     <% end %>

--- a/app/views/assistants/_assistant.html.erb
+++ b/app/views/assistants/_assistant.html.erb
@@ -11,7 +11,6 @@
             bg-gray-50 dark:bg-gray-900
               group cursor-pointer
               text-sm rounded-lg
-              select-none
               <%= selected && 'relationship' %>
             "
       data-role="assistant"
@@ -19,7 +18,7 @@
       data-action="radio-changed@window->radio-behavior#select"
       data-radio-behavior-id-param="<%= assistant.id %>"
   >
-    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate ", data: { role: "name" } do %>
+    <%= link_to new_assistant_message_path(assistant), class: "flex-1 flex items-center text-gray-950 dark:text-gray-100 font-medium truncate", data: { role: "name" } do %>
       <%= render partial: "layouts/assistant_avatar", locals: { assistant: assistant, size: 7, classes: "mr-2" } %>
       <%= assistant.name %>
     <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,7 +54,7 @@
       data-action="click->transition#toggleClass"
     ></div>
 
-    <main class="flex flex-1 h-full bg-white dark:bg-gray-800">
+    <main class="flex flex-1 h-full w-full bg-white dark:bg-gray-800">
       <%= content_for?(:main) ? yield(:main) : yield %>
     </main>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,9 +4,6 @@
   <%= render "head" %>
   <body
     class="
-      h-screen
-      font-sans text-gray-950 dark:text-gray-100
-      flex
       nav-closed
     "
     data-controller="transition"
@@ -15,9 +12,9 @@
   >
     <nav
       class="
-        h-screen w-[260px]
+        w-[260px]
         bg-gray-50 dark:bg-gray-900
-
+        h-screen
         flex nav-closed:hidden <%= !Current.user.preferences[:nav_closed] && "md:!flex" %>
         z-30 md:z-auto nav-closed:z-auto
         absolute md:relative nav-closed:relative
@@ -25,7 +22,7 @@
         flex-col
       "
     >
-      <div id="nav-container" class="flex-1 flex flex-col h-screen">
+      <div id="nav-container" class="flex-1 flex flex-col h-full">
         <div id="nav-scrollable" class="flex-grow pl-3 overflow-y-auto overflow-x-clip scrollbar-hide overscroll-contain">
           <%= yield :nav_column %>
         </div>
@@ -57,7 +54,7 @@
       data-action="click->transition#toggleClass"
     ></div>
 
-    <main class="flex flex-1 h-screen bg-white dark:bg-gray-800">
+    <main class="flex flex-1 h-full bg-white dark:bg-gray-800">
       <%= content_for?(:main) ? yield(:main) : yield %>
     </main>
 

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -2,7 +2,7 @@
 <html>
   <%= render "head" %>
   <body class="font-sans text-gray-950 dark:text-gray-100">
-    <main class="flex h-screen bg-white dark:bg-gray-800">
+    <main class="flex h-screen bg-white dark:bg-gray-800  w-full">
       <%= content_for?(:main) ? yield(:main) : yield %>
     </main>
     <%= render "layouts/toast" %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,6 +77,6 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.hosts << /[a-z0-9\-]+\.ngrok-free\.app/
-  config.hosts << /hostedgpt.*/
+
   config.hotwire_livereload.reload_method = :turbo_stream
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -78,4 +78,5 @@ Rails.application.configure do
 
   config.hosts << /[a-z0-9\-]+\.ngrok-free\.app/
   config.hosts << /hostedgpt.*/
+  config.hotwire_livereload.reload_method = :turbo_stream
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,4 +77,5 @@ Rails.application.configure do
   config.action_controller.raise_on_missing_callback_actions = true
 
   config.hosts << /[a-z0-9\-]+\.ngrok-free\.app/
+  config.hosts << /hostedgpt.*/
 end


### PR DESCRIPTION
* [x]  We should disable all hover tooltips on mobile. With the touch screen, the tooltip doesn't appear until you tap and then it's left sitting on screen. So, for example, when you send a chat message you still see "send message" tooltip above the submit button after you've tapped it. Tooltips aren't appropriate on mobile.
* [x]  When you open the nav bar on mobile there is a weird black line at the top, we should hide this:
* [x]  We need to make room at the bottom of the page for the iOS grab handle. The tricky thing is, some iOS devices need that extra space and others don't. React Native (and I believe Swift) solve this by the concept of safe area (react native can wrap the view in SafeAreaProvider and it just does the right thing). Does an equivalent exist in PWA apps?
* [x]  When you try to scroll outside of the scroll box (because you reach the top and the bottom) it moves the header and footer. Here I'm pulling down. There is some fix for this with CSS but I forget what it is:

- adding hotwire-livereload dev dependencies, improving frontend dev 
