### PR TITLE
Validate email format in Person model

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -6,7 +6,7 @@ class Person < ApplicationRecord
 
   validate :personable_id_unchanged, on: :update
   validates_associated :personable
-  validates :email, presence: true, uniqueness: true
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validate :proper_personable_id, on: :update
 
   scope :ordered, -> { order(:created_at) }

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -46,4 +46,11 @@ class PersonTest < ActiveSupport::TestCase
     assert person.save
     assert_instance_of User, person.personable
   end
+
+  test "person with invalid email format validation" do
+    person = Person.new(email: "invalid_email")
+    refute person.valid?
+    assert_includes person.errors[:email], "is invalid"
+    refute person.save, "Person with invalid email was saved"
+  end
 end


### PR DESCRIPTION
Implements email format validation for the `Person` model and adds a corresponding unit test.

- Adds a validation in the `Person` model to ensure the email attribute conforms to a valid email format using `URI::MailTo::EMAIL_REGEXP`.
- Introduces a new unit test in `person_test.rb` to verify that a `Person` instance with an invalid email format is not considered valid and cannot be saved to the database.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AllYourBot/hostedgpt?shareId=6fdb15a4-5b92-4167-a7c3-7e7dd5cb7b7e).