### PR TITLE
Be more conservative in surfacing API errors to the user

### DIFF
--- a/app/javascript/blocks/interfaces/listener_interface.js
+++ b/app/javascript/blocks/interfaces/listener_interface.js
@@ -42,10 +42,12 @@ export default class extends Interface {
                         }
                       }
 
-  Disable()           { $.processing = null
-                        $.screenService.end()
-                        Flip.Transcriber.off()
-                        Play.Speaker.sound('pip')
+  Disable()           { if ($.processing != null) {
+                          $.processing = null
+                          $.screenService.end()
+                          Flip.Transcriber.off()
+                          Play.Speaker.sound('pip')
+                        }
                       }
 
   attr_consideration  = ''

--- a/app/javascript/stimulus/composer_controller.js
+++ b/app/javascript/stimulus/composer_controller.js
@@ -62,7 +62,7 @@ export default class extends Controller {
 
     if (Listener.engaged) {
       this.disableMicrophone()
-    } else if (Microphone.off){
+    } else if (Microphone.off) {
       this.enableMicrophone()
     }
   }
@@ -90,19 +90,19 @@ export default class extends Controller {
     this.microphoneDisableTarget.classList.remove('animate-blink')
     this.disableComposer()
     this.inputTarget.placeholder = "Speak aloud..."
-    Flip.Microphone.on()
+    Invoke.Listener()
   }
 
   blinkingMicrophone() {
-    this.enableMicrophone()
     this.microphoneDisableTarget.classList.add('animate-blink')
+    Dismiss.Listener()
   }
 
   disableMicrophone() {
     this.microphoneEnableTarget.classList.remove('hidden')
     this.microphoneDisableTarget.classList.add('hidden')
     this.enableComposer()
-    Flip.Microphone.off()
+    Disable.Listener()
     this.determineSubmitButton()
   }
 

--- a/app/javascript/stimulus/speaker_controller.js
+++ b/app/javascript/stimulus/speaker_controller.js
@@ -52,6 +52,8 @@ export default class extends Controller {
     const thinking = target.getAttribute('data-thinking') === 'true'
     const thoughts = SpeechService.splitIntoThoughts(target.innerText)
 
+    if (thoughts.includes('::ServerError')) return  // client is displaying a server error
+
     for(this.thoughtsSentCount; this.thoughtsSentCount < thoughts.length-1; this.thoughtsSentCount ++)
       Prompt.Speaker.toSay(thoughts[this.thoughtsSentCount])
 

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -91,11 +91,10 @@ class GetNextAIMessageJob < ApplicationJob
       puts e.backtrace.join("\n") if Rails.env.development?
 
       if attempt < 3
-        @message.content_text = "(Error after #{attempt.ordinalize} try, retrying... #{msg&.slice(0..3000)})"
         GetNextAIMessageJob.broadcast_updated_message(@message, thinking: false)
         GetNextAIMessageJob.set(wait: (attempt+1).seconds).perform_later(user_id, message_id, assistant_id, attempt+1)
       else
-        set_unexpected_error(msg)
+        set_unexpected_error(msg&.slice(0...2000))
         wrap_up_the_message
       end
     end


### PR DESCRIPTION
Fixes some issues in #331 

- Ensure mic doesn't enable until after screen share answer
- If we do surface errors, don't speak them
- Be more conservative in surfacing API errors to the user