### PR TITLE
renames API key methods on User to avoid keys leaking into JSON objects

### DIFF
--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -8,7 +8,7 @@ class AutotitleConversationJob < ApplicationJob
   def perform(conversation_id)
     conversation = Conversation.find(conversation_id)
     Current.user = conversation.user
-    return false if Current.user.openai_key.blank? # should we use anthropic key if that's all the user has?
+    return false if Current.user.preferred_openai_key.blank? # should we use anthropic key if that's all the user has?
 
     messages = conversation.messages.ordered.limit(4)
     raise ConversationNotReady  if messages.empty?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,10 +28,10 @@ class User < ApplicationRecord
   end
 
   def preferred_openai_key
-    self.attributes["openai_key"].presence || (Feature.default_llm_keys? ? Setting.default_openai_key : nil)
+    self.openai_key.presence || (Feature.default_llm_keys? ? Setting.default_openai_key : nil)
   end
 
   def preferred_anthropic_key
-    self.attributes["anthropic_key"].presence || (Feature.default_llm_keys? ? Setting.default_anthropic_key : nil)
+    self.anthropic_key.presence || (Feature.default_llm_keys? ? Setting.default_anthropic_key : nil)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,11 +27,11 @@ class User < ApplicationRecord
     attributes["preferences"].with_defaults(dark_mode: "system")
   end
 
-  def openai_key
+  def preferred_openai_key
     self.attributes["openai_key"].presence || (Feature.default_llm_keys? ? Setting.default_openai_key : nil)
   end
 
-  def anthropic_key
+  def preferred_anthropic_key
     self.attributes["anthropic_key"].presence || (Feature.default_llm_keys? ? Setting.default_anthropic_key : nil)
   end
 end

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -13,9 +13,9 @@ class AIBackend::Anthropic < AIBackend
   end
 
   def initialize(user, assistant, conversation, message)
-    raise ::Anthropic::ConfigurationError if user.anthropic_key.blank?
+    raise ::Anthropic::ConfigurationError if user.preferred_anthropic_key.blank?
     begin
-      @client = self.class.client.new(access_token: user.anthropic_key)
+      @client = self.class.client.new(access_token: user.preferred_anthropic_key)
     rescue ::Faraday::UnauthorizedError => e
       raise ::Anthropic::ConfigurationError
     end

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -49,9 +49,9 @@ class AIBackend::OpenAI < AIBackend
   end
 
   def initialize(user, assistant, conversation, message)
-    raise ::OpenAI::ConfigurationError if user.openai_key.blank?
+    raise ::OpenAI::ConfigurationError if user.preferred_openai_key.blank?
     begin
-      @client = self.class.client.new(access_token: user.openai_key)
+      @client = self.class.client.new(access_token: user.preferred_openai_key)
     rescue ::Faraday::UnauthorizedError => e
       raise ::OpenAI::ConfigurationError
     end

--- a/app/services/chat_completion_api.rb
+++ b/app/services/chat_completion_api.rb
@@ -58,7 +58,7 @@ class ChatCompletionAPI
     end
 
     client = OpenAI::Client.new(
-      access_token: Current.user.openai_key,
+      access_token: Current.user.preferred_openai_key,
       request_timeout: 240,
     )
 

--- a/app/views/settings/people/_form.html.erb
+++ b/app/views/settings/people/_form.html.erb
@@ -122,7 +122,6 @@
         <li>Add a "Payment method."</li>
       </ol>
       <%= user_fields.text_field :openai_key,
-        value: person.user.attributes["openai_key"],
         class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full dark:text-black",
         placeholder: "OpenAI Key"
       %>
@@ -174,7 +173,6 @@
         </li>
       </ol>
       <%= user_fields.text_field :anthropic_key,
-        value: person.user.attributes["anthropic_key"],
         class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full dark:text-black",
         placeholder: "Anthropic Key"
       %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -92,8 +92,8 @@ class UserTest < ActiveSupport::TestCase
     stub_features(default_llm_keys: false) do
       user = users(:keith)
       user.update!(openai_key: '', anthropic_key: ' ')
-      assert_nil user.openai_key
-      assert_nil user.anthropic_key
+      assert_nil user.preferred_openai_key
+      assert_nil user.preferred_anthropic_key
     end
   end
 end


### PR DESCRIPTION
From feedback on #407, renames the methods to avoid leaking the keys. The OpenAI key injected into JS for the voice feature does not fallback to a default API key.