### PR TITLE
Fix database.yml password for production

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,4 +20,5 @@ production:
   <<: *default
   database: hostedgpt_production
   username: hostedgpt
-  password: <%= ENV["HOSTEDGPT_DATABASE_PASSWORD"] %>=
+  password: <%= ENV["HOSTEDGPT_DATABASE_PASSWORD"] %>
+  


### PR DESCRIPTION
There was always an = sign appended the production database password.