### PR TITLE
fix(db_migrations): conversations

### DIFF
--- a/db/migrate/20240624100000_add_groq.rb
+++ b/db/migrate/20240624100000_add_groq.rb
@@ -25,7 +25,7 @@ class AddGroq < ActiveRecord::Migration[7.0]
         asst = user.assistants.find_by(name: name)
         next if asst.nil?
         asst.deleted! if asst.conversations.count == 0
-        asst.deleted! if asst.conversations.count == 1 && asst.conversation.first.messages.count <= 2
+        asst.deleted! if asst.conversations.count == 1 && asst.conversations.first.messages.count <= 2
       end
 
       user.assistants.create!(name: "Meta Llama 3 70b", language_model: language_model)


### PR DESCRIPTION
fix converstaion to conversations in
Update 20240624100000_add_groq.rb

```
a25fac9f7c1e:/rails# bin/rails db:migrate 
== 20240624100000 AddGroq: migrating ==========================================
bin/rails aborted!
StandardError: An error has occurred, this and all later migrations canceled: (StandardError)

undefined method `conversation' for #<Assistant id: 11, user_id: 3, name: "GPT-3.5", description: nil, instructions: nil, tools: [], created_at: "2024-06-20 13:55:30.842694000 -0500", updated_at: "2024-06-25 16:22:16.475230000 -0500", language_model_id: 958075974, deleted_at: nil, external_id: nil>
/rails/db/migrate/20240624100000_add_groq.rb:28:in `block (2 levels) in up'
/rails/db/migrate/20240624100000_add_groq.rb:24:in `each'
/rails/db/migrate/20240624100000_add_groq.rb:24:in `block in up'
/rails/db/migrate/20240624100000_add_groq.rb:8:in `up'

Caused by:
NoMethodError: undefined method `conversation' for #<Assistant id: 11, user_id: 3, name: "GPT-3.5", description: nil, instructions: nil, tools: [], created_at: "2024-06-20 13:55:30.842694000 -0500", updated_at: "2024-06-25 16:22:16.475230000 -0500", language_model_id: 958075974, deleted_at: nil, external_id: nil> (NoMethodError)
Did you mean?  conversations
/rails/db/migrate/20240624100000_add_groq.rb:28:in `block (2 levels) in up'
/rails/db/migrate/20240624100000_add_groq.rb:24:in `each'
/rails/db/migrate/20240624100000_add_groq.rb:24:in `block in up'
/rails/db/migrate/20240624100000_add_groq.rb:8:in `up'
Tasks: TOP => db:migrate
(See full trace by running task with --trace)
```