### PR TITLE
Fix some additional edge cases with voice playback

### DIFF
--- a/app/assets/stylesheets/includes/daisyui_tooltip.css
+++ b/app/assets/stylesheets/includes/daisyui_tooltip.css
@@ -159,6 +159,7 @@
 .alert-error {
   --er: 0% 0 0;
   --erc: 100% 0 0;
+  border: 1px solid white;
 }
 
 /* Form overrides */

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,29 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
+import { cable } from "@hotwired/turbo-rails"
+
+window.isConnected = true
+window.cable = cable
+window.consumer = await cable.createConsumer()
+setInterval(() => {
+  if (consumer.connection.isOpen() != window.isConnected) {
+    window.isConnected = consumer.connection.isOpen()
+    console.log(`cable ${window.isConnected ? 'connected' : 'DISCONNECTED'}`)
+    const elem = document.getElementById('connection-status')
+    if (!window.isConnected) {
+      if (elem) {
+        elem.classList.add('bg-red-400')
+        elem.classList.add('text-white')
+      }
+    } else {
+      if (elem) {
+        elem.classList.remove('bg-red-400')
+        elem.classList.remove('text-white')
+        elem.classList.add('text-red-500')
+      }
+    }
+  }
+}, 500)
+window.consumer.connection.open()
 
 // TODO: Remove this debug code
 // This is included in main just for awhile to aid with some debugging

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,20 +7,11 @@ import "@hotwired/turbo-rails"
 
 let oldTimestamp
 
-console.log('Document: refresh')
-document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}`))
-document.addEventListener('turbo:morph', () => console.log('Document: morph render'))
-document.addEventListener('turbo:frame-render', () => console.log('Document: frame render'))
-document.addEventListener('turbo:before-stream-render', (event) => {
-  const stream = event.target
-  const newElement = stream.children[0].content.children[0]
-  let newTimestamp
-  //const oldElement = document.getElementById(newElement.id.toString())
-  if (newElement) newTimestamp = parseInt(newElement.getAttribute('data-timestamp'))
-
-  console.log(`Document: stream render (${stream.getAttribute('action')} event) ${newTimestamp <= oldTimestamp ? 'REORDER!' : ''}`, stream)
-  oldTimestamp = newTimestamp
-})
+// console.log('Document: refresh')
+// document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}`))
+// document.addEventListener('turbo:morph', () => console.log('Document: morph render'))
+// document.addEventListener('turbo:frame-render', () => console.log('Document: frame render'))
+// document.addEventListener('turbo:before-stream-render', (event) => console.log(`Document: stream render (${event.target.getAttribute('action')} event)`, event.target, event.detail.newStream.querySelector('template').content?.firstChild?.nextSibling?.querySelector('[data-speaker-target="text assistantText"]')))
 
 window.imageLoadingForSystemTestsToCheck = {}
 window.logs = []

--- a/app/javascript/blocks/services/audio_service.js
+++ b/app/javascript/blocks/services/audio_service.js
@@ -75,7 +75,7 @@ export default class extends Service {
 
     for (let i = 1; i <= 3; i++) {
       try {
-        log(`  generating job ${index} attempt ${i} (${text.slice(0, 20)}...)`)
+        // log(`  generating job ${index} attempt ${i} (${text.slice(0, 20)}...)`)
         audioUrl = await SpeechService.audioFromOpenAI(text)
       } catch(error) {
         log(`  error fetching job ${index} attempt ${i}${i == 3 ? ' - giving up' : ''}`)

--- a/app/javascript/blocks/services/audio_service.js
+++ b/app/javascript/blocks/services/audio_service.js
@@ -7,6 +7,7 @@ export default class extends Service {
     $.player = new Audio()
     $.queue = []
     $.playing = false
+    $.speaking = false
     $.busy = false
   }
 
@@ -74,6 +75,7 @@ export default class extends Service {
 
     for (let i = 1; i <= 3; i++) {
       try {
+        log(`  generating job ${index} attempt ${i} (${text.slice(0, 20)}...)`)
         audioUrl = await SpeechService.audioFromOpenAI(text)
       } catch(error) {
         log(`  error fetching job ${index} attempt ${i}${i == 3 ? ' - giving up' : ''}`)
@@ -91,33 +93,33 @@ export default class extends Service {
   }
 
   async _speakingLoop(trigger) {
-    const jobsToPlay = $.queue.filter((job) => !job.played)
+    const jobsToPlay = $.queue.filter((job) => !job.spoken)
     // if (trigger) {
-    //   log(`speakingLoop with ${jobsToPlay.length} jobs remaining - ${trigger} finished & speaking = ${$.playing}`)
-    //   jobsToPlay.forEach((job) => log(`  job #${job.index}: ${job.generated ? 'generated' : 'not generated'} : ${job.played ? 'played' : 'not played'} : ${job.errored ? 'errored' : 'no error'} : ${job.words}...`))
+    //   log(`speakingLoop with ${jobsToPlay.length} jobs remaining - "${trigger}" finished & speaking = ${$.speaking} & playing = ${$.playing}`)
+    //   jobsToPlay.forEach((job) => log(`  job #${job.index}: ${job.generated ? 'generated' : 'not generated'} : ${job.spoken ? 'spoken' : 'not spoken'} : ${job.errored ? 'errored' : 'no error'} : ${job.words}...`))
     // }
 
     if (jobsToPlay.length > 0) {
       const job = jobsToPlay[0]
 
-      if (job.generated && !$.playing && job.errored) {
-        log(`  play #${job.index} skipped because of generating error`)
-        job.played = true
+      if (job.generated && !$.speaking && job.errored) {
+        log(`  speak #${job.index} skipped because of generating error`)
+        job.spoken = true
         _speakingLoop('playback')
         return
-      } else if (job.generated && !$.playing && !job.errored) {
-        job.played = true
-        _playThenLoop(job.index, job.words, job.audioUrl)
+      } else if (job.generated && !$.speaking && !job.errored) {
+        job.spoken = true
+        _speakThenLoop(job.index, job.words, job.audioUrl)
         return
       } else {
         await sleep(250)
         _speakingLoop()
         return
       }
-    } else if (!$.playing) _doneSpeaking()
+    } else if (!$.speaking) _doneSpeaking()
   }
 
-  _playThenLoop(index, words, audioUrl) {
+  _speakThenLoop(index, words, audioUrl) {
     // if (_plabackSoundTimeoutHandler) clearTimeout(_plabackSoundTimeoutHandler)
 
     // _plabackSoundTimeoutHandler = setTimeout(() => {
@@ -127,9 +129,11 @@ export default class extends Service {
     //   _speakingLoop('timer')
     // }, 8000) // figure out how to cancel this timeout as soon as speaking starts. Add a callback from background to indicate this
 
-    log(`Playing: ${words}`)
+    log(`Speaking: ${words}`)
+    $.speaking = true
     play(audioUrl, () => {
-      // f (_plabackSoundTimeoutHandler) clearTimeout(_plabackSoundTimeoutHandler)
+      $.speaking = false
+      // f (._plabackSoundTimeoutHandler) clearTimeout(._plabackSoundTimeoutHandler)
       // log(`  done #${index} - ${words.slice(0,10)}...`)
       _speakingLoop('playback')
     }, words)

--- a/app/javascript/blocks/services/speech_service.js
+++ b/app/javascript/blocks/services/speech_service.js
@@ -48,6 +48,7 @@ export default class extends Service {
   }
 
   static splitIntoThoughts(text) {
+    if (!text) return []
     text = text.replace(". . .", "...")
     const thoughts = text.split(/(?<=[^ ][\.,:!\?;…] |[\n，。．！？；：])/)
     return thoughts.reject(t => t.strip().empty())

--- a/app/javascript/stimulus/nested_pointer_controller.js
+++ b/app/javascript/stimulus/nested_pointer_controller.js
@@ -28,11 +28,11 @@ export default class extends Controller {
   boundRemoveParentClickable = (event) => { this.removeParentClickable(event) }
   removeParentClickable(event) {
     this.parent = event.currentTarget.parentNode.closest('.cursor-pointer')
-    this.parent.classList.remove('cursor-pointer')
+    this.parent?.classList?.remove('cursor-pointer')
   }
 
   boundAddParentClickable = () => { this.addParentClickable() }
   addParentClickable() {
-    this.parent.classList.add('cursor-pointer')
+    this.parent?.classList?.add('cursor-pointer')
   }
 }

--- a/app/javascript/stimulus/speaker_controller.js
+++ b/app/javascript/stimulus/speaker_controller.js
@@ -9,7 +9,13 @@ export default class extends Controller {
     this.textTargetsCount = this.textTargets.length
     this.thoughtsSentCount = 0
 
-    this.textTargets.forEach((target) => target.addEventListener('turbo:before-morph', this.boundParseWords))
+    this.textTargets.forEach((target) => target.addEventListener('turbo:before-morph-element', this.boundParseWords))
+    document.addEventListener('turbo:visit', this.lastParseWords)
+  }
+
+  disconnect() {
+    this.textTargets.forEach((target) => target.removeEventListener('turbo:before-morph-element', this.boundParseWords))
+    document.removeEventListener('turbo:visit', this.lastParseWords)
   }
 
   textTargetConnected(target) {
@@ -25,12 +31,10 @@ export default class extends Controller {
     this.parseWords(target)
   }
 
-  disconnect() {
-    this.textTargets.forEach((target) => target.removeEventListener('turbo:before-morph', this.boundParseWords))
-  }
-
-  boundParseWords = (event) => { this.parseWords(event) }
-  parseWords(target) {
+  lastParseWords = () => { this.parseWords(this.textTargets.last(), 'visit replace') }
+  boundParseWords = (event) => { this.parseWords(event.target, 'morph-element') }
+  parseWords(target, source = 'targetConnected') {
+    if (!target) return
     if (Microphone.off) return
 
     const thinking = target.getAttribute('data-thinking') === 'true'
@@ -39,7 +43,9 @@ export default class extends Controller {
     for(this.thoughtsSentCount; this.thoughtsSentCount < thoughts.length-1; this.thoughtsSentCount ++)
       Prompt.Speaker.toSay(thoughts[this.thoughtsSentCount])
 
-    if (!thinking && this.thoughtsSentCount == thoughts.length-1)
+    if (!thinking && this.thoughtsSentCount == thoughts.length-1) {
       Prompt.Speaker.toSay(thoughts[this.thoughtsSentCount])
+      this.thoughtsSentCount += 1
+    }
   }
 }

--- a/app/javascript/stimulus/speaker_controller.js
+++ b/app/javascript/stimulus/speaker_controller.js
@@ -18,7 +18,7 @@ export default class extends Controller {
   }
 
   disconnect() {
-    document.addEventListener('turbo:before-stream-render', this.parseReplaceWords)
+    document.removeEventListener('turbo:before-stream-render', this.parseReplaceWords)
     if (this.hasAssistantTextTarget) this.assistantTextTargets.forEach((target) => target.removeEventListener('turbo:morph-element', this.boundParseWords))
     document.removeEventListener('turbo:visit', this.firstParseWords)
   }
@@ -35,12 +35,11 @@ export default class extends Controller {
     this.parseWords(target, 'targetConnected')
   }
 
-  parseReplaceWords = (event) => { console.log('replace', event.target.getAttribute('action')); if (event.target.getAttribute('action') == 'replace') this.parseWords(event.detail.newStream.querySelector('template').content?.firstChild?.nextSibling?.querySelector('[data-speaker-target="text assistantText"]'), 'replace') }
+  parseReplaceWords = (event) => { if (event.target.getAttribute('action') == 'replace') this.parseWords(event.detail.newStream.querySelector('template').content?.firstChild?.nextSibling?.querySelector('[data-speaker-target="text assistantText"]'), 'replace') }
   firstParseWords = () => { if (this.assistantTextTargets.length == 1) this.parseWords(this.assistantTextTargets.first(), 'visit replace or first morph') }
   boundParseWords = (event) => { this.parseWords(event.target, 'morph') }
   parseWords(target, source) {
     if (!target) return
-    console.log(`parseWords (${source})`, target)
     if (source == 'morph' &&
        (target != this.assistantTextTargets.last() || target != this.textTargets.last())) {
       console.log(`morphed but not last`, target, this.assistantTextTargets.last(), this.textTargets.last())

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -85,11 +85,12 @@ class GetNextAIMessageJob < ApplicationJob
 
     unless Rails.env.test?
       puts "\n### Finished GetNextAIMessageJob attempt ##{attempt} with ERROR: #{msg}" unless Rails.env.test?
+      puts e.backtrace.join("\n") if Rails.env.development?
 
       if attempt < 3
         @message.content_text = "(Error after #{attempt.ordinalize} try, retrying... #{msg&.slice(0..3000)})"
         GetNextAIMessageJob.broadcast_updated_message(@message, thinking: false)
-        GetNextAIMessageJob.set(wait: (attempt+1).seconds).perform_later(message_id, assistant_id, attempt+1)
+        GetNextAIMessageJob.set(wait: (attempt+1).seconds).perform_later(user_id, message_id, assistant_id, attempt+1)
       else
         set_unexpected_error(msg)
         wrap_up_the_message
@@ -143,7 +144,7 @@ class GetNextAIMessageJob < ApplicationJob
     @message.save!
     @message.conversation.touch # updated_at change will bump it up your list + ensures it will be auto-titled
 
-    puts "\n### Finished GetNextAIMessageJob.perform(#{@message.id}, #{@message.assistant_id})" unless Rails.env.test?
+    puts "\n### Finished GetNextAIMessageJob.perform(#{@user.id}, #{@message.id}, #{@message.assistant_id})" unless Rails.env.test?
   end
 
   def generation_was_cancelled?

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -104,7 +104,7 @@ class GetNextAIMessageJob < ApplicationJob
       only_scroll_down_if_was_bottom: true,
       timestamp: (Time.current.to_f*1000).to_i,
       streamed: true,
-  }.merge(locals)
+    }.merge(locals)
   end
 
   private

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -197,7 +197,7 @@
             |,
             data: {
               composer_target: "cancel",
-              turbo_frame: "_top" # this causes the page to morph, without this it does a frame replace
+              turbo_frame: "_top" # this causes the page to morph, without this it does a frame substitution
           }) do |form| %>
             <div class="text-gray-300 dark:text-gray-500 mr-2 hidden md:block">
               ⌘ ESC
@@ -228,7 +228,8 @@
           model: [@assistant, @new_message],
           data: {
             composer_target: "form",
-            turbo_frame: "_top" # this causes the page to morph, without this it does a frame replace
+            turbo_frame: "_top", # this causes the page to morph, without this it does a frame substitution
+            turbo_action: "replace",
         }) do |form| %>
           <%= form.hidden_field :conversation_id %>
           <%= form.hidden_field :index, value: @messages&.length %>

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -395,6 +395,7 @@
 
       <div class="w-full mb-2 text-xs text-center text-gray-400 dark:text-gray-300">
         <span id="connection-status" class="" data-turbo-permanent>HostedGPT can make mistakes. Double check information.</span>
+        <span>&nbsp;</span> <!-- the data-turbo-permanent causes height of page to be calculated incorrectly, adding this span fixes it -->
       </div>
   </footer>
 </turbo-frame>

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -394,7 +394,7 @@
       </div>
 
       <div class="w-full mb-2 text-xs text-center text-gray-400 dark:text-gray-300">
-        HostedGPT can make mistakes. Double check information.
+        <span id="connection-status" class="" data-turbo-permanent>HostedGPT can make mistakes. Double check information.</span>
       </div>
   </footer>
 </turbo-frame>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -52,9 +52,10 @@ end
       <turbo-frame id="message-<%= message.id %>">
 
       <div
+        id="message-text-<%= message.id %>"
         class="hidden"
         data-clipboard-target="text"
-        <%= message.assistant? && "data-speaker-target=text" %>
+        data-speaker-target="text <%= message.assistant? && 'assistantText' %>"
         data-thinking="<%= thinking ? 'true' : 'false' %>"
       ><%= message.content_text %></div>
         <div

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,6 @@ Rails.application.routes.draw do
 
   # routes to still be cleaned up:
 
-  resources :chats, only: [:index, :show, :create]
-
   get "/login", to: "sessions#new"
   post "/login", to: "sessions#create"
   get "/register", to: "users#new"


### PR DESCRIPTION
The notable fixes in here are:

* When the "thinking" sound is being played, it was preventing (or significantly delaying) playback of an audio file because it causes a "play next?" check to fail
* When you start a brand new conversation (from /new) the first submit takes you to a new URL and does not do a turbo morph but a turbo advance. If the response was short in this case, then no streaming would occur because it would all be present instantly and this would cause playback to be missed. I turned this into a `replace` action (since we don't want "back" to take you to the previous step in the conversation) and added an extra event listener for this.
* Adding a visual indicator that a disconnection has occurred.