### PR TITLE
Allow google oauth signup without a last_name

### DIFF
--- a/app/controllers/authentications/google_oauth_controller.rb
+++ b/app/controllers/authentications/google_oauth_controller.rb
@@ -35,7 +35,8 @@ class Authentications::GoogleOauthController < ApplicationController
       redirect_to root_path
     else
       @person&.errors&.delete :personable
-      redirect_to new_user_path, errors: @person&.errors&.full_messages
+      msg = @person.errors.full_messages.map { |m| m.gsub(/Personable |credentials /, '') }.to_sentence.capitalize
+      redirect_to new_user_path, alert: msg
     end
   rescue => e
     redirect_to edit_settings_person_path, alert: "Error. #{e.message}", status: :see_other

--- a/app/controllers/authentications/google_oauth_controller.rb
+++ b/app/controllers/authentications/google_oauth_controller.rb
@@ -36,6 +36,7 @@ class Authentications::GoogleOauthController < ApplicationController
     else
       @person&.errors&.delete :personable
       msg = @person.errors.full_messages.map { |m| m.gsub(/Personable |credentials /, '') }.to_sentence.capitalize
+      msg += " Cannot try again until you remove this website as a \"Google third-party connection\"." if msg.downcase.include?("oauth refresh token can't be blank")
       redirect_to new_user_path, alert: msg
     end
   rescue => e

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,12 +23,20 @@ class User < ApplicationRecord
   belongs_to :last_cancelled_message, class_name: "Message", optional: true
 
   validates :first_name, presence: true
-  validates :last_name, presence: true, on: :create
+  validates :last_name, presence: true, on: :create, unless: :creating_google_credential?
 
   accepts_nested_attributes_for :credentials
   serialize :preferences, coder: JsonSerializer
 
   def preferences
     attributes["preferences"].with_defaults(dark_mode: "system")
+  end
+
+  private
+
+  def creating_google_credential?
+    return false unless credential = credentials.first
+
+    !credential.persisted? && credential.type == "GoogleCredential"
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -53,6 +53,13 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal "example@gmail.com", person.email
   end
 
+  test "person cannot have an invalid email" do
+    person = Person.new(email: "invalid_email")
+    refute person.valid?
+    assert_includes person.errors[:email], "is invalid"
+    refute person.save, "Person with invalid email was saved"
+  end
+
   test "it can create a nested user" do
     person = Person.new({
       email: "example@gmail.com",
@@ -77,10 +84,51 @@ class PersonTest < ActiveSupport::TestCase
     assert_instance_of PasswordCredential, person.user.credentials.first
   end
 
-  test "person with invalid email format validation" do
-    person = Person.new(email: "invalid_email")
-    refute person.valid?
-    assert_includes person.errors[:email], "is invalid"
-    refute person.save, "Person with invalid email was saved"
+  test "the nested user errors without a last name" do
+    person = Person.new({
+      email: "example@gmail.com",
+      personable_type: "User",
+      personable_attributes: {
+        first_name: "John",
+        last_name: nil,
+        credentials_attributes: {
+          '0' => {
+            type: "PasswordCredential",
+            password: "password",
+          }
+        }
+      }
+    })
+    refute person.save
+    assert person.user.errors[:last_name].present?
+  end
+
+  test "the nested user CAN save without a last name when creating a GoogleCredential" do
+    # This test is in person_test rather than user_test because the oauth controller creates it through person
+    person = Person.new({
+      email: "example@gmail.com",
+      personable_type: "User",
+      personable_attributes: {
+        first_name: "John",
+        last_name: nil,
+        credentials_attributes: {
+          '0' => {
+            type: "GoogleCredential",
+            oauth_id: "123",
+            oauth_token: "abc-123",
+            oauth_refresh_token: "def-456",
+            oauth_email: "other-rob-email@gmail.com",
+            properties: {}
+          }
+        }
+      }
+    })
+    assert_difference "User.count", 1 do
+      assert_difference "Credential.count", 1 do
+        assert person.save
+      end
+    end
+    assert_instance_of User, person.personable
+    assert_instance_of GoogleCredential, person.user.credentials.first
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -85,4 +85,6 @@ class UserTest < ActiveSupport::TestCase
       users(:keith).update!(last_name: nil)
     end
   end
+
+  # Tests for creating_google_credential? are in person_test
 end


### PR DESCRIPTION
One of my Google accounts is missing a last name. Our auth flow makes last_name required but Google doesn't so this allows registration without a last name from Google Oauth.