### PR TITLE
Configure optional database port

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,7 @@ default: &default
   encoding: unicode
   host: localhost
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  port: <%= ENV['HOSTEDGPT_DATABASE_PORT'] || 5432 %>
 <% if RUBY_PLATFORM =~ /darwin/ %>
   gssencmode: disable
 <% end %>


### PR DESCRIPTION
Configure an optional database port via environment variable, falls back to PostgreSQL default if not provided.