### PR TITLE
Fix a race that sometimes hides stop streaming

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -22,7 +22,7 @@ class MessagesController < ApplicationController
     @messages = @conversation.messages.for_conversation_version(@version)
     @new_message = @assistant.messages.new(conversation: @conversation)
     @streaming_message = Message.where(
-      content_text: nil,
+      content_text: [nil, ""],
       cancelled_at: nil
     ).find_by(id: redis.get("conversation-#{@conversation.id}-latest-assistant_message-id"))
   end


### PR DESCRIPTION
The stop streaming icon is checking for nil content_text, but right after the job gets picked up the nil changes to "" so sometimes that was happening before the controller refreshed and the stop was not appearing.