### PR TITLE
Adds a DB unique constraints for registration

### DIFF
--- a/db/migrate/20240617100905_add_unique_indexes_for_emails_and_external_id.rb
+++ b/db/migrate/20240617100905_add_unique_indexes_for_emails_and_external_id.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexesForEmailsAndExternalId < ActiveRecord::Migration[7.1]
+  def change
+    add_index :people, [:email], unique: true
+    add_index :credentials, [:type, :external_id], unique: true
+    add_index :credentials, [:type, :oauth_email], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_06_012618) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_100905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -123,6 +123,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_012618) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["external_id"], name: "index_credentials_on_external_id"
+    t.index ["type", "external_id"], name: "index_credentials_on_type_and_external_id", unique: true
+    t.index ["type", "oauth_email"], name: "index_credentials_on_type_and_oauth_email", unique: true
     t.index ["user_id"], name: "index_credentials_on_user_id"
   end
 
@@ -192,6 +194,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_06_012618) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_people_on_email", unique: true
     t.index ["personable_type", "personable_id"], name: "index_people_on_personable"
   end
 


### PR DESCRIPTION
https://github.com/AllYourBot/hostedgpt/discussions/405

Ensures no two people share the same email address, which primarily matters for authentication via email.

Likewise, ensures no two credentials share email or external id for a given credential type, allowing the system to uniquely identify the entity being authenticated.