### PR TITLE
Add support for API clients

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,24 @@
 class ApplicationController < ActionController::Base
   include Authenticate
 
+  def default_render
+    if api_request?
+      json_payload = user_defined_ivars.map { |i| [ i.to_s[1..], instance_variable_get(i) ] }.to_h
+      render json: json_payload, status: :ok
+    else
+      super
+    end
+  end
+
   private
+
+  def api_request?
+    request.format.json?
+  end
+
+  def user_defined_ivars
+    instance_variables.select { |i| !i.to_s.starts_with?('@_') }
+  end
 
   def ensure_manual_login_allowed
     return if manual_login_allowed?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include Authenticate
 
+  skip_before_action :verify_authenticity_token, if: :api_request?
   before_action :set_system_ivars
 
   def default_render(*args)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::Base
   include Authenticate
 
+  before_action :set_system_ivars
+
   def default_render
     if api_request?
       json_payload = user_defined_ivars.map { |i| [ i.to_s[1..], instance_variable_get(i) ] }.to_h
@@ -12,12 +14,20 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def set_system_ivars
+    @system_ivars = public_ivars
+  end
+
+  def public_ivars
+    instance_variables.select { |i| !i.to_s.starts_with?('@_') }
+  end
+
   def api_request?
     request.format.json?
   end
 
   def user_defined_ivars
-    instance_variables.select { |i| !i.to_s.starts_with?('@_') }
+    public_ivars - @system_ivars
   end
 
   def ensure_manual_login_allowed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
   end
 
   def user_defined_ivars
-    public_ivars - @system_ivars
+    public_ivars - @system_ivars - ["system_ivar"]
   end
 
   def ensure_manual_login_allowed

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,12 +3,26 @@ class ApplicationController < ActionController::Base
 
   before_action :set_system_ivars
 
-  def default_render
+  def default_render(*args)
     if api_request?
       json_payload = user_defined_ivars.map { |i| [ i.to_s[1..], instance_variable_get(i) ] }.to_h
       render json: json_payload, status: :ok
     else
-      super
+      super(*args)
+    end
+  end
+
+  def redirect_to(*args)
+    if api_request?
+      options = args.extract_options!
+      status = options[:status]
+
+      if status == :see_other
+        render json: options.merge(redirect_to: args.first), status: :ok
+        return
+      end
+    else
+      super(*args)
     end
   end
 

--- a/app/controllers/assistants_controller.rb
+++ b/app/controllers/assistants_controller.rb
@@ -1,6 +1,6 @@
 class AssistantsController < ApplicationController
   def index
     assistant = Current.user.assistants.ordered.first
-    redirect_to new_assistant_message_path(assistant)
+    redirect_to new_assistant_message_path(assistant), status: :see_other
   end
 end

--- a/app/controllers/authentications/google_oauth_controller.rb
+++ b/app/controllers/authentications/google_oauth_controller.rb
@@ -34,7 +34,7 @@ class Authentications::GoogleOauthController < ApplicationController
 
   def destroy
     if Current.user
-      redirect_to edit_settings_person_path, alert: "Cancelled"
+      redirect_to edit_settings_person_path, alert: "Cancelled", status: :see_other
     else
       redirect_to login_path
     end

--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -9,10 +9,10 @@ class AuthenticationsController < ApplicationController
 
   def create
     person = Person.find_by(email: params[:email])
-    @user = person&.personable
+    user = person&.personable
 
-    if person.present? && @user&.password_credential&.authenticate(params[:password])
-      login_as(person, credential: @user.password_credential)
+    if person.present? && user&.password_credential&.authenticate(params[:password])
+      login_as(person, credential: user.password_credential)
       redirect_to root_path
       return
     end

--- a/app/controllers/concerns/authenticate.rb
+++ b/app/controllers/concerns/authenticate.rb
@@ -1,7 +1,7 @@
 module Authenticate
   extend ActiveSupport::Concern
   include LoginLogout
-  include ByCookie, ByHttpHeader
+  include ByCookie, ByHttpHeader, ByBearerToken
 
   included do
     before_action :require_authentication
@@ -35,6 +35,8 @@ module Authenticate
   end
 
   def request_authentication
+    return if performed?
+
     session[:return_to_after_authenticating] = request.url
     if manual_login_allowed?
       redirect_to login_url
@@ -48,7 +50,7 @@ module Authenticate
   end
 
   def find_client
-    find_client_by_cookie || find_client_by_http_header
+    find_client_by_cookie || find_client_by_http_header || find_client_by_bearer_token
   end
 
   def post_authenticating_url

--- a/app/controllers/concerns/authenticate/by_bearer_token.rb
+++ b/app/controllers/concerns/authenticate/by_bearer_token.rb
@@ -24,5 +24,6 @@ module Authenticate::ByBearerToken
   def render_unauthorized
     self.headers['WWW-Authenticate'] = 'Token realm="Application"'
     render json: { error: "Authentication Bearer token was invalid" }, status: :unauthorized
+    nil
   end
 end

--- a/app/controllers/concerns/authenticate/by_bearer_token.rb
+++ b/app/controllers/concerns/authenticate/by_bearer_token.rb
@@ -6,7 +6,7 @@ module Authenticate::ByBearerToken
     authenticate_with_http_token do |double_token, options|
       client, client_token = parse_double_token(double_token)
 
-      if client_token && ActiveSupport::SecurityUtils.secure_compare(client.token, client_token)
+      if client && client_token && ActiveSupport::SecurityUtils.secure_compare(client.token, client_token)
         client
       else
         render_unauthorized

--- a/app/controllers/concerns/authenticate/by_bearer_token.rb
+++ b/app/controllers/concerns/authenticate/by_bearer_token.rb
@@ -1,0 +1,28 @@
+module Authenticate::ByBearerToken
+
+  private
+
+  def find_client_by_bearer_token
+    authenticate_with_http_token do |double_token, options|
+      client, client_token = parse_double_token(double_token)
+
+      if client_token && ActiveSupport::SecurityUtils.secure_compare(client.token, client_token)
+        client
+      else
+        render_unauthorized
+      end
+    end
+  end
+
+  def parse_double_token(double_token)
+    client_id, client_token = double_token.split(':')
+    client = Client.authenticated.api.find_by(id: client_id)
+
+    [client, client_token]
+  end
+
+  def render_unauthorized
+    self.headers['WWW-Authenticate'] = 'Token realm="Application"'
+    render json: { error: "Authentication Bearer token was invalid" }, status: :unauthorized
+  end
+end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -20,7 +20,7 @@ class DocumentsController < ApplicationController
     @document = Document.new(document_params)
 
     if @document.save
-      redirect_to @document, notice: "Document was successfully created."
+      redirect_to @document, notice: "Document was successfully created.", status: :see_other
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -13,10 +13,9 @@ class MessagesController < ApplicationController
   def index
     if @version.blank?
       version = @conversation.messages.order(:created_at).last&.version
-      redirect_to conversation_messages_path(
-        params[:conversation_id],
-        version: version
-      ) if version
+      if version
+        redirect_to conversation_messages_path(params[:conversation_id], version: version), status: :see_other
+      end
     end
 
     @messages = @conversation.messages.for_conversation_version(@version)
@@ -44,7 +43,7 @@ class MessagesController < ApplicationController
     if @message.save
       after_create_assistant_reply = @message.conversation.latest_message_for_version(@message.version)
       GetNextAIMessageJob.perform_later(Current.user.id, after_create_assistant_reply.id, @assistant.id)
-      redirect_to conversation_messages_path(@message.conversation, version: @message.version)
+      redirect_to conversation_messages_path(@message.conversation, version: @message.version), status: :see_other
     else
       # what's the right flow for a failed message create? it's not this, but hacking it so tests pass until we have a plan
       set_nav_conversations
@@ -57,7 +56,7 @@ class MessagesController < ApplicationController
 
   def update
     if @message.update(message_params)
-      redirect_to conversation_messages_path(@message.conversation, version: @version || @message.version)
+      redirect_to conversation_messages_path(@message.conversation, version: @version || @message.version), status: :see_other
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/settings/assistants_controller.rb
+++ b/app/controllers/settings/assistants_controller.rb
@@ -13,7 +13,7 @@ class Settings::AssistantsController < Settings::ApplicationController
     @assistant = Current.user.assistants.new(assistant_params)
 
     if @assistant.save
-      redirect_to edit_settings_assistant_path(@assistant), notice: "Saved"
+      redirect_to edit_settings_assistant_path(@assistant), notice: "Saved", status: :see_other
     else
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,7 +19,7 @@ class UsersController < ApplicationController
 
     if @person.save
       login_as(@person, credential: @person.user.password_credential)
-      redirect_to root_path
+      redirect_to root_path, status: :see_other
     else
       @person.errors.delete :personable
       render :new, status: :unprocessable_entity

--- a/app/models/client.rb
+++ b/app/models/client.rb
@@ -3,8 +3,9 @@ class Client < ApplicationRecord
 
   has_one :authentication, -> { not_deleted }
   has_many :authentications_including_deleted, class_name: "Authentication", inverse_of: :client, dependent: :destroy
+  scope :authenticated, -> { joins(:authentication).merge(Authentication.not_deleted) }
 
-  enum platform: %w[ ios android web ].index_by(&:to_sym)
+  enum platform: %w[ ios android web api ].index_by(&:to_sym)
 
   has_secure_token
 
@@ -27,6 +28,11 @@ class Client < ApplicationRecord
     authentication.deleted!
     reload_authentication
     true
+  end
+
+  def bearer_token
+    return nil unless api?
+    "#{id}:#{token}"
   end
 
   def to_s

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,7 +6,7 @@ class Current < ActiveSupport::CurrentAttributes
   def self.initialize_with(client: nil)
     self.client = client
 
-    if client&.is_a?(Client) && client&.authenticated?
+    if client&.is_a?(Client) && client.authenticated?
       self.person = client.person
       self.user = client.person&.user
     end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,7 +6,7 @@ class Current < ActiveSupport::CurrentAttributes
   def self.initialize_with(client: nil)
     self.client = client
 
-    if client&.is_a?(Client) && client.authenticated?
+    if client&.authenticated?
       self.person = client.person
       self.user = client.person&.user
     end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -6,7 +6,7 @@ class Current < ActiveSupport::CurrentAttributes
   def self.initialize_with(client: nil)
     self.client = client
 
-    if client&.authenticated?
+    if client&.is_a?(Client) && client&.authenticated?
       self.person = client.person
       self.user = client.person&.user
     end

--- a/test/controllers/concerns/authenticate/by_bearer_token_test.rb
+++ b/test/controllers/concerns/authenticate/by_bearer_token_test.rb
@@ -1,12 +1,14 @@
 require 'test_helper'
 
 class Authenticate::ByBearerTokenTest < ActionDispatch::IntegrationTest
-  test "should auth user with a bearer token and returns JSON" do
+  test "should auth user with a bearer token and returns proper JSON" do
     get conversation_messages_path(conversations(:greeting), version: 1), headers: bearer_token_for(clients(:keith_api))
     assert_response :success
+    data = nil
     assert_nothing_raised do
-      JSON.parse(response.body)
+      data = JSON.parse(response.body)
     end
+    refute data.keys.include?("rendered_format")
   end
 
   test "auth fails when bearer token is missing" do

--- a/test/controllers/concerns/authenticate/by_bearer_token_test.rb
+++ b/test/controllers/concerns/authenticate/by_bearer_token_test.rb
@@ -26,6 +26,12 @@ class Authenticate::ByBearerTokenTest < ActionDispatch::IntegrationTest
     assert_response :unauthorized
   end
 
+  test "auth fails when an authentication does not exist" do
+    client = clients(:rob_browser)
+    get conversation_messages_path(conversations(:greeting), version: 1), headers: bearer_token_for(client, "#{client.id}:#{client.token}")
+    assert_response :unauthorized
+  end
+
   private
 
   def bearer_token_for(client, token = nil)

--- a/test/controllers/concerns/authenticate/by_bearer_token_test.rb
+++ b/test/controllers/concerns/authenticate/by_bearer_token_test.rb
@@ -6,6 +6,7 @@ class Authenticate::ByBearerTokenTest < ActionDispatch::IntegrationTest
     assert_response :success
     data = proper_json_response
     refute data.keys.include?("rendered_format")
+    refute data.keys.include?("system_ivar")
   end
 
   test "GET request that redirects should auth user and return a special JSON response for redirect" do

--- a/test/controllers/concerns/authenticate/by_bearer_token_test.rb
+++ b/test/controllers/concerns/authenticate/by_bearer_token_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Authenticate::ByBearerTokenTest < ActionDispatch::IntegrationTest
+  test "should auth user with a bearer token and returns JSON" do
+    get conversation_messages_path(conversations(:greeting), version: 1), headers: bearer_token_for(clients(:keith_api))
+    assert_response :success
+    assert_nothing_raised do
+      JSON.parse(response.body)
+    end
+  end
+
+  test "auth fails when bearer token is missing" do
+    get conversation_messages_path(conversations(:greeting), version: 1)
+    assert_redirected_to login_path, "Expected this request to fail"
+  end
+
+  test "auth fails when bearer token contains just ID" do
+    get conversation_messages_path(conversations(:greeting), version: 1), headers: bearer_token_for(clients(:keith_api), clients(:keith_api).id)
+    assert_response :unauthorized
+  end
+
+  test "auth fails when bearer token contains just TOKEN" do
+    get conversation_messages_path(conversations(:greeting), version: 1), headers: bearer_token_for(clients(:keith_api), clients(:keith_api).token)
+    assert_response :unauthorized
+  end
+
+  private
+
+  def bearer_token_for(client, token = nil)
+    {
+      "Accept" => "application/json",
+      "Content-Type" => "application/json",
+      "Authorization" => "Bearer #{token || client.bearer_token}",
+    }
+  end
+end

--- a/test/fixtures/authentications.yml
+++ b/test/fixtures/authentications.yml
@@ -7,3 +7,8 @@ keith_google:
   credential: keith_google
   client: keith_phone_browser
   deleted_at:
+
+keith_api:
+  credential: keith_google
+  client: keith_api
+  deleted_at:

--- a/test/fixtures/clients.yml
+++ b/test/fixtures/clients.yml
@@ -19,13 +19,6 @@ keith_api:
   user_agent:
   ip_address:
 
-keith_tool:
-  person: keith_registered
-  token: xyz004
-  platform: tool
-  user_agent:
-  ip_address:
-
 rob_browser:
   person: rob_registered
   token: xyz005

--- a/test/models/client_test.rb
+++ b/test/models/client_test.rb
@@ -19,6 +19,15 @@ class ClientTest < ActiveSupport::TestCase
     end
   end
 
+  test "authenticated scope only gives the clients with an active authentication" do
+    ids = [ clients(:rob_browser).id, clients(:keith_desktop_browser).id ]
+    assert_equal 2, Client.where(id: ids).count
+
+    assert_equal 1, Client.authenticated.where(id: ids).count
+    refute clients(:rob_browser).authenticated?
+    assert clients(:keith_desktop_browser).authenticated?
+  end
+
   test "simple create works and token is generated" do
     assert_nothing_raised do
       Client.create!(person: people(:keith_registered), platform: :ios)
@@ -57,5 +66,10 @@ class ClientTest < ActiveSupport::TestCase
 
     assert_equal credentials(:keith_password), keith_browser.authentication.credential
     assert old_authentication.reload.deleted_at, "The old authentication should be deleted"
+  end
+
+  test "bearer_token returns nil for NON-API clients AND token for API clients" do
+    assert_nil clients(:keith_desktop_browser).bearer_token
+    assert_equal "#{clients(:keith_api).id}:#{clients(:keith_api).token}", clients(:keith_api).bearer_token
   end
 end


### PR DESCRIPTION
A request will be authenticated if there is a proper Bearer token in the request and JSON should be returned for all endpoints.

Automatically returning a response for actions that end with redirect_to was a little tricky. The way this was implemented was to assign a special significance to `redirect_to` with a `status: :see_other`. When this status is present, we take this as a sign of success and we render a simple success JSON response.