### PR TITLE
Add Claude 3.5 Sonnet and make it the Anthropic default

### DIFF
--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -2,7 +2,7 @@
 class LanguageModel < ApplicationRecord
   BEST_MODELS = {
     "gpt-best" => "gpt-4o-2024-05-13",
-    "claude-best" => "claude-3-opus-20240229"
+    "claude-best" => "claude-3-5-sonnet-20240620"
   }
 
   scope :ordered, -> { order(:position) }

--- a/app/models/user/registerable.rb
+++ b/app/models/user/registerable.rb
@@ -10,7 +10,7 @@ module User::Registerable
   def create_initial_assistants
     assistants.create! name: "GPT-4o", language_model: LanguageModel.find_by(name: "gpt-best")
     assistants.create! name: "GPT-3.5", language_model: LanguageModel.find_by(name: "gpt-3.5-turbo")
-    assistants.create! name: "Claude 3 Opus", language_model: LanguageModel.find_by(name: "claude-best")
-    assistants.create! name: "Claude 3 Sonnet", language_model: LanguageModel.find_by(name: "claude-3-sonnet-20240229")
+    assistants.create! name: "Claude 3.5 Sonnet", language_model: LanguageModel.find_by(name: "claude-best")
+    assistants.create! name: "Claude 3 Opus", language_model: LanguageModel.find_by(name: "claude-3-opus-20240229")
   end
 end

--- a/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
+++ b/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
@@ -14,7 +14,9 @@ class AddClaude35SonnetToLanguageModels < ActiveRecord::Migration[7.0]
     end
 
     Assistant.where(name: "Claude 3 Opus").update_all(name: "Claude 3.5 Sonnet")
-    Assistant.where(name: "Claude 3 Sonnet").update_all(name: "Claude 3 Opus", language_model_id: LanguageModel.find_by(name: "claude-3-opus-20240229").id)
+    if language_model_id = LanguageModel.find_by(name: "claude-3-opus-20240229")&.id
+      Assistant.where(name: "Claude 3 Sonnet").update_all(name: "Claude 3 Opus", language_model_id: language_model_id)
+    end
   end
 
   def down

--- a/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
+++ b/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
@@ -8,6 +8,12 @@ class AddClaude35SonnetToLanguageModels < ActiveRecord::Migration[7.0]
       supports_images: true
     )
 
+    LanguageModel.class_eval do
+      def readonly?
+        false
+      end
+    end
+
     # Increment the position of existing Language Models where position >= 19
     LanguageModel.where('position >= 19').where.not(name: 'claude-3-5-sonnet-20240620').find_each do |model|
       model.update(position: model.position + 1)

--- a/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
+++ b/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
@@ -14,7 +14,7 @@ class AddClaude35SonnetToLanguageModels < ActiveRecord::Migration[7.0]
     end
 
     Assistant.where(name: "Claude 3 Opus").update_all(name: "Claude 3.5 Sonnet")
-    Assistant.where(name: "Claude 3 Sonnet").update_all(name: "Claude 3 Opus", language_model: LanguageModel.find_by(name: "claude-3-opus-20240229"))
+    Assistant.where(name: "Claude 3 Sonnet").update_all(name: "Claude 3 Opus", language_model_id: LanguageModel.find_by(name: "claude-3-opus-20240229").id)
   end
 
   def down

--- a/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
+++ b/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
@@ -1,0 +1,16 @@
+class AddClaude35SonnetToLanguageModels < ActiveRecord::Migration[7.0]
+  def change
+    # Insert 'claude-3-5-sonnet-20240620' with position 20
+    LanguageModel.create!(
+      position: 19,
+      name: 'claude-3-5-sonnet-20240620',
+      description: 'Claude 3.5 Sonnet (2024-06-20)',
+      supports_images: true
+    )
+
+    # Increment the position of existing Language Models where position >= 19
+    LanguageModel.where('position >= 19').where.not(name: 'claude-3-5-sonnet-20240620').find_each do |model|
+      model.update(position: model.position + 1)
+    end
+  end
+end

--- a/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
+++ b/db/migrate/20240620100000_add_claude_3_5_sonnet_to_language_models.rb
@@ -1,5 +1,5 @@
 class AddClaude35SonnetToLanguageModels < ActiveRecord::Migration[7.0]
-  def change
+  def up
     # Insert 'claude-3-5-sonnet-20240620' with position 20
     LanguageModel.create!(
       position: 19,
@@ -12,5 +12,12 @@ class AddClaude35SonnetToLanguageModels < ActiveRecord::Migration[7.0]
     LanguageModel.where('position >= 19').where.not(name: 'claude-3-5-sonnet-20240620').find_each do |model|
       model.update(position: model.position + 1)
     end
+
+    Assistant.where(name: "Claude 3 Opus").update_all(name: "Claude 3.5 Sonnet")
+    Assistant.where(name: "Claude 3 Sonnet").update_all(name: "Claude 3 Opus", language_model: LanguageModel.find_by(name: "claude-3-opus-20240229"))
+  end
+
+  def down
+    raise "This migration can't be reversed easily."
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_18_154045) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_20_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/test/fixtures/language_models.yml
+++ b/test/fixtures/language_models.yml
@@ -108,38 +108,44 @@ gpt_3_5_turbo_instruct:
   description: GPT-3.5 Turbo Instruct
   supports_images: false
 
-claude_3_opus_20240229:
+claude_3_5_sonnet_20240620:
   position: 19
+  name: claude-3-5-sonnet-20240620
+  description: Claude 3.5 Sonnet (2024-06-20)
+  supports_images: true
+
+claude_3_opus_20240229:
+  position: 20
   name: claude-3-opus-20240229
   description: Claude 3 Opus (2024-02-29)
   supports_images: true
 
 claude_3_sonnet_20240229:
-  position: 20
+  position: 21
   name: claude-3-sonnet-20240229
   description: Claude 3 Sonnet (2024-02-29)
   supports_images: true
 
 claude_3_haiku_20240307:
-  position: 21
+  position: 22
   name: claude-3-haiku-20240307
   description: Claude 3 Haiku (2024-03-07)
   supports_images: true
 
 claude_2_1:
-  position: 22
+  position: 23
   name: claude-2.1
   description: Claude 2.1
   supports_images: false
 
 claude_2_0:
-  position: 23
+  position: 24
   name: claude-2.0
   description: Claude 2.0
   supports_images: false
 
 claude_instant_1_2:
-  position: 24
+  position: 25
   name: claude-instant-1.2
   description: Claude Instant 1.2
   supports_images: false

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -22,7 +22,7 @@ class LanguageModelTest < ActiveSupport::TestCase
 
   test "provider_name for best models" do
     assert_equal "gpt-4o-2024-05-13", language_models(:gpt_best).provider_name
-    assert_equal "claude-3-opus-20240229", language_models(:claude_best).provider_name
+    assert_equal "claude-3-5-sonnet-20240620", language_models(:claude_best).provider_name
   end
 
   test "provider_name for non-best models" do


### PR DESCRIPTION
Related to #426

This pull request introduces changes to add the new Claude 3.5 Sonnet model to the Language Models table, updates the `language_models.yml` fixture, and sets the new model as the best Claude model in the application.

- **Adds new Claude 3.5 Sonnet model to the database**: A migration is added to insert 'claude-3-5-sonnet-20240620' with position 19 into the Language Models table and increments the position of existing models where position >= 19 by 1.
- **Updates the `language_models.yml` fixture**: Adjusts the positions of models where position >= 19 by incrementing them by 1 and adds the new 'claude-3-5-sonnet-20240620' model with position 19.
- **Sets the new model as the best Claude model**: Modifies `app/models/language_model.rb` to update the `BEST_MODELS` hash, setting `claude-best` to "claude-3-5-sonnet-20240620".


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AllYourBot/hostedgpt/issues/426?shareId=bb23565f-109d-4211-8d50-68fbbfb55b25).