### PR TITLE
Fix edge cases where voice mode is getting stuck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem "sprockets-rails" # The original asset pipeline for Rails [https://github.co
 gem "pg", "~> 1.1"
 gem "puma", ">= 5.0"
 gem "importmap-rails" # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-gem "turbo-rails", "~> 2.0.5"
-gem "stimulus-rails"
+gem "turbo-rails", git: "https://github.com/hotwired/turbo-rails.git", branch: "main"
+gem "stimulus-rails", git: "https://github.com/hotwired/stimulus-rails.git", branch: "main"
 gem "tailwindcss-rails", "~> 2.6.0"
 gem "rack-cors"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,21 @@
+GIT
+  remote: https://github.com/hotwired/stimulus-rails.git
+  revision: ae4b675473b71fdf01530c8a6a3bb277d3388ee2
+  branch: main
+  specs:
+    stimulus-rails (1.3.3)
+      railties (>= 6.0.0)
+
+GIT
+  remote: https://github.com/hotwired/turbo-rails.git
+  revision: c57122c65d887df7ed0de35a5d3a7f97f73179da
+  branch: main
+  specs:
+    turbo-rails (2.0.5)
+      actionpack (>= 6.0.0)
+      activejob (>= 6.0.0)
+      railties (>= 6.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -360,8 +378,6 @@ GEM
     standard-performance (1.2.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.1)
-    stimulus-rails (1.3.0)
-      railties (>= 6.0.0)
     stringio (3.1.0)
     sync (0.5.0)
     tailwindcss-rails (2.6.0-aarch64-linux)
@@ -382,10 +398,6 @@ GEM
     tins (1.33.0)
       bigdecimal
       sync
-    turbo-rails (2.0.5)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -446,11 +458,11 @@ DEPENDENCIES
   solid_queue (~> 0.2.1)
   sprockets-rails
   standard
-  stimulus-rails
+  stimulus-rails!
   tailwindcss-rails (~> 2.6.0)
   tiktoken_ruby (~> 0.0.6)
   timecop
-  turbo-rails (~> 2.0.5)
+  turbo-rails!
   tzinfo-data
   web-console
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,6 +19,7 @@ class MessagesController < ApplicationController
     end
 
     @messages = @conversation.messages.for_conversation_version(@version)
+    @last_message_playback_active = params[:last_message_playback_active].to_b
     @new_message = @assistant.messages.new(conversation: @conversation)
     @streaming_message = Message.where(
       content_text: [nil, ""],
@@ -43,7 +44,10 @@ class MessagesController < ApplicationController
     if @message.save
       after_create_assistant_reply = @message.conversation.latest_message_for_version(@message.version)
       GetNextAIMessageJob.perform_later(Current.user.id, after_create_assistant_reply.id, @assistant.id)
-      redirect_to conversation_messages_path(@message.conversation, version: @message.version), status: :see_other
+      extra_params = if request.referer == new_assistant_message_path(@assistant)
+        { last_message_playback_active: true }
+      end
+      redirect_to conversation_messages_path(@message.conversation, version: @message.version, **extra_params.to_h), status: :see_other
     else
       # what's the right flow for a failed message create? it's not this, but hacking it so tests pass until we have a plan
       set_nav_conversations

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,6 +1,22 @@
 require "./lib/markdown_renderer"
 
 module MessagesHelper
+  def render_avatar_for(message)
+    if message.user?
+      render partial: "layouts/user_avatar",      locals: { user: Current.user,           size: 7, classes: "mt-1" }
+    else
+      render partial: "layouts/assistant_avatar", locals: { assistant: message.assistant, size: 7, classes: "mt-1" }
+    end
+  end
+
+  def from_name_for(message)
+    case message.role
+      when "user" then "You"
+      when "assistant" then message.assistant.name
+      when "tool" then "Tool"
+    end
+  end
+
   def format_for_copying(text)
     text
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,24 +3,6 @@ import("blocks").then(() => {
   import("stimulus")
 })
 
-// Populate environment vars
-window.request = {
-  current_path: window.location.pathname,
-  referer_path: null
-}
-const getParams = () => { return Object.fromEntries(new URLSearchParams(window.location.search)) }
-window.params = getParams()
-
-document.addEventListener("turbo:visit", (event) => {
-  console.log('turbo:visit')
-  const new_path = URL.parse(event.detail.url).pathname
-  if (new_path != request.current_path) {
-    request.referer_path = request.current_path
-    request.current_path = new_path
-  }
-  window.params = getParams()
-})
-
 // Utilities for test environment
 window.imageLoadingForSystemTestsToCheck = {}
 window.logs = []

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,22 +1,34 @@
 import "@hotwired/turbo-rails"
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import("blocks").then(() => {
+  import("stimulus")
+})
 
+// Populate environment vars
+window.request = {
+  current_path: window.location.pathname,
+  referer_path: null
+}
+const getParams = () => { return Object.fromEntries(new URLSearchParams(window.location.search)) }
+window.params = getParams()
 
-// BEGIN debug code
-let oldTimestamp
+document.addEventListener("turbo:visit", (event) => {
+  console.log('turbo:visit')
+  const new_path = URL.parse(event.detail.url).pathname
+  if (new_path != request.current_path) {
+    request.referer_path = request.current_path
+    request.current_path = new_path
+  }
+  window.params = getParams()
+})
 
+// Utilities for test environment
+window.imageLoadingForSystemTestsToCheck = {}
+window.logs = []
+
+// Debug code
 // console.log('Document: refresh')
-// document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}`))
+// document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}, path = ${window.location.pathname} vs ${event.detail.url}`))
 // document.addEventListener('turbo:morph', () => console.log('Document: morph render'))
 // document.addEventListener('turbo:before-morph-element', (e) => { if (document.getElementById('composer').contains(e.target)) console.log('Document: before-morph', e.target) })
 // document.addEventListener('turbo:frame-render', () => console.log('Document: frame render'))
 // document.addEventListener('turbo:before-stream-render', (event) => console.log(`Document: stream render (${event.target.getAttribute('action')} event)`, event.target, event.detail.newStream.querySelector('template').content?.firstChild?.nextSibling?.querySelector('[data-speaker-target="text assistantText"]')))
-
-window.imageLoadingForSystemTestsToCheck = {}
-window.logs = []
-// END debug code
-
-
-import("blocks").then(() => {
-  import("stimulus")
-})

--- a/app/javascript/blocks/interfaces/listener_interface.js
+++ b/app/javascript/blocks/interfaces/listener_interface.js
@@ -24,7 +24,7 @@ export default class extends Interface {
                           log('Invoked')
                           $.processing = true
                           await $.screenService.start()
-                          await Flip.Transcriber.on() // TODO: with multiple streamed messages after dismissing, this did not Uncover the transcriber. Why??
+                          await Flip.Transcriber.on()
                         } else Uncover.Transcriber()
                       }
   async Dismiss()     { if ($.processing) {

--- a/app/javascript/blocks/interfaces/listener_interface.js
+++ b/app/javascript/blocks/interfaces/listener_interface.js
@@ -15,7 +15,7 @@ export default class extends Interface {
                           Uncover.Transcriber()
                           return
                         }
-
+                        log(`consideration = ${words}`)
                         $.consideration = words
                         $.attachment    = await _takeScreenshotIfNeeded(words)
                         _playThinkingSounds()
@@ -24,7 +24,7 @@ export default class extends Interface {
                           log('Invoked')
                           $.processing = true
                           await $.screenService.start()
-                          await Flip.Transcriber.on()
+                          await Flip.Transcriber.on() // TODO: with multiple streamed messages after dismissing, this did not Uncover the transcriber. Why??
                         } else Uncover.Transcriber()
                       }
   async Dismiss()     { if ($.processing) {

--- a/app/javascript/blocks/interfaces/listener_interface.js
+++ b/app/javascript/blocks/interfaces/listener_interface.js
@@ -20,15 +20,15 @@ export default class extends Interface {
                         $.attachment    = await _takeScreenshotIfNeeded(words)
                         _playThinkingSounds()
                       }
-  log_Invoke
   async Invoke()      { if (!$.processing) {
+                          log('Invoked')
                           $.processing = true
                           await $.screenService.start()
                           await Flip.Transcriber.on()
-                        }
+                        } else Uncover.Transcriber()
                       }
-  log_Dismiss
   async Dismiss()     { if ($.processing) {
+                          log('Dismissed')
                           $.processing = false
                           await Flip.Transcriber.on() // so it can wait for "wake" words
                           await Play.Speaker.sound('pip')
@@ -36,6 +36,7 @@ export default class extends Interface {
                       }
 
   async Disable()     { if ($.processing != null) {
+                          log('Disabled')
                           $.processing = null
                           await $.screenService.end()
                           await Flip.Transcriber.off()

--- a/app/javascript/blocks/interfaces/listener_interface.js
+++ b/app/javascript/blocks/interfaces/listener_interface.js
@@ -9,23 +9,16 @@ export default class extends Interface {
   logLevel_info
 
   log_Tell
-  async Tell(words)   { if (this.engaged && _intendedDismiss(words)) {
-                          await Dismiss.Listener()
+  async Tell(words)   { if (await _dismissIfNeeded(words)) return
+                        words = await _invokeIfNeeded(words)
+                        if (!$.processing) {
+                          Uncover.Transcriber()
                           return
                         }
-                        if (_intendedInvoke(words)) {
-                          await Invoke.Listener()
-                          words = _removeSpeechBeforeName(words)
-                        }
-                        if (!$.processing) return // Invoke() did not succeed
-
-                        if (_referencingTheScreen(words))
-                          $.attachment = await $.screenService.takeScreenshot()
-                        else
-                          $.attachment = null
 
                         $.consideration = words
-                        _startThinking()
+                        $.attachment    = await _takeScreenshotIfNeeded(words)
+                        _playThinkingSounds()
                       }
   log_Invoke
   async Invoke()      { if (!$.processing) {
@@ -64,24 +57,29 @@ export default class extends Interface {
     $.screenService = new ScreenService
   }
 
+  async _dismissIfNeeded(words) {
+    if (!engaged() || ! _intendedDismiss(words)) return false
+
+    await Dismiss.Listener()
+    Uncover.Transcriber()
+    return true
+  }
+
   _intendedDismiss(words) {
     return words.downcase().includeAny(["hold on", "hold up", "one sec", "one second", "stop", "on a call"]) &&
-           words.downcase().includeAny(["samantha"])
+      words.downcase().includeAny(["samantha"])
+  }
+
+  async _invokeIfNeeded(words) {
+    if (! _intendedInvoke(words)) return words
+
+    await Invoke.Listener()
+    return _removeSpeechBeforeName(words)
   }
 
   _intendedInvoke(words) {
     return words.downcase().includeAny(["samantha", "i'm back", "i am back", "i'm here"]) &&
-           words.downcase().includeAny(["samantha"]) //TODO; let's recognize these phrases without "samantha" and simply reply with "are you talking to me?"
-  }
-
-  _referencingTheScreen(words) {
-    return words.downcase().includeAny(["can you see", "you can see", "do you see", "look at", "this", "my screen", "the screen"])
-  }
-
-  _startThinking() {
-    Play.Speaker.sound('jeep', () => {
-      Loop.Speaker.every(4, 'thinking')
-    })
+      words.downcase().includeAny(["samantha"]) //TODO; let's recognize these phrases without "samantha" and simply reply with "are you talking to me?"
   }
 
   _removeSpeechBeforeName(words) {
@@ -89,5 +87,21 @@ export default class extends Interface {
       return words.slice(words.downcase().indexOf("samantha"))
     else
       return words
+  }
+
+  async _takeScreenshotIfNeeded(words) {
+    if (! _referencingTheScreen(words)) return null
+
+    return await $.screenService.takeScreenshot()
+  }
+
+  _referencingTheScreen(words) {
+    return words.downcase().includeAny(["can you see", "you can see", "do you see", "look at", "this", "my screen", "the screen"])
+  }
+
+  _playThinkingSounds() {
+    Play.Speaker.sound('jeep', () => {
+      Loop.Speaker.every(4, 'thinking')
+    })
   }
 }

--- a/app/javascript/blocks/interfaces/listener_interface.js
+++ b/app/javascript/blocks/interfaces/listener_interface.js
@@ -48,6 +48,7 @@ export default class extends Interface {
 
   get engaged()       { return $.processing === true  }
   get dismissed()     { return $.processing === false }
+  get enabled()       { return $.processing !== null }
   get disabled()      { return $.processing === null }
 
   get supported()     { return Transcriber.supported }

--- a/app/javascript/blocks/interfaces/speaker_interface.js
+++ b/app/javascript/blocks/interfaces/speaker_interface.js
@@ -2,6 +2,7 @@ import Interface from "../interface.js"
 
 export default class extends Interface {
   logLevel_info
+  attrAccessor_onBusyDone
 
   log_Prompt
   Prompt(sentence)          { $.audioService.speakNext(sentence) }
@@ -15,13 +16,18 @@ export default class extends Interface {
   new() {
     $.audioService = new AudioService
     $.audioService.onBusyChanged = (busy) => {
-      //log(`onbusyChanged(${busy})`)
-      if (busy) Cover.Transcriber()
-      if (!busy) {
+      if (busy) {
+        Cover.Transcriber()
+
+      } else if (!busy && !Listener.disabled) {
         Play.Speaker.sound('pop', () => {
           Loop.Speaker.every(8, 'typing1')
         })
         Invoke.Listener()
+        if ($.onBusyDone) $.onBusyDone()
+
+      } else if (!busy) {
+        if ($.onBusyDone) $.onBusyDone()
       }
     }
   }

--- a/app/javascript/blocks/interfaces/speaker_interface.js
+++ b/app/javascript/blocks/interfaces/speaker_interface.js
@@ -15,12 +15,13 @@ export default class extends Interface {
   new() {
     $.audioService = new AudioService
     $.audioService.onBusyChanged = (busy) => {
-      console.log(`onbusyChanged(${busy})`)
+      //log(`onbusyChanged(${busy})`)
+      if (busy) Cover.Transcriber()
       if (!busy) {
         Play.Speaker.sound('pop', () => {
           Loop.Speaker.every(8, 'typing1')
         })
-        Uncover.Transcriber()
+        Invoke.Listener()
       }
     }
   }

--- a/app/javascript/blocks/interfaces/speaker_interface.js
+++ b/app/javascript/blocks/interfaces/speaker_interface.js
@@ -4,7 +4,7 @@ export default class extends Interface {
   logLevel_info
 
   log_Prompt
-  Prompt(words)             { $.audioService.speakNext(words) }
+  Prompt(sentence)          { $.audioService.speakNext(sentence) }
   Reset()                   { $.audioService.stop() }
   async Play(sound, onEnd)  { await $.audioService.play(sound, onEnd) }
   Loop(sec, sound)          { $.audioService.playEvery(sec, sound) }

--- a/app/javascript/blocks/interfaces/speaker_interface.js
+++ b/app/javascript/blocks/interfaces/speaker_interface.js
@@ -16,10 +16,7 @@ export default class extends Interface {
     $.audioService = new AudioService
     $.audioService.onBusyChanged = (busy) => {
       console.log(`onbusyChanged(${busy})`)
-      if (busy)
-        Cover.Transcriber()
-      else
-        Uncover.Transcriber()
+      if (!busy) Uncover.Transcriber()
     }
   }
 }

--- a/app/javascript/blocks/interfaces/speaker_interface.js
+++ b/app/javascript/blocks/interfaces/speaker_interface.js
@@ -16,7 +16,12 @@ export default class extends Interface {
     $.audioService = new AudioService
     $.audioService.onBusyChanged = (busy) => {
       console.log(`onbusyChanged(${busy})`)
-      if (!busy) Uncover.Transcriber()
+      if (!busy) {
+        Play.Speaker.sound('pop', () => {
+          Loop.Speaker.every(8, 'typing1')
+        })
+        Uncover.Transcriber()
+      }
     }
   }
 }

--- a/app/javascript/blocks/interfaces/transcriber_interface.js
+++ b/app/javascript/blocks/interfaces/transcriber_interface.js
@@ -17,8 +17,7 @@ export default class extends Interface {
 
   async Flip(turnOn)    { if (turnOn && !$.active) {
                             $.active = true
-                            $.covered = false
-                            await $.transcriberService.start()
+                            Uncover.Transcriber()
                             await Invoke.Listener()
 
                           } else if (!turnOn && $.active) {
@@ -41,7 +40,10 @@ export default class extends Interface {
                           _shortWaitThenTell()
                         }
 
-  Cover()               { $.covered = true }
+  Cover()               { $.covered = true
+                          $.silenceService.stop()
+                        }
+
   Uncover()             { $.covered = false
                           $.transcriberService.restart()
                           _longWaitThenDismis()
@@ -65,7 +67,7 @@ export default class extends Interface {
                             if ($.silenceService.msOfSilence <= 1000) return
                             log('enough silence to start processing...')
 
-                            if (! $.covered) $.covered = true
+                            if (! $.covered) Cover.Transcriber()
                             Tell.Listener.to.consider($.words)
 
                             $.words = ''

--- a/app/javascript/blocks/interfaces/transcriber_interface.js
+++ b/app/javascript/blocks/interfaces/transcriber_interface.js
@@ -44,10 +44,7 @@ export default class extends Interface {
   Cover()               { $.covered = true }
   Uncover()             { $.covered = false
                           $.transcriberService.restart()
-                          Play.Speaker.sound('pop', () => {
-                            Loop.Speaker.every(8, 'typing1')
-                            _longWaitThenDismis()
-                          })
+                          _longWaitThenDismis()
                         }
 
   attr_words            = ''

--- a/app/javascript/blocks/interfaces/transcriber_interface.js
+++ b/app/javascript/blocks/interfaces/transcriber_interface.js
@@ -15,7 +15,10 @@ export default class extends Interface {
   logLevel_info
   attrReader_covered
 
-  async Flip(turnOn)    { if (turnOn && !$.active) {
+  async Flip(turnOn)    { if (turnOn && $.active) {
+                            Uncover.Transcriber()
+
+                          } else if (turnOn && !$.active) {
                             $.active = true
                             Uncover.Transcriber()
                             await Invoke.Listener()

--- a/app/javascript/blocks/lib/array.js
+++ b/app/javascript/blocks/lib/array.js
@@ -16,6 +16,9 @@ Array.prototype.include = function(...args) { return this.includes(...args) }
 Array.prototype.exclude = function(...args) { return !this.includes(...args) }
 Array.prototype.sum = function() { return this.reduce((acc, val) => acc + val, 0) }
 Array.prototype.select = function(...args) { return this.filter(...args) }
+Array.prototype.find = function (...args) { return this.filter(...args).first() }
+Array.prototype.each = Array.prototype.forEach
+Array.prototype.eachWithIndex = function (callback) { return this.forEach((item, index) => callback(item, index)) }
 Array.prototype.reject = function(callback) { return this.filter(e => !callback(e)) }
 Array.prototype.uniq = function() { return [...new Set(this)] }
 Array.prototype.collect = function(...args) { return this.map(...args) }

--- a/app/javascript/blocks/lib/array.js
+++ b/app/javascript/blocks/lib/array.js
@@ -22,3 +22,4 @@ Array.prototype.eachWithIndex = function (callback) { return this.forEach((item,
 Array.prototype.reject = function(callback) { return this.filter(e => !callback(e)) }
 Array.prototype.uniq = function() { return [...new Set(this)] }
 Array.prototype.collect = function(...args) { return this.map(...args) }
+Array.prototype.index = function (valueOrPredicate) { return (typeof valueOrPredicate === 'function') ? this.findIndex(valueOrPredicate) : this.indexOf(valueOrPredicate) }

--- a/app/javascript/blocks/readable_model.js
+++ b/app/javascript/blocks/readable_model.js
@@ -80,7 +80,7 @@ export default class {
         {
           const $ = this.attributes;
           ${this._callableMethodsExceptUppercase.map(func => 'const '+func+' = this.'+func+'.bind(this);').join("\n")}
-          ${this._getterMethods.map(func => 'const '+func+' = (v) => { return (typeof v == "undefined") ? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "'+func+'").get() : Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "'+func+'").set(v); };').join("\n")}
+          ${this._getterMethods.map(func => 'const ' + func + ' = (v) => { return (typeof v == "undefined") ? this.'+func+' : this.'+func+' = v };').join("\n")}
           this._methodLog('${func}', arguments, this.${func}.length);
 
           ${methodBody}
@@ -103,7 +103,7 @@ export default class {
           {
             const $ = this.attributes;
             ${this._callableMethodsExceptUppercase.map(func => 'const '+func+' = this.'+func+'.bind(this);').join("\n")}
-            ${this._getterMethods.map(func => 'const '+func+' = (v) => { return (typeof v == "undefined") ? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "'+func+'").get() : Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "'+func+'").set(v); };').join("\n")}
+            ${this._getterMethods.map(func => 'const '+func+' = (v) => { return (typeof v == "undefined") ? this.'+func+' : this.'+func+' = v };').join("\n")}
             this._methodLog('${func}', [], 0)
 
             ${methodBody}
@@ -125,7 +125,7 @@ export default class {
           {
             const $ = this.attributes;
             ${this._callableMethodsExceptUppercase.map(func => 'const '+func+' = this.'+func+'.bind(this);').join("\n")}
-            ${this._getterMethods.map(func => 'const '+func+' = (v) => { return (typeof v == "undefined") ? Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "'+func+'").get() : Object.getOwnPropertyDescriptor(Object.getPrototypeOf(this), "'+func+'").set(v); };').join("\n")}
+            ${this._getterMethods.map(func => 'const ' + func + ' = (v) => { return (typeof v == "undefined") ? this.'+func+' : this.'+func+' = v };').join("\n")}
             this._methodLog('${func}', [${arg}], 1);
 
             ${methodBody}

--- a/app/javascript/blocks/services/audio_service.js
+++ b/app/javascript/blocks/services/audio_service.js
@@ -66,6 +66,7 @@ export default class extends Service {
       $.playerSource.stop()
     }
     _resetQueue()
+    $.speaking = false
     $.playing = false
     $.busy = false
   }
@@ -125,7 +126,7 @@ export default class extends Service {
         return
       } else {
         await sleep(0.25)
-        _speakingLoop()
+        _speakingLoop('waiting')
         return
       }
     } else if (!$.speaking) _doneSpeaking()

--- a/app/javascript/blocks/services/audio_service.js
+++ b/app/javascript/blocks/services/audio_service.js
@@ -108,7 +108,7 @@ export default class extends Service {
     const jobsToPlay = $.queue.all.filter((job) => !job.spoken)
     if (trigger) {
       log(`speakingLoop with ${jobsToPlay.length} jobs remaining - "${trigger}" finished & speaking = ${$.speaking} & playing = ${$.playing}`, 'debug')
-      jobsToPlay.forEach((job) => log(`  job #${job.index}: ${job.generated ? 'generated' : 'not generated'} : ${job.spoken ? 'spoken' : 'not spoken'} : ${job.errored ? 'errored' : 'no error'} : ${job.words}...`), 'debug')
+      jobsToPlay.forEach((job) => log(`  job #${job.index}: ${job.generated ? 'generated' : 'not generated'} : ${job.spoken ? 'spoken' : 'not spoken'} : ${job.errored ? 'errored' : 'no error'} : ${job.words}...`, 'debug'))
     }
 
     if (jobsToPlay.length > 0) {
@@ -159,7 +159,6 @@ export default class extends Service {
   }
 
   _resetQueue() {
-    log('resetting queue')
     $.queue.reset()
     $.queue = new QueueService()
   }

--- a/app/javascript/blocks/services/silence_service.js
+++ b/app/javascript/blocks/services/silence_service.js
@@ -1,7 +1,7 @@
 ﻿import Service from "../service.js"
 
 export default class extends Service {
-  logLevel_debug
+  logLevel_info
   attr_msOfSilence
 
   new() {
@@ -10,11 +10,10 @@ export default class extends Service {
 
   restartCounter() {
     $.msOfSilence = 0
-    if (!$.poller?.handler) $.poller = runEvery(0.2, () => {$.msOfSilence += 200})
+    if (!$.poller?.handler) $.poller = runEvery(0.2, () => { $.msOfSilence += 200 })
   }
 
-  _timerEnd() {
+  stop() {
     $.poller?.end()
-    restartCounter()
   }
 }

--- a/app/javascript/blocks/services/silence_service.js
+++ b/app/javascript/blocks/services/silence_service.js
@@ -4,10 +4,6 @@ export default class extends Service {
   logLevel_info
   attr_msOfSilence
 
-  new() {
-    restartCounter()
-  }
-
   restartCounter() {
     $.msOfSilence = 0
     if (!$.poller?.handler) $.poller = runEvery(0.2, () => { $.msOfSilence += 200 })

--- a/app/javascript/blocks/services/speech_service.js
+++ b/app/javascript/blocks/services/speech_service.js
@@ -56,6 +56,6 @@ export default class extends Service {
     if (!text) return []
     text = text.replace(". . .", "...")
     const thoughts = text.split(/(?<=[^ ][\.:!\?;…] |[\n，。．！？；：])/)
-    return thoughts.reject(t => t.strip().empty())
+    return thoughts.reject(t => t.strip().empty()).map(t => t.replace(/''/g, "'"))
   }
 }

--- a/app/javascript/blocks/services/transcriber_service.js
+++ b/app/javascript/blocks/services/transcriber_service.js
@@ -32,7 +32,7 @@ export default class extends Service {
   }
 
   async start()   { $.intendedState = 'started';  return await _executeStart() }
-  restart()       { $.intendedState = 'started';  _executeRestart() }
+  async restart() { $.intendedState = 'started';  return await _executeRestart() }
   end()           { $.intendedState = 'ended';    _executeEnd() }
   get listening()  { $.state == 'started' }
   get ended()      { $.state == 'ended' }
@@ -72,6 +72,8 @@ export default class extends Service {
 
     if ($.state == 'started')
       _executeEnd() // will eventually trigger _onStart() b/c of intendedState
+    else if ($.state == 'ended')
+      _executeStart()
     else
       _onStart()
   }

--- a/app/javascript/blocks/services/transcriber_service.js
+++ b/app/javascript/blocks/services/transcriber_service.js
@@ -2,7 +2,6 @@ import Service from "../service.js"
 
 export default class extends Service {
   logLevel_info
-  attrAccessor_onTextReceived
   attrReader_listening
 
   new() {
@@ -120,6 +119,6 @@ export default class extends Service {
 
     if (transcript.length <= 1) return
 
-    $.onTextReceived(transcript)
+    SpeakTo.Transcriber.with.words(transcript)
   }
 }

--- a/app/javascript/stimulus/composer_controller.js
+++ b/app/javascript/stimulus/composer_controller.js
@@ -4,6 +4,7 @@ import viewport from "stimulus/utils/viewport"
 export default class extends Controller {
   static targets = [ "form", "input", "submit", "overlay", "cancel",
     "disabledSubmit", "microphoneEnable", "microphoneDisable" ]
+  static outlets = [ "speaker" ]
 
   get cleanInputValue() {
     return this.inputTarget.value.trim()
@@ -100,6 +101,7 @@ export default class extends Controller {
     if (Listener.disabled) {
       await Invoke.Listener()
       Play.Speaker.sound("pop")
+      this.speakerOutlet.start()
     }
   }
 
@@ -108,11 +110,16 @@ export default class extends Controller {
     Dismiss.Listener()
   }
 
-  disableMicrophone() {
+  userDisableMicrophone() {
+    this.userDisableMicrophone(true)
+  }
+
+  disableMicrophone(userClicked = false) {
     this.microphoneEnableTarget.classList.remove('hidden')
     this.microphoneDisableTarget.classList.add('hidden')
     this.enableComposer()
     Disable.Listener()
+    if (userClicked) this.speakerOutlet?.stop()
     this.determineSubmitButton()
   }
 

--- a/app/javascript/stimulus/composer_controller.js
+++ b/app/javascript/stimulus/composer_controller.js
@@ -111,7 +111,7 @@ export default class extends Controller {
   }
 
   userDisableMicrophone() {
-    this.userDisableMicrophone(true)
+    this.disableMicrophone(true)
   }
 
   disableMicrophone(userClicked = false) {

--- a/app/javascript/stimulus/permanent_value_controller.js
+++ b/app/javascript/stimulus/permanent_value_controller.js
@@ -2,7 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    console.log('## connecting...')
     this.element.addEventListener('turbo:before-morph-element', this.boundSaveValue)
     this.element.addEventListener('turbo:morph-element', this.boundRestoreValue)
     this.savedValue = null

--- a/app/javascript/stimulus/playback_controller.js
+++ b/app/javascript/stimulus/playback_controller.js
@@ -1,86 +1,77 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = {index: Number, sentencesIndex: Number, speakerActive: Boolean }
+  static values = { index: Number, sentencesIndex: Number }
+  static targets = [ "assistantText" ]
 
   connect() {
-    console.log(`playback connected for message ${this.indexValue} and it's initially active = ${this.speakerActiveValue}`)
+    console.log(`playback connected for message ${this.indexValue}`, this.element)
   }
 
-  speakerActiveValueChanged() {
-    if (!this.speaker) return
+  // speakerActiveValueChanged() {
+  //   if (!this.speaker) return
 
-    if (this.speakerActiveValue) {
-      console.log(`active value for ${this.indexValue} is now ${this.speakerActiveValue}`)
-      this.speaker.playbackIndexValue = this.indexValue
+  //   if (this.speakerActiveValue)
+  //     this.startSpeakingMessage()
+  //   else
+  //     this.stopSpeakingMessage()
+  // }
+
+  startSpeakingMessage() {
+    console.log('startSpeakingMessage()')
+    this.speaker.playbackIndexValue = this.indexValue
+
+    this.observer = new MutationObserver(() => this.speakMessage('mutation'))
+    this.observer.observe(this.assistantTextTarget, {
+      characterData: true,
+      childList: true,
+      subtree: true,
+      attributes: true
+    })
+
+    window.debug = this.assistantTextTarget
+    this.speakMessage('initial')
+  }
+
+  stopSpeakingMessage() {
+    console.log('stopSpeakingMessage()')
+    this.observer?.disconnect()
+  }
+
+  // speak() {
+  //   console.log(`speak()`)
+  //   Prompt.Speaker.toSay("I am testing this feature")
+  // }
+
+  speakMessage(src = '') {
+    console.log(`speakMessage(${Listener.disabled}) ${src} :: ${this.indexValue} = ${this.assistantTextTarget.innerText}`)
+    if (Listener.disabled) return
+    const sentences = SpeechService.splitIntoThoughts(this.assistantTextTarget.innerText)
+    if (sentences.length == 0) return
+
+    console.log(`processing message ${this.indexValue}...`, sentences)
+    const thinkingDone = this.assistantTextTarget.getAttribute('data-thinking') === 'false'
+    const toSentenceIndex = thinkingDone ? sentences.length : sentences.length - 1
+
+    console.log(`speaking from ${this.sentencesIndexValue} to ${toSentenceIndex} (done? ${thinkingDone})`)
+    this.speakSentencesFromTo(sentences, this.sentencesIndexValue, toSentenceIndex)
+    this.sentencesIndexValue = toSentenceIndex + 1
+
+    if (thinkingDone) done()
+  }
+
+  speakSentencesFromTo(sentences, fromIndex, toIndex) {
+    toIndex = Math.max(toIndex, 0)
+    if (fromIndex >= toIndex) return
+    for (let i = fromIndex; fromIndex <= toIndex; i ++) {
+      if (!sentences[i]) break
+      if (sentences[i].includes('::ServerError') || sentences[i].includes('Faraday::')) break  // client is displaying a server error
+      Prompt.Speaker.toSay(sentences[i])
     }
   }
 
-  // static targets = [ "assistantText" ]
-
-  // get newlyCreatedConversation() {
-  //   return params.from == "create" &&
-  //     new RegExp(`^/assistants/\\d+/messages/new`).test(request.referer_path)
-  // }
-
-  // connect() {
-  //   window.debug = this
-  //   this.sentencesIndex = 0
-  //   this.messagesIndex = this.assistantTextTargets.length
-
-  //   document.addEventListener('turbo:visit', this.boundInit) // turbo visit is firing again when messagers stream in, need to make sure this ONLY fires once on initial page load
-  //   document.addEventListener('turbo:morph', this.boundSpeakMessages)
-  //   document.addEventListener('turbo:before-stream-render', this.boundSpeakMessages)
-
-  //   this.init()
-  // }
-
-  // boundInit = () => { this.init() }
-  // init() {
-  //   console.log('init()')
-
-  //   if (this.newlyCreatedConversation) {
-  //     console.log('subtracting 1')
-  //     this.messagesIndex = this.assistantTextTargets.length - 1
-  //   }
-
-  //   this.speakMessages()
-  // }
-
-  // disconnect() {
-  //   document.removeEventListener('turbo:visit', this.boundInit)
-  //   document.removeEventListener('turbo:morph', this.boundSpeakMessages)
-  //   document.removeEventListener('turbo:before-stream-render', this.boundSpeakMessages)
-  // }
-
-  // boundSpeakMessages = () => { this.speakMessages() }
-  // speakMessages() {
-  //   console.log(`speakMessages() :: ${this.messagesIndex} of ${this.assistantTextTargets.length}`)
-  //   let message, sentences, messageDone, toSentenceIndex
-  //   if (Listener.disabled) return
-
-  //   for (this.messagesIndex; this.messagesIndex < this.assistantTextTargets.length; this.messagesIndex ++) {
-  //     message = this.assistantTextTargets[this.messagesIndex]
-
-  //     sentences = SpeechService.splitIntoThoughts(message.innerText)
-  //     if (sentences.length == 0) continue
-  //     console.log(`processing message ${this.messagesIndex}...`, sentences)
-  //     messageDone = message.getAttribute('data-thinking') === 'false'
-  //     toSentenceIndex = messageDone ? sentences.length : sentences.length-1
-  //     if (toSentenceIndex < 0) toSentenceIndex = 0
-
-  //     console.log(`speaking from ${this.sentencesIndex} to ${toSentenceIndex} (done? ${messageDone})`)
-  //     this.speakSentencesFromTo(sentences, this.sentencesIndex, toSentenceIndex)
-  //     this.sentenceIndex = messageDone ? 0 : toSentenceIndex+1
-  //   }
-  //   if (!messageDone) this.messagesIndex -= 1 // we need to check this message again
-  // }
-
-  // speakSentencesFromTo(sentences, fromIndex, toIndex) {
-  //   for (let i = fromIndex; fromIndex <= toIndex; i ++) {
-  //     if (!sentences[i]) break
-  //     if (sentences[i].includes('::ServerError') || sentences[i].includes('Faraday::')) break  // client is displaying a server error
-  //     Prompt.Speaker.toSay(sentences[i])
-  //   }
-  // }
+  done() {
+    this.speakerActiveValue = false
+    this.speaker?.advancePlayback()
+  }
 }

--- a/app/javascript/stimulus/playback_controller.js
+++ b/app/javascript/stimulus/playback_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { index: Number, sentencesIndex: Number }
+  static values = { id: Number, sentencesIndex: Number }
   static targets = [ "assistantText" ]
   static outlets = [ "transition" ]
 
@@ -26,8 +26,6 @@ export default class extends Controller {
   }
 
   startSpeakingMessage() {
-    this.speaker.playbackIndexValue = this.indexValue
-
     this.observer = new MutationObserver((mutations) => {
       if (mutations.some(mutation => mutation.target == this.element)) {
         console.log('mutation', mutations)
@@ -48,12 +46,12 @@ export default class extends Controller {
   }
 
   messageTextUpdated(src = '') {
-    //console.log(`${this.indexValue}: messageTextUpdated(${src}) ${Listener.enabled ? 'enabled' : 'disabled'} :: from ${this.sentencesIndexValue} to ... (${this.assistantTextTarget.textContent})`)
+    //console.log(`${this.idValue}: messageTextUpdated(${src}) ${Listener.enabled ? 'enabled' : 'disabled'} :: from ${this.sentencesIndexValue} to ... (${this.assistantTextTarget.textContent})`)
     if (Listener.disabled && !this.manualSpeaking) return
     const sentences = SpeechService.splitIntoThoughts(this.assistantTextTarget.textContent)
     if (sentences.length == 0) return
 
-    //console.log(`processing message ${this.indexValue}...`, sentences)
+    //console.log(`processing message ${this.idValue}...`, sentences)
     const thinkingDone = this.assistantTextTarget.getAttribute('data-thinking') === 'false'
     const toSentenceIndex = thinkingDone ? sentences.length-1 : sentences.length-2
 

--- a/app/javascript/stimulus/playback_controller.js
+++ b/app/javascript/stimulus/playback_controller.js
@@ -1,39 +1,19 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { playbackIndex: { type: Number, default: undefined } }
-  static outlets = [ "playback" ]
+  static values = {index: Number, sentencesIndex: Number, speakerActive: Boolean }
 
   connect() {
-    console.log(`speaker connected with index initially ${this.playbackIndexValue}`)
-  }
-  // initialize() {
-  //   this.playbackIndexValue = this.activePlaybackOutlets?.indexValue
-  // }
-
-  stop() {
-    this.playbackIndexValue = undefined
-    this.setActivePlaybackIndex(undefined)
+    console.log(`playback connected for message ${this.indexValue} and it's initially active = ${this.speakerActiveValue}`)
   }
 
-  playbackIndexValueChanged() {
-    if (!this.playbackIndexValue) return // we want to ignore it's default value state
-    console.log(`playback index value changed to ${this.playbackIndexValue}`)
-    if (this.hasPlaybackOutlet) runAfter(0, () => { // runAfter 0 simply pushes this to the end of the callback chain to solve a race
-      this.setActivePlaybackIndex(this.playbackIndexValue)
-    }, 0)
-  }
+  speakerActiveValueChanged() {
+    if (!this.speaker) return
 
-  setActivePlaybackIndex(index) {
-    this.playbackOutlets.each(playback => {
-      const active = playback.indexValue == index
-      if (active != playback.speakerActiveValue) playback.speakerActiveValue = active
-    })
-  }
-
-  playbackOutletConnected(playback) {
-    playback.speaker = this   // so playback instances can call into auto-speaker
-    playback.speakerActiveValueChanged() // runs on init, but may have failed w/o speaker so re-do it
+    if (this.speakerActiveValue) {
+      console.log(`active value for ${this.indexValue} is now ${this.speakerActiveValue}`)
+      this.speaker.playbackIndexValue = this.indexValue
+    }
   }
 
   // static targets = [ "assistantText" ]

--- a/app/javascript/stimulus/playback_controller.js
+++ b/app/javascript/stimulus/playback_controller.js
@@ -18,15 +18,19 @@ export default class extends Controller {
   // }
 
   startSpeakingMessage() {
-    console.log('startSpeakingMessage()')
+    console.log(`startSpeakingMessage(${this.indexValue})`)
     this.speaker.playbackIndexValue = this.indexValue
 
-    this.observer = new MutationObserver(() => this.speakMessage('mutation'))
-    this.observer.observe(this.assistantTextTarget, {
+    this.observer = new MutationObserver((mutations) => {
+      if (mutations.some(mutation => mutation.target == this.element)) {
+        console.log('mutation', mutations)
+        this.speakMessage('mutation')
+      }
+    })
+    this.observer.observe(this.element, {
       characterData: true,
       childList: true,
-      subtree: true,
-      attributes: true
+      subtree: true
     })
 
     window.debug = this.assistantTextTarget
@@ -34,14 +38,9 @@ export default class extends Controller {
   }
 
   stopSpeakingMessage() {
-    console.log('stopSpeakingMessage()')
+    console.log(`stopSpeakingMessage(${this.indexValue})`)
     this.observer?.disconnect()
   }
-
-  // speak() {
-  //   console.log(`speak()`)
-  //   Prompt.Speaker.toSay("I am testing this feature")
-  // }
 
   speakMessage(src = '') {
     console.log(`speakMessage(${Listener.disabled}) ${src} :: ${this.indexValue} = ${this.assistantTextTarget.innerText}`)
@@ -57,7 +56,7 @@ export default class extends Controller {
     this.speakSentencesFromTo(sentences, this.sentencesIndexValue, toSentenceIndex)
     this.sentencesIndexValue = toSentenceIndex + 1
 
-    if (thinkingDone) done()
+    if (thinkingDone) this.done()
   }
 
   speakSentencesFromTo(sentences, fromIndex, toIndex) {
@@ -71,7 +70,11 @@ export default class extends Controller {
   }
 
   done() {
-    this.speakerActiveValue = false
+    console.log(`done() for ${this.indexValue}`)
     this.speaker?.advancePlayback()
+  }
+
+  preserveStimulusValues(e) {
+    if (e.target == this.element && e.detail.attributeName == "data-playback-sentences-index-value") e.preventDefault()
   }
 }

--- a/app/javascript/stimulus/speaker_controller.js
+++ b/app/javascript/stimulus/speaker_controller.js
@@ -20,8 +20,9 @@ export default class extends Controller {
   }
 
   playbackIndexValueChanged() {
+    console.log(`## playbackIndex = ${this.playbackIndexValue}`)
     if (this.suppressCallback) { this.suppressCallback = false; return }
-    console.log(`playback index value changed to ${this.playbackIndexValue}`)
+    //console.log(`playback index value changed to ${this.playbackIndexValue}`)
     if (!this.playbackIndexValue) return // we want to ignore it's default value state
     if (this.hasPlaybackOutlet) runAfter(0, () => { // runAfter 0 simply pushes this to the end of the callback chain to solve a race
       this.startThePlayback(this.playbackIndexValue, 'playbackIndexValueChanged')
@@ -29,7 +30,7 @@ export default class extends Controller {
   }
 
   startThePlayback(index, from = null) {
-    console.log(`startThePlayback(${index}) from ${from}`)
+    //console.log(`startThePlayback(${index}) from ${from}`)
     runAfter(0, () => this.playbackOutlets.each(playback => {
       const active = playback.indexValue == index
       //console.log(`${playback.indexValue}: active = ${active}`)
@@ -41,10 +42,10 @@ export default class extends Controller {
   }
 
   playbackOutletConnected(playback) {
-    console.log(`playbackOutletConnected ${playback.indexValue} with Listener enabled? ${Listener.enabled}`)
+    //console.log(`playbackOutletConnected ${playback.indexValue} with Listener enabled? ${Listener.enabled}`)
     playback.speaker = this // so playback instances can call into auto-speaker
     if (Listener.disabled) // these connections are happening on initial page load
-      this.setPlaybackIndexLast()
+      runAfter(0, () => this.setPlaybackIndexLast())
     else
       runAfter(0, () => this.startThePlayback(this.playbackIndexValue, 'connected'))
   }
@@ -58,7 +59,7 @@ export default class extends Controller {
     const lastValue = this.hasPlaybackOutlet ? this.playbackOutlets.last().indexValue : 0
 
     if (!this.playbackIndexValue || lastValue > this.playbackIndexValue) this.playbackIndexValue = lastValue
-    console.log(`set index value to ${this.playbackIndexValue}`)
+    //console.log(`set index value to ${this.playbackIndexValue}`)
   }
 
   preserveStimulusValues(e) {

--- a/app/javascript/stimulus/speaker_controller.js
+++ b/app/javascript/stimulus/speaker_controller.js
@@ -1,39 +1,37 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static values = { playbackIndex: { type: Number, default: undefined } }
+  static values = { playedbackId: { type: Number, default: undefined } }
   static outlets = [ "playback" ]
 
   connect() {
-    console.log(`speaker connected with index initially ${this.playbackIndexValue}`)
-    if (Listener.enabled) this.setPlaybackIndexLast('suppressCallback') // navigated from messages/new to conversation/#/messages
+    console.log(`speaker connected with index initially ${this.playedbackIdValue}`)
+    //if (Listener.enabled) this.setPlayedToLast() // 'suppressCallback') // navigated from messages/new to conversation/#/messages
   }
 
   start() {
     console.log('speaker start()')
-    this.setPlaybackIndexLast()
+    this.setPlayedToLast('start')
   }
 
   stop() {
-    console.log('speaker stop()')
-    this.playbackIndexValue = undefined
+    console.log('speaker stop()') // TODO: when is this called?
   }
 
-  playbackIndexValueChanged() {
-    console.log(`## playbackIndex = ${this.playbackIndexValue}`)
-    if (this.suppressCallback) { this.suppressCallback = false; return }
-    //console.log(`playback index value changed to ${this.playbackIndexValue}`)
-    if (!this.playbackIndexValue) return // we want to ignore it's default value state
+  playedbackIdValueChanged() {
+    console.log(`## playedbackIdValue = ${this.playedbackIdValue}`)
+    //if (this.suppressCallback) { this.suppressCallback = false; return }
+    if (!this.playedbackIdValue) return // we want to ignore it's default value state
     if (this.hasPlaybackOutlet) runAfter(0, () => { // runAfter 0 simply pushes this to the end of the callback chain to solve a race
-      this.startThePlayback(this.playbackIndexValue, 'playbackIndexValueChanged')
+      this.continuePlayback('playbackIndexValueChanged')
     }, 0)
   }
 
-  startThePlayback(index, from = null) {
-    //console.log(`startThePlayback(${index}) from ${from}`)
+  continuePlayback(src = null) {
+    //console.log(`continuePlayback(${index}) from ${src}`)
     runAfter(0, () => this.playbackOutlets.each(playback => {
-      const active = playback.indexValue == index
-      //console.log(`${playback.indexValue}: active = ${active}`)
+      const active = playback.idValue == this._nextPlaybackId()
+      //console.log(`${playback.idValue}: active = ${active}`)
       if (active)
         playback.startSpeakingMessage()
       else
@@ -42,27 +40,37 @@ export default class extends Controller {
   }
 
   playbackOutletConnected(playback) {
-    //console.log(`playbackOutletConnected ${playback.indexValue} with Listener enabled? ${Listener.enabled}`)
+    //console.log(`playbackOutletConnected ${playback.idValue} with Listener enabled? ${Listener.enabled}`)
     playback.speaker = this // so playback instances can call into auto-speaker
     if (Listener.disabled) // these connections are happening on initial page load
-      runAfter(0, () => this.setPlaybackIndexLast())
+      runAfter(0, () => this.setPlayedToLast('outlet connected'))
     else
-      runAfter(0, () => this.startThePlayback(this.playbackIndexValue, 'connected'))
+      runAfter(0, () => this.continuePlayback('outlet connected'))
   }
 
   advancePlayback() {
-    this.setPlaybackIndexLast()
+    this.setPlayedToLast('advance')
   }
 
-  setPlaybackIndexLast(suppressCallback = false) {
-    this.suppressCallback = suppressCallback
-    const lastValue = this.hasPlaybackOutlet ? this.playbackOutlets.last().indexValue : 0
+  setPlayedToLast(src = null) {
+    //this.suppressCallback = suppressCallback
 
-    if (!this.playbackIndexValue || lastValue > this.playbackIndexValue) this.playbackIndexValue = lastValue
-    //console.log(`set index value to ${this.playbackIndexValue}`)
+    const lastValue = this.hasPlaybackOutlet ? this.playbackOutlets.last().idValue : 0
+
+    if (lastValue && (!this.playedbackIdValue || lastValue > this.playedbackIdValue))
+      this.playedbackIdValue = lastValue
+
+    console.log(`set playedbackIdValue to ${this.playedbackIdValue} (${src})`)
   }
 
   preserveStimulusValues(e) {
-    if (e.target == this.element && e.detail.attributeName == "data-speaker-playback-index-value") e.preventDefault()
+    if (e.target == this.element && e.detail.attributeName == "data-speaker-playedback-id-value") e.preventDefault()
+  }
+
+  _nextPlaybackId() {
+    if (!this.hasPlaybackOutlet) return undefined
+
+    const curIndex = this.playbackOutlets.index(playback => playback.idValue == this.playedbackIdValue)
+    return this.playbackOutlets[curIndex+1]?.idValue
   }
 }

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -27,7 +27,7 @@ class GetNextAIMessageJob < ApplicationJob
 
     last_sent_at = Time.current
     @message.update!(processed_at: Time.current, content_text: "")
-    GetNextAIMessageJob.broadcast_updated_message(@message, thinking: true) # signal to user that we're waiting on API
+    GetNextAIMessageJob.broadcast_updated_message(@message, thinking: true) # thinking shows dot, signaling to user that we're waiting now on ai_backend
 
     puts "\n### Wait for reply" unless Rails.env.test?
 

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -1,3 +1,6 @@
+include ActionView::RecordIdentifier
+require "nokogiri/xml/node"
+
 class GetNextAIMessageJob < ApplicationJob
   include ActionView::Helpers::RenderingHelper
   class ResponseCancelled < StandardError; end
@@ -121,10 +124,9 @@ class GetNextAIMessageJob < ApplicationJob
         message_counter: message.index
       }.merge(locals)
     )
-    target = "message-contents-#{message.id}"
     dom = Nokogiri::HTML.fragment(html)
-    html = dom.at_css("#"+target).inner_html
-    message.broadcast_update_to message.conversation, target: target, html: html
+    html = dom.at_id(dom_id message).inner_html
+    message.broadcast_update_to message.conversation, target: message, html: html
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -26,7 +26,8 @@ class Message < ApplicationRecord
 
   scope :ordered, -> { latest_version_for_conversation }
 
-  def name
+  def name_for_api
+    # TODO: We should sanitize name within the database since we don't need to support crazy characters
     case role
     when "user" then user.first_name[/\A[a-zA-Z0-9_-]+/]
     when "assistant" then assistant.name[/\A[a-zA-Z0-9_-]+/]

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -95,13 +95,13 @@ class AIBackend::OpenAI < AIBackend
 
         {
           role: message.role,
-          name: message.name,
+          name: message.name_for_api,
           content: content_with_images,
         }.compact
       else
         {
           role: message.role,
-          name: message.name,
+          name: message.name_for_api,
           content: message.content_text,
           tool_calls: message.content_tool_calls, # only for some assistant messages
           tool_call_id: message.tool_call_id,     # only for tool messages

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -140,6 +140,7 @@
           w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px]
         "
         data-controller="composer image-upload"
+        data-composer-speaker-outlet="[data-controller~='speaker']"
       >
         <%= button_tag type: "button",
               id: "attach-button",
@@ -305,7 +306,7 @@
             <%= form.button type: "button",
               data: {
                 composer_target: "microphoneDisable",
-                action: "composer#disableMicrophone"
+                action: "composer#userDisableMicrophone"
               },
               id: "microphone-disable",
               class: %w|
@@ -399,7 +400,7 @@
           <div
             id="composer-overlay"
             data-composer-target="overlay"
-            data-action="click->composer#disableMicrophone"
+            data-action="click->composer#userDisableMicrophone"
             class="absolute inset-0 bg-white dark:bg-gray-800 !bg-opacity-65 hidden">
           </div>
 

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -104,6 +104,7 @@
   <section
     class="flex flex-col flex-grow overflow-y-auto bg-white dark:bg-gray-800 overflow-x-clip scrollbar-hide"
     data-controller="scrollable speaker"
+    data-speaker-playback-outlet="[data-role='assistant-message']"
     data-scrollable-not-bottom-class="!block"
   >
     <div id="messages" class="relative flex-grow overflow-y-auto overflow-x-clip scrollbar-hide overscroll-contain" data-scrollable-target="scrollable" data-action="scroll->scrollable#scrolled">

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -104,7 +104,8 @@
   <section
     class="flex flex-col flex-grow overflow-y-auto bg-white dark:bg-gray-800 overflow-x-clip scrollbar-hide"
     data-controller="scrollable speaker"
-    data-speaker-playback-outlet="[data-role='assistant-message']"
+    data-action="turbo:before-morph-attribute->speaker#preserveStimulusValues"
+    data-speaker-playback-outlet="[data-subrole='assistant-message']"
     data-scrollable-not-bottom-class="!block"
   >
     <div id="messages" class="relative flex-grow overflow-y-auto overflow-x-clip scrollbar-hide overscroll-contain" data-scrollable-target="scrollable" data-action="scroll->scrollable#scrolled">

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -25,6 +25,7 @@ end %>
   data-playback-index-value="<%= message_counter %>"
   data-playback-sentences-index-value="0"
   data-playback-done-prompting-value="false"
+  data-playback-transition-outlet="[data-subrole='playback-control-<%= message.id %>']"
   data-action="turbo:before-morph-attribute->playback#preserveStimulusValues"
 >
   <!-- Left Column -->
@@ -192,14 +193,15 @@ end %>
             class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
             data: {
               role: "playback",
+              subrole: "playback-control-#{message.id}",
+              controller: "transition",
+              transition_toggle_class: "hidden",
               action: %|
-                playback#speak
-                transition#toggleClassOn
+                playback#toggleSpeakingMessage
               |,
-              # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
           } do %>
-            <%= icon "speaker-wave", variant: :outline, size: 18, title: "Read aloud", data: { transition_target: "transitionable" } %>
-            <%= icon "stop-circle", variant: :outline, size: 18, title: "Stop", data: { transition_target: "transitionable" }, class: "hidden" %>
+            <%= icon "speaker-wave", variant: :outline, size: 19, title: "Read aloud #{message_counter}", data: { transition_target: "transitionable" } %>
+            <%= icon "stop-circle", variant: :outline, size: 19, title: "Stop", data: { transition_target: "transitionable" }, class: "hidden" %>
           <% end %>
           <%= button_tag type: "button",
                 class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -22,7 +22,7 @@ end %>
   class="flex mb-5 ml-9 sm:ml-3 md:ml-8 group flex <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
   data-controller="<%= message.assistant? && "playback" %>"
 
-  data-playback-index-value="<%= message_counter %>"
+  data-playback-id-value="<%= message.id %>"
   data-playback-sentences-index-value="0"
   data-playback-done-prompting-value="false"
   data-playback-transition-outlet="[data-subrole='playback-control-<%= message.id %>']"

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (message:, request_id: nil, scroll_down: false, only_scroll_down_if_was_bottom: false, timestamp: nil, thinking: nil, streamed: false, message_counter: -1) -%>
+<%# locals: (message:, request_id: nil, scroll_down: false, only_scroll_down_if_was_bottom: false, thinking: nil, streamed: false, message_counter: -1) -%>
 <%# request_id is not used, but broadcasting turbo stream messages provides it as a local so it needs to be accepted %>
 
 <% conversation = message.conversation %>
@@ -13,269 +13,279 @@ end %>
 <% scroll_down = scroll_down || initial_page_load %>
 <% thinking ||= last_message && message.content_text == "" && message.not_cancelled? %>
 <% done_thinking = !thinking && message.content_text.present? %>
-<% autoplay = last_message && @last_message_playback_active %>
 <% debug_tool_messages = false %>
 
 <div
   id="<%= dom_id message %>"
   data-role="message"
-  class="mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
-  data-timestamp="<%= timestamp %>"
-  data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
-  data-message-scroller-scroll-down-value="<%= scroll_down %>"
-  data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
-  data-message-scroller-instantly-value="<%= initial_page_load %>"
+  data-subrole="<%= message.role %>-message"
+  class="flex mb-5 ml-9 sm:ml-3 md:ml-8 group flex <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
+  data-controller="<%= message.assistant? && "playback" %>"
+
+  data-playback-index-value="<%= message_counter %>"
+  data-playback-sentences-index-value="0"
+  data-playback-done-prompting-value="false"
 >
+  <!-- Left Column -->
+  <div class="w-6 ml-1 flex">
+    <%= render_avatar_for(message) %>
+  </div>
+
+  <!-- Right Column -->
   <div
-    data-role="<%= message.role %>-message"
-    data-controller="<%= message.assistant? && "playback" %>"
-    data-playback-index-value="<%= message_counter %>"
-    data-playback-sentences-index-value="0"
-    data-playback-speaker-active-value="<%= !!autoplay %>"
-    class="flex"
+    id="message-contents-<%= message.id %>"
+    class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
+    data-controller="
+      clipboard
+      transition
+      <%= message.has_document_image? && "modal" %>
+      <%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>
+    "
+    data-transition-toggle-class="hidden"
+
+    data-message-scroller-scroll-down-value="<%= scroll_down %>"
+    data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
+    data-message-scroller-instantly-value="<%= initial_page_load %>"
   >
-    <!-- Left Column -->
-    <div class="w-6 ml-1 flex">
-      <%= render_avatar_for(message) %>
+    <div class="mt-[6px] mb-1 font-semibold" data-role="from">
+      <%= from_name_for(message) %>
     </div>
 
-    <!-- Right Column -->
-    <div
-      data-controller="
-        clipboard
-        transition
-        <%= message.has_document_image? && "modal" %>
-      "
-      data-transition-toggle-class="hidden"
-      class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
-    >
-      <div class="mt-[6px] mb-1 font-semibold" data-role="from">
-        <%= from_name_for(message) %>
+    <turbo-frame id="message-text-<%= message.id %>">
+      <div
+        class="hidden"
+        data-clipboard-target="text"
+      ><%= format_for_copying message.content_text %></div>
+      <div
+        class="hidden"
+        data-playback-target="<%= message.assistant? && "assistantText" %>"
+        data-thinking="<%= !!thinking %>"
+      ><%= format_for_speaking message.content_text %></div>
+
+      <div
+        data-role="content-text"
+        class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
+      >
+        <% if message.has_document_image? %>
+          <%= button_tag type: "button",
+                class: "w-full h-auto flex focus:outline-none",
+                data: {
+                  controller: "image-loader",
+                  image_loader_message_scroller_outlet: "[data-role='message']",
+                  image_loader_url_value: message.document_image_path(:small),
+                  action: "modal#open",
+                  role: "image-preview",
+                } do
+          %>
+            <%= image_tag message.document_image_path(:small, fallback: ""),
+                  data: {
+                    image_loader_target: "image",
+                    action: %|
+                      error->image-loader#retryAfterDelay
+                      load->image-loader#show
+                    |
+                  },
+                  class: %|
+                    my-0
+                    mx-auto
+                    max-w-full
+                    border-2 border-gray-100 dark:border-gray-400
+                    rounded-md
+                  |,
+                  width: 1,
+                  height: 1
+            %>
+            <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
+              <%= spinner size: 6, class: "text-black dark:text-white" %>
+            </div>
+          <% end %>
+        <% end %>
+        <%= formatted_text = format_for_display message.content_text,
+              append_inside_tag: span_tag("", class: %|
+                animate-breathe
+                w-3 h-3
+                rounded-full
+                bg-black dark:bg-white
+                inline-block
+                ml-1
+                #{!thinking && 'hidden'}
+              |) +
+              span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
+              icon("stop",
+                variant: :solid,
+                size: 17,
+                title: "Stopped",
+                tooltip: :top,
+                data: { role: "cancelled" },
+                class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
+              )
+        %>
       </div>
 
-      <turbo-frame id="message-text-<%= message.id %>">
-        <div
-          class="hidden"
-          data-clipboard-target="text"
-        ><%= format_for_copying message.content_text %></div>
-        <div
-          class="hidden"
-          data-speaker-target="<%= message.assistant? && "assistantText" %>"
-          data-thinking="<%= !!thinking %>"
-        ><%= format_for_speaking message.content_text %></div>
-
+      <% if debug_tool_messages && message.content_tool_calls.present? %>
         <div
           data-role="content-text"
           class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
         >
-          <% if message.has_document_image? %>
-            <%= button_tag type: "button",
-                  class: "w-full h-auto flex focus:outline-none",
-                  data: {
-                    controller: "image-loader",
-                    image_loader_message_scroller_outlet: "[data-role='message']",
-                    image_loader_url_value: message.document_image_path(:small),
-                    action: "modal#open",
-                    role: "image-preview",
-                  } do
-            %>
-              <%= image_tag message.document_image_path(:small, fallback: ""),
-                    data: {
-                      image_loader_target: "image",
-                      action: %|
-                        error->image-loader#retryAfterDelay
-                        load->image-loader#show
-                      |
-                    },
-                    class: %|
-                      my-0
-                      mx-auto
-                      max-w-full
-                      border-2 border-gray-100 dark:border-gray-400
-                      rounded-md
-                    |,
-                    width: 1,
-                    height: 1
-              %>
-              <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
-                <%= spinner size: 6, class: "text-black dark:text-white" %>
-              </div>
-            <% end %>
-          <% end %>
-          <%= formatted_text = format_for_display message.content_text,
-                append_inside_tag: span_tag("", class: %|
-                  animate-breathe
-                  w-3 h-3
-                  rounded-full
-                  bg-black dark:bg-white
-                  inline-block
-                  ml-1
-                  #{!thinking && 'hidden'}
-                |) +
-                span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
-                icon("stop",
-                  variant: :solid,
-                  size: 17,
-                  title: "Stopped",
-                  tooltip: :top,
-                  data: { role: "cancelled" },
-                  class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
-                )
-          %>
+          <%= formatted_text = format "```\n#{message.content_tool_calls}\n```" %>
         </div>
+      <% end %>
 
-        <% if debug_tool_messages && message.content_tool_calls.present? %>
-          <div
-            data-role="content-text"
-            class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
-          >
-            <%= formatted_text = format "```\n#{message.content_tool_calls}\n```" %>
-          </div>
+      <div class="
+        flex justify-start
+        gap-2
+        text-gray-600 dark:text-gray-300
+        <%= !last_message && done_thinking && 'invisible' %> group-hover:visible
+      ">
+        <% if message.versions.length > 1 %>
+          <%= button_to message_path(message, version: previous_version),
+            method: :patch,
+            params: { message: { id: message.id } },
+            class: "-ml-1 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
+            disabled: previous_version.nil?,
+            form: {
+              class: "flex items-center",
+              data: {
+                turbo_frame: "_top",
+                turbo_action: "replace",
+              }
+            },
+            data: {
+              role: "previous",
+          } do %>
+            <%= icon "chevron-left", variant: :micro, title: previous_version.present? && "Previous", data: { } %>
+          <% end %>
+
+          v<%= message.version %>
+          <%= button_to message_path(message, version: next_version),
+            method: :patch,
+            params: { message: { id: message.id } },
+            class: "mr-2 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
+            disabled: next_version.nil?,
+            form: {
+              class: "flex items-center",
+              data: {
+                turbo_frame: "_top",
+                turbo_action: "replace",
+              }
+            },
+            data: {
+              role: "next",
+          } do %>
+            <%= icon "chevron-right", variant: :micro, title: next_version.present? && "Next", data: { } %>
+          <% end %>
         <% end %>
 
-        <div class="
-          flex justify-start
-          gap-2
-          text-gray-600 dark:text-gray-300
-          <%= !last_message && done_thinking && 'invisible' %> group-hover:visible
-        ">
-          <% if message.versions.length > 1 %>
-            <%= button_to message_path(message, version: previous_version),
-              method: :patch,
-              params: { message: { id: message.id } },
-              class: "-ml-1 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
-              disabled: previous_version.nil?,
-              form: {
-                class: "flex items-center",
-                data: {
-                  turbo_frame: "_top",
-                  turbo_action: "replace",
-                }
-              },
-              data: {
-                role: "previous",
+        <% if message.user? && message.assistant.not_deleted? && !message.has_document_image? %>
+          <%= link_to edit_assistant_message_path(message.assistant, message),
+            class: "cursor-pointer hover:text-gray-900 dark:hover:text-white flex items-center",
+            data: {
+              role: "message-edit",
+              composer_target: "messageEdit",
+              turbo_frame: "message-text-#{message.id}",
             } do %>
-              <%= icon "chevron-left", variant: :micro, title: previous_version.present? && "Previous", data: { } %>
-            <% end %>
-
-            v<%= message.version %>
-            <%= button_to message_path(message, version: next_version),
-              method: :patch,
-              params: { message: { id: message.id } },
-              class: "mr-2 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
-              disabled: next_version.nil?,
-              form: {
-                class: "flex items-center",
-                data: {
-                  turbo_frame: "_top",
-                  turbo_action: "replace",
-                }
-              },
-              data: {
-                role: "next",
-            } do %>
-              <%= icon "chevron-right", variant: :micro, title: next_version.present? && "Next", data: { } %>
-            <% end %>
+            <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
           <% end %>
-
-          <% if message.user? && message.assistant.not_deleted? && !message.has_document_image? %>
-            <%= link_to edit_assistant_message_path(message.assistant, message),
-              class: "cursor-pointer hover:text-gray-900 dark:hover:text-white flex items-center",
-              data: {
-                role: "message-edit",
-                composer_target: "messageEdit",
-                turbo_frame: "message-text-#{message.id}",
-              } do %>
-              <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
-            <% end %>
-          <% elsif message.assistant? && message.assistant.not_deleted? %>
-            <%= button_tag type: "button",
-                  class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
-                  data: {
-                    role: "clipboard",
-                    action: %|
-                      clipboard#copy
-                      transition#toggleClassOn
-                      mouseleave->transition#toggleClassOff
-                    |,
-                    keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
-                    # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
-            } do %>
-              <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
-              <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
-            <% end %>
-
-            <div class="dropdown dropdown-top flex items-center">
-              <%= icon "arrow-path",
-                tabindex: 0,
-                role: :button,
-                variant: :outline,
-                size: 18,
-                title: "Regenerate",
-                data: { role: "regenerate" }
-              %>
-
-              <menu tabindex="0" class="dropdown-content -ml-6 z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
-                <% message.user.assistants.ordered.excluding(message.assistant).to_a.push(message.assistant).each do |assistant| %>
-                  <% last = message.assistant == assistant %>
-                  <li class="overflow-hidden <%= 'border-t border-gray-200 dark:border-gray-500 pt-1 mt-1' if last %>">
-                    <%= button_to assistant_messages_path(assistant),
-                      form_class: "inline-block p-0",
-                      class: "truncate w-full py-2 px-4 text-left",
-                      method: :post,
-                      data: {
-                        turbo_frame: "_top",
-                        turbo_action: "replace",
-                      },
-                      params: { message: {
-                        conversation_id: conversation.id,
-                        assistant_id: assistant.id,
-                        role: "assistant",
-                        index: message.index,
-                        branched: true,
-                        branched_from_version: message.version
-                      } } do
-                    %>
-                      Using <%= assistant.name %>
-                    <% end %>
-                  </li>
-                <% end %>
-              </menu>
-            </div>
+        <% elsif message.assistant? && message.assistant.not_deleted? %>
+          <%= button_tag type: "button",
+            class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
+            data: {
+              role: "playback",
+              action: %|
+                playback#speak
+                transition#toggleClassOn
+              |,
+              # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
+          } do %>
+            <%= icon "speaker-wave", variant: :outline, size: 18, title: "Read aloud", data: { transition_target: "transitionable" } %>
+            <%= icon "stop-circle", variant: :outline, size: 18, title: "Stop", data: { transition_target: "transitionable" }, class: "hidden" %>
           <% end %>
-        </div>
-      </turbo-frame>
-
-      <% if message.has_document_image? %>
-        <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
-          <main class="modal-box max-w-5xl p-0 rounded-none">
-            <article
-              data-controller="image-loader"
-              data-image-loader-message-scroller-outlet="[data-role='message']"
-              data-image-loader-url-value="<%= message.document_image_path(:large) %>"
-              data-turbo-permanent
-              class="flex flex-col md:flex-row justify-center"
-            >
-              <%= image_tag message.document_image_path(:large, fallback: ""),
+          <%= button_tag type: "button",
+                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
                 data: {
-                  image_loader_target: "image",
+                  role: "clipboard",
                   action: %|
-                    error->image-loader#retryAfterDelay
-                    load->image-loader#show
-                  |
-                },
-                class: "w-full h-auto"
-              %>
-              <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
-                <%= spinner size: 6, class: "text-black dark:text-white" %>
-              </div>
-            </article>
-          </main>
-          <form method="dialog" class="modal-backdrop no-focus-outline">
-            <button id="modal-backdrop">close</button>
-          </form>
-        </dialog>
-      <% end %>
-    </div>
+                    clipboard#copy
+                    transition#toggleClassOn
+                    mouseleave->transition#toggleClassOff
+                  |,
+                  keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
+                  # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
+          } do %>
+            <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
+            <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
+          <% end %>
+
+          <div class="dropdown dropdown-top flex items-center">
+            <%= icon "arrow-path",
+              tabindex: 0,
+              role: :button,
+              variant: :outline,
+              size: 18,
+              title: "Regenerate",
+              data: { role: "regenerate" }
+            %>
+
+            <menu tabindex="0" class="dropdown-content -ml-6 z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
+              <% message.user.assistants.ordered.excluding(message.assistant).to_a.push(message.assistant).each do |assistant| %>
+                <% last = message.assistant == assistant %>
+                <li class="overflow-hidden <%= 'border-t border-gray-200 dark:border-gray-500 pt-1 mt-1' if last %>">
+                  <%= button_to assistant_messages_path(assistant),
+                    form_class: "inline-block p-0",
+                    class: "truncate w-full py-2 px-4 text-left",
+                    method: :post,
+                    data: {
+                      turbo_frame: "_top",
+                      turbo_action: "replace",
+                    },
+                    params: { message: {
+                      conversation_id: conversation.id,
+                      assistant_id: assistant.id,
+                      role: "assistant",
+                      index: message.index,
+                      branched: true,
+                      branched_from_version: message.version
+                    } } do
+                  %>
+                    Using <%= assistant.name %>
+                  <% end %>
+                </li>
+              <% end %>
+            </menu>
+          </div>
+        <% end %>
+      </div>
+    </turbo-frame>
+
+    <% if message.has_document_image? %>
+      <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
+        <main class="modal-box max-w-5xl p-0 rounded-none">
+          <article
+            data-controller="image-loader"
+            data-image-loader-message-scroller-outlet="[data-role='message']"
+            data-image-loader-url-value="<%= message.document_image_path(:large) %>"
+            data-turbo-permanent
+            class="flex flex-col md:flex-row justify-center"
+          >
+            <%= image_tag message.document_image_path(:large, fallback: ""),
+              data: {
+                image_loader_target: "image",
+                action: %|
+                  error->image-loader#retryAfterDelay
+                  load->image-loader#show
+                |
+              },
+              class: "w-full h-auto"
+            %>
+            <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
+              <%= spinner size: 6, class: "text-black dark:text-white" %>
+            </div>
+          </article>
+        </main>
+        <form method="dialog" class="modal-backdrop no-focus-outline">
+          <button id="modal-backdrop">close</button>
+        </form>
+      </dialog>
+    <% end %>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -25,6 +25,7 @@ end %>
   data-playback-index-value="<%= message_counter %>"
   data-playback-sentences-index-value="0"
   data-playback-done-prompting-value="false"
+  data-action="turbo:before-morph-attribute->playback#preserveStimulusValues"
 >
   <!-- Left Column -->
   <div class="w-6 ml-1 flex">

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,39 +1,42 @@
-<%# locals: (message:, scroll_down: false, only_scroll_down_if_was_bottom: false, request_id: nil, timestamp: nil, thinking: nil, streamed: false, message_counter: -1) -%>
+<%# locals: (message:, request_id: nil, scroll_down: false, only_scroll_down_if_was_bottom: false, timestamp: nil, thinking: nil, streamed: false, message_counter: -1) -%>
 <%# request_id is not used, but broadcasting turbo stream messages provides it as a local so it needs to be accepted %>
 
 <% conversation = message.conversation %>
 <% conversation_version = streamed ? message.version : @version %>
-<% max_index = conversation.messages.for_conversation_version(conversation_version).count - 1 %>
-<% last_message = message_counter == max_index %>
-<% initial_page_load = last_message && !scroll_down %>
-<% scroll_down = scroll_down || initial_page_load %>
-<% thinking ||= last_message && message.content_text == "" && message.not_cancelled? %>
-<% last_message_done = last_message && !thinking && message.content_text.present? %>
-<% debug_tool = false %>
-<%
-if message.versions.present?
+<% if message.versions.present?
   previous_version  = message.versions.push(nil)[ message.versions.index(message.version)-1 ]
   next_version      = message.versions.push(nil)[ message.versions.index(message.version)+1 ]
-end
-%>
+end %>
+<% max_index = conversation.messages.for_conversation_version(conversation_version).count - 1 %>
+<% last_message = message_counter == max_index %>
+<% initial_page_load = last_message && !scroll_down # this value is only accurate when rendering last_message %>
+<% scroll_down = scroll_down || initial_page_load %>
+<% thinking ||= last_message && message.content_text == "" && message.not_cancelled? %>
+<% done_thinking = !thinking && message.content_text.present? %>
+<% autoplay = last_message && @last_message_playback_active %>
+<% debug_tool_messages = false %>
 
 <div
   id="<%= dom_id message %>"
-  class="mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool && "hidden" %>"
   data-role="message"
+  class="mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
   data-timestamp="<%= timestamp %>"
   data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
   data-message-scroller-scroll-down-value="<%= scroll_down %>"
   data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
   data-message-scroller-instantly-value="<%= initial_page_load %>"
 >
-  <div class="flex">
-    <div class="flex flex-col items-center w-6 ml-1">
-      <% if message.user? %>
-        <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "mt-1" } %>
-      <% else %>
-        <%= render partial: "layouts/assistant_avatar", locals: { assistant: message.assistant, size: 7, classes: "mt-1" } %>
-      <% end %>
+  <div
+    data-role="<%= message.role %>-message"
+    data-controller="<%= message.assistant? && "playback" %>"
+    data-playback-index-value="<%= message_counter %>"
+    data-playback-sentences-index-value="0"
+    data-playback-speaker-active-value="<%= !!autoplay %>"
+    class="flex"
+  >
+    <!-- Left Column -->
+    <div class="w-6 ml-1 flex">
+      <%= render_avatar_for(message) %>
     </div>
 
     <!-- Right Column -->
@@ -44,27 +47,21 @@ end
         <%= message.has_document_image? && "modal" %>
       "
       data-transition-toggle-class="hidden"
-      class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100">
-
+      class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
+    >
       <div class="mt-[6px] mb-1 font-semibold" data-role="from">
-        <%= case message.role
-          when "user" then "You"
-          when "assistant" then message.assistant.name
-          when "tool" then "Tool"
-          end
-        %>
+        <%= from_name_for(message) %>
       </div>
 
-      <turbo-frame id="message-<%= message.id %>">
-
+      <turbo-frame id="message-text-<%= message.id %>">
         <div
           class="hidden"
           data-clipboard-target="text"
         ><%= format_for_copying message.content_text %></div>
         <div
           class="hidden"
-          data-speaker-target="text <%= message.assistant? ? "assistantText" : "userText" %>"
-          data-thinking="<%= thinking ? "true" : "false" %>"
+          data-speaker-target="<%= message.assistant? && "assistantText" %>"
+          data-thinking="<%= !!thinking %>"
         ><%= format_for_speaking message.content_text %></div>
 
         <div
@@ -127,7 +124,7 @@ end
           %>
         </div>
 
-        <% if debug_tool && message.content_tool_calls.present? %>
+        <% if debug_tool_messages && message.content_tool_calls.present? %>
           <div
             data-role="content-text"
             class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
@@ -140,7 +137,7 @@ end
           flex justify-start
           gap-2
           text-gray-600 dark:text-gray-300
-          <%= !last_message_done && 'invisible' %> group-hover:visible
+          <%= !last_message && done_thinking && 'invisible' %> group-hover:visible
         ">
           <% if message.versions.length > 1 %>
             <%= button_to message_path(message, version: previous_version),
@@ -187,7 +184,7 @@ end
               data: {
                 role: "message-edit",
                 composer_target: "messageEdit",
-                turbo_frame: "message-#{message.id}",
+                turbo_frame: "message-text-#{message.id}",
               } do %>
               <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
             <% end %>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">Editing message</h1>
 
-  <turbo-frame id="message-<%= @message.id %>">
+  <turbo-frame id="message-text-<%= @message.id %>">
     <%= form_with(
       model: [@assistant, @new_message],
       class: "content-text",

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1,0 +1,5 @@
+class Nokogiri::XML::Node
+  def at_id(id)
+    at_css("##{id}")
+  end
+end

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -341,7 +341,7 @@ claude_replying:
 claude_age:
   assistant: keith_claude3
   conversation: hello_claude
-  role: assistant
+  role: user
   content_text: How old are you?
   content_document:
   run:

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -50,11 +50,11 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal h, Message.new.content_tool_calls
   end
 
-  test "name returns a properly formatted string" do
-    assert_equal users(:keith).first_name, messages(:hear_me).name
-    assert_equal "Samantha", messages(:yes_i_do).name
-    assert_equal "OpenAI", messages(:popstate_event).name # strips off non-alphanumeric
-    assert_nil messages(:weather_tool_result).name
+  test "name_for_api returns a properly formatted string" do
+    assert_equal users(:keith).first_name, messages(:hear_me).name_for_api
+    assert_equal "Samantha", messages(:yes_i_do).name_for_api
+    assert_equal "OpenAI", messages(:popstate_event).name_for_api # strips off non-alphanumeric
+    assert_nil messages(:weather_tool_result).name_for_api
   end
 
   test "finished? returns true if processed and missing either content_text or content_tool_calls" do

--- a/test/system/conversations/messages/playback_test.rb
+++ b/test/system/conversations/messages/playback_test.rb
@@ -1,0 +1,64 @@
+require "application_system_test_case"
+
+class ConversationMessagesPlaybackTest < ApplicationSystemTestCase
+  setup do
+    login_as users(:keith)
+    @conversation = conversations(:hello_claude)
+  end
+
+  test "ensure no auto playback on a normal load" do
+    visit_and_scroll_wait conversation_messages_path(@conversation, version: 1)
+
+    speaker = page.find("[data-controller~='speaker']")
+    refute speaker["data-speaker-playback-index-value"], "initial index should not be present"
+
+    messages = page.all("[data-role='assistant-message']")
+    assert_equal 2, messages.length
+
+    assert_equal "1",     messages[0]["data-playback-index-value"]
+    assert_equal "0",     messages[0]["data-playback-sentences-index-value"]
+    assert_equal "false", messages[0]["data-playback-speaker-active-value"]
+
+    assert_equal "3",     messages[1]["data-playback-index-value"]
+    assert_equal "0",     messages[1]["data-playback-sentences-index-value"]
+    assert_equal "false", messages[1]["data-playback-speaker-active-value"]
+  end
+
+  test "ensure playback index & auto-speaker index stay in sync" do
+    visit_and_scroll_wait conversation_messages_path(@conversation, version: 1, last_message_playback_active: true)
+    speaker = page.find("[data-controller~='speaker']")
+    messages = page.all("[data-role='assistant-message']")
+    assert_equal 2, messages.length
+
+    assert_equal "3", speaker["data-speaker-playback-index-value"], "initial index should have been set"
+
+    assert_equal "1",     messages[0]["data-playback-index-value"]
+    assert_equal "0",     messages[0]["data-playback-sentences-index-value"]
+    assert_equal "false", messages[0]["data-playback-speaker-active-value"]
+
+    assert_equal "3",     messages[1]["data-playback-index-value"]
+    assert_equal "0",     messages[1]["data-playback-sentences-index-value"]
+    assert_equal "true",  messages[1]["data-playback-speaker-active-value"]
+
+    # Setting a message to speaker-active propogates
+    page.execute_script("document.querySelectorAll(`[data-role='assistant-message']`)[0].setAttribute('data-playback-speaker-active-value', 'true')")
+
+    assert_equal "1", speaker["data-speaker-playback-index-value"]
+    assert_equal "true", messages[0]["data-playback-speaker-active-value"]
+    assert_equal "false",  messages[1]["data-playback-speaker-active-value"]
+
+    # Changing the speaker index propogates
+    page.execute_script("document.querySelector(`[data-controller~='speaker']`).setAttribute('data-speaker-playback-index-value', '3')")
+
+    assert_equal "3", speaker["data-speaker-playback-index-value"]
+    assert_equal "false", messages[0]["data-playback-speaker-active-value"]
+    assert_equal "true",  messages[1]["data-playback-speaker-active-value"]
+
+    # Stop all speaker auto playback
+    page.execute_script("Stimulus.getControllerForElementAndIdentifier(document.querySelector(`[data-controller~='speaker']`), 'speaker').stop()")
+
+    refute speaker["data-speaker-playback-index-value"]
+    assert_equal "false", messages[0]["data-playback-speaker-active-value"]
+    assert_equal "false",  messages[1]["data-playback-speaker-active-value"]
+  end
+end

--- a/test/system/conversations/messages/playback_test.rb
+++ b/test/system/conversations/messages/playback_test.rb
@@ -12,7 +12,7 @@ class ConversationMessagesPlaybackTest < ApplicationSystemTestCase
     speaker = page.find("[data-controller~='speaker']")
     refute speaker["data-speaker-playback-index-value"], "initial index should not be present"
 
-    messages = page.all("[data-role='assistant-message']")
+    messages = page.all("[data-subrole='assistant-message']")
     assert_equal 2, messages.length
 
     assert_equal "1",     messages[0]["data-playback-index-value"]
@@ -27,7 +27,7 @@ class ConversationMessagesPlaybackTest < ApplicationSystemTestCase
   test "ensure playback index & auto-speaker index stay in sync" do
     visit_and_scroll_wait conversation_messages_path(@conversation, version: 1, last_message_playback_active: true)
     speaker = page.find("[data-controller~='speaker']")
-    messages = page.all("[data-role='assistant-message']")
+    messages = page.all("[data-subrole='assistant-message']")
     assert_equal 2, messages.length
 
     assert_equal "3", speaker["data-speaker-playback-index-value"], "initial index should have been set"
@@ -41,7 +41,7 @@ class ConversationMessagesPlaybackTest < ApplicationSystemTestCase
     assert_equal "true",  messages[1]["data-playback-speaker-active-value"]
 
     # Setting a message to speaker-active propogates
-    page.execute_script("document.querySelectorAll(`[data-role='assistant-message']`)[0].setAttribute('data-playback-speaker-active-value', 'true')")
+    page.execute_script("document.querySelectorAll(`[data-subrole='assistant-message']`)[0].setAttribute('data-playback-speaker-active-value', 'true')")
 
     assert_equal "1", speaker["data-speaker-playback-index-value"]
     assert_equal "true", messages[0]["data-playback-speaker-active-value"]


### PR DESCRIPTION
Fix more edge cases with voice interaction:

* Do not keep listening after SpeakTo called (if a user keeps talking it would submit another SpeakTo while it's still processing the first one)
* Preserve the composer text during the morph that happens at the end of a response. Occasionally the user Transcriber would submit the next message too quickly, it would get cleared, and then the front-end thinks it submitted text but the backend never received it so it'll wait forever.
* Got a more reliable way to know if this is the first response (i.e. newly created conversation) because then I can remove some of the complex logic which isn't working
* Add support for the assistant replying twice in a row without a user message in between
* Added support for manually clicking to have a voice speak

Todo:


* Figure out how to detect speech even before the person has finished sharing their thought because the dismiss timeout will currently fire while I'm still speaking

* Investigate whether a PWA app can prevent the device from going to sleep because the screen turns off while using the app with your voice.

* When the screen goes to sleep and you reactivate it, the microphone stops working and prevents you from speaking to it.

* Consider adding a timeout when the "thinking" process takes too long to avoid it hanging.
