### PR TITLE
Add missing scope and method to Assistant

### DIFF
--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -17,6 +17,7 @@ class Assistant < ApplicationRecord
   validates :name, presence: true
 
   scope :ordered, -> { order(:id) }
+  scope :not_deleted, -> { where(deleted_at: nil) }
 
   def initials
     return nil if name.blank?

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -31,4 +31,8 @@ class Assistant < ApplicationRecord
   def to_s
     name
   end
+
+  def not_deleted?
+    deleted_at.nil?
+  end
 end


### PR DESCRIPTION
Signup wasn't working for me and it appeared to be due to a missing scope on the Assistant model. I also ran into an issue where a missing method on the model was causing an error.

Before:
<img width="821" alt="Screenshot 2024-06-13 at 11 49 51 AM" src="https://github.com/AllYourBot/hostedgpt/assets/7636254/020056fc-7f80-4b19-837e-7d4f5d7acdcd">

<img width="660" alt="Screenshot 2024-06-13 at 11 58 47 AM" src="https://github.com/AllYourBot/hostedgpt/assets/7636254/da62ce22-1ac8-41a5-871a-1fcd303bbf0f">


