### PR TITLE
Add language models to seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ require "active_record/fixtures"
 if Rails.env.development?
 
   puts "loading fixtures"
-  order_to_load_fixtures = %w[people users tombstones assistants conversations runs messages steps]
+  order_to_load_fixtures = %w[people users tombstones language_models assistants conversations runs messages steps ]
 
   ActiveRecord::Base.transaction do
     ActiveRecord::Base.connection.disable_referential_integrity do

--- a/test/seeds_test.rb
+++ b/test/seeds_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class SeedsTest < ActiveSupport::TestCase
   def setup
-    Rails.application.load_seed 
+    Rails.application.load_seed
   end
 
   test 'seeds run without errors' do

--- a/test/seeds_test.rb
+++ b/test/seeds_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class SeedsTest < ActiveSupport::TestCase
+  def setup
+    Rails.application.load_seed 
+  end
+
+  test 'seeds run without errors' do
+    assert_nothing_raised do
+      load Rails.root.join('db', 'seeds.rb')
+    end
+  end
+
+  test 'seeds created the expected data' do
+    load Rails.root.join('db', 'seeds.rb')
+
+    assert LanguageModel.count > 0, "Expected at least one LanguageModel to be created"
+    assert Assistant.count > 0, "Expected at least one Assistant to be created"
+  end
+end


### PR DESCRIPTION
I was running into an issue setting up the application locally, specifically at the seeding step (see image below). I realized it was due to the fact that it was trying to create assistant records without having language model records to connect them to.


<img width="1708" alt="Screenshot 2024-05-30 at 2 23 07 PM" src="https://github.com/AllYourBot/hostedgpt/assets/7636254/8a44958a-47c9-4220-8a75-1f99cab18137">