### PR TITLE
Don't render signup link if registration feature is disabled

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,7 +6,7 @@
 
   <h2 class='text-3xl font-semibold'>Welcome back</h2>
 
-  <% unless Feature.registration? %>
+  <% if Feature.registration? %>
     <span class='text-sm text-center'>
       Don't have an account? <%= link_to "Sign up", register_path, class: "underline" %>
     </span>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -6,9 +6,11 @@
 
   <h2 class='text-3xl font-semibold'>Welcome back</h2>
 
-  <span class='text-sm text-center'>
-    Don't have an account? <%= link_to "Sign up", register_path, class: "underline" %>
-  </span>
+  <% unless Feature.registration? %>
+    <span class='text-sm text-center'>
+      Don't have an account? <%= link_to "Sign up", register_path, class: "underline" %>
+    </span>
+  <% end %>
 
   <%= form_with(url: login_path, method: :post, class: "flex flex-col space-y-4 w-80") do |f| %>
     <%= f.email_field :email,

--- a/test/models/feature_test.rb
+++ b/test/models/feature_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class FeatureTest < ActiveSupport::TestCase
+  include FeatureHelpers
+
   test "should return value of feature" do
     stub_features(my_feature: true) do
       assert Feature.enabled?(:my_feature)
@@ -64,23 +66,5 @@ class FeatureTest < ActiveSupport::TestCase
       refute Feature.enabled?(:google_authentication)
       refute Feature.google_authentication?
     end
-  end
-
-  private
-
-  def stub_features(hash, &block)
-    Feature.features_hash = nil
-    Feature.stub :features, hash do
-      yield
-    end
-    Feature.features_hash = nil
-  end
-
-  def stub_raw_features(hash, &block)
-    Feature.features_hash = nil
-    Feature.stub :raw_features, hash do
-      yield
-    end
-    Feature.features_hash = nil
   end
 end

--- a/test/support/feature_helpers.rb
+++ b/test/support/feature_helpers.rb
@@ -1,0 +1,20 @@
+module FeatureHelpers
+
+  private
+
+  def stub_features(hash, &block)
+    Feature.features_hash = nil
+    Feature.stub :features, hash do
+      yield
+    end
+    Feature.features_hash = nil
+  end
+
+  def stub_raw_features(hash, &block)
+    Feature.features_hash = nil
+    Feature.stub :raw_features, hash do
+      yield
+    end
+    Feature.features_hash = nil
+  end
+end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -1,6 +1,8 @@
 require "application_system_test_case"
 
 class UsersTest < ApplicationSystemTestCase
+  include FeatureHelpers
+
   setup do
     @user = users(:keith)
     visit root_url
@@ -35,6 +37,13 @@ class UsersTest < ApplicationSystemTestCase
     click_text "Sign Up"
 
     assert_text "can't be blank"
+  end
+
+  test "should hide the Sign Up link if the registration feature is disabled" do
+    stub_features(registration: false) do
+      visit root_url
+      assert_no_text 'Sign up'
+    end
   end
 
   test "should create a new user" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,8 @@ require "rails/test_help"
 require "minitest/autorun"
 require "pry"
 
+require_relative 'support/feature_helpers'
+
 class Capybara::Node::Element
   def obsolete?
     inspect.include?('Obsolete')


### PR DESCRIPTION
Hides the signup link since the controller just redirects back to root path if the registration feature is disabled.