### PR TITLE
Fix two bugs with composer (mistaken clearing & bad up-to-edit)

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,8 +6,9 @@ import "@hotwired/turbo-rails"
 let oldTimestamp
 
 // console.log('Document: refresh')
-document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}`))
+// document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}`))
 // document.addEventListener('turbo:morph', () => console.log('Document: morph render'))
+// document.addEventListener('turbo:before-morph-element', (e) => { if (document.getElementById('composer').contains(e.target)) console.log('Document: before-morph', e.target) })
 // document.addEventListener('turbo:frame-render', () => console.log('Document: frame render'))
 // document.addEventListener('turbo:before-stream-render', (event) => console.log(`Document: stream render (${event.target.getAttribute('action')} event)`, event.target, event.detail.newStream.querySelector('template').content?.firstChild?.nextSibling?.querySelector('[data-speaker-target="text assistantText"]')))
 

--- a/app/javascript/stimulus/composer_controller.js
+++ b/app/javascript/stimulus/composer_controller.js
@@ -56,6 +56,8 @@ export default class extends Controller {
   }
 
   editPrevious() {
+    if (this.inputTarget.value != "") return
+
     const messageEdits = document.querySelectorAll("[data-role='message-edit']")
     const lastEdit = messageEdits[messageEdits.length - 1]
     if (lastEdit) lastEdit.click()

--- a/app/javascript/stimulus/message_scroller_controller.js
+++ b/app/javascript/stimulus/message_scroller_controller.js
@@ -24,6 +24,7 @@ export default class extends Controller {
                                                                       // because it's higher in DOM than messages.
     window.addEventListener('resize', this.throttledScrollDownIfScrolledToBottom)
     window.addEventListener('main-column-changed', this.throttledScrollDownIfScrolledToBottom)
+    document.addEventListener('turbo:morph', this.throttledScrollDownIfScrolledToBottom)
 
     this.considerScroll()
   }
@@ -31,7 +32,7 @@ export default class extends Controller {
   disconnect() {
     window.removeEventListener('resize', this.throttledScrollDownIfScrolledToBottom)
     window.removeEventListener('main-column-changed', this.throttledScrollDownIfScrolledToBottom)
-    window.removeEventListener('load', this.throttledScrollDownIfScrolledToBottom)
+    document.removeEventListener('turbo:morph', this.throttledScrollDownIfScrolledToBottom)
   }
 
   considerScroll() {

--- a/app/javascript/stimulus/permanent_value_controller.js
+++ b/app/javascript/stimulus/permanent_value_controller.js
@@ -13,25 +13,13 @@ export default class extends Controller {
     this.element.removeEventListener('turbo:morph-element', this.boundRestoreValue)
   }
 
-  boundSaveValue = (event) => { this.saveValue(event) }
-  saveValue(event) {
-    // this.savedValue = event.target.value
-    // this.savedTarget = event.target
-    // console.log(`## saving value "${event.target.value}" or "${this.element.value}" = `, this.savedValue)
+  boundSaveValue = () => { this.saveValue() }
+  saveValue() {
     this.savedTarget = this.element.value
   }
 
-  boundRestoreValue = (event) => { this.restoreValue(event) }
-  restoreValue(event) {
+  boundRestoreValue = () => { this.restoreValue() }
+  restoreValue() {
     this.element.value = this.savedTarget
-    // console.log(`## finding element "${this.savedTarget.id}"`, document.getElementById(`${this.savedTarget.id}`).id)
-    // console.log(`## original element: `, this.element.id)
-    // console.log(`## target element: `, event.target.id)
-
-    // this.element.value = this.savedValue
-    // document.getElementById(`${this.savedTarget.id}`).value = this.savedValue
-    // event.target.value = this.savedValue
-
-    // console.log(`## new element set to ${this.element.value} and ${document.getElementById(`${this.savedTarget.id}`).value} and ${event.target.value}`)
   }
 }

--- a/app/javascript/stimulus/permanent_value_controller.js
+++ b/app/javascript/stimulus/permanent_value_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    console.log('## connecting...')
+    this.element.addEventListener('turbo:before-morph-element', this.boundSaveValue)
+    this.element.addEventListener('turbo:morph-element', this.boundRestoreValue)
+    this.savedValue = null
+  }
+
+  disconnect() {
+    this.element.removeEventListener('turbo:before-morph-element', this.boundSaveValue)
+    this.element.removeEventListener('turbo:morph-element', this.boundRestoreValue)
+  }
+
+  boundSaveValue = (event) => { this.saveValue(event) }
+  saveValue(event) {
+    // this.savedValue = event.target.value
+    // this.savedTarget = event.target
+    // console.log(`## saving value "${event.target.value}" or "${this.element.value}" = `, this.savedValue)
+    this.savedTarget = this.element.value
+  }
+
+  boundRestoreValue = (event) => { this.restoreValue(event) }
+  restoreValue(event) {
+    this.element.value = this.savedTarget
+    // console.log(`## finding element "${this.savedTarget.id}"`, document.getElementById(`${this.savedTarget.id}`).id)
+    // console.log(`## original element: `, this.element.id)
+    // console.log(`## target element: `, event.target.id)
+
+    // this.element.value = this.savedValue
+    // document.getElementById(`${this.savedTarget.id}`).value = this.savedValue
+    // event.target.value = this.savedValue
+
+    // console.log(`## new element set to ${this.element.value} and ${document.getElementById(`${this.savedTarget.id}`).value} and ${event.target.value}`)
+  }
+}

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -130,8 +130,15 @@
       </div>
 
       <div id="composer"
-            class="<%= @assistant.deleted? && 'hidden' %> flex-1 pl-6 pr-6 w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px] mx-auto relative leading-relaxed <%= !@assistant.supports_images? && 'relationship' %>"
-            data-controller="composer image-upload"
+        class="
+          <%= @assistant.deleted? && 'hidden' %>
+          <%= !@assistant.supports_images? && 'relationship' %>
+          flex-1 relative
+          leading-relaxed
+          pl-6 pr-6 mx-auto mb-6
+          w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px]
+        "
+        data-controller="composer image-upload"
       >
         <%= button_tag type: "button",
               id: "attach-button",
@@ -248,7 +255,7 @@
               composer_target: "input",
               image_upload_target: "content",
               application_target: "newMessageField",
-              controller: "textarea-autogrow",
+              controller: "textarea-autogrow permanent-value",
               action: %|
                 composer#determineSubmitButton
 
@@ -397,10 +404,6 @@
           </div>
 
         <% end %>
-      </div>
-
-      <div class="w-full mb-2 text-xs text-center text-gray-400 dark:text-gray-300">
-        <span>&nbsp;</span> <!-- the data-turbo-permanent causes height of page to be calculated incorrectly, adding this span fixes it -->
       </div>
   </footer>
 </turbo-frame>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -76,6 +76,8 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
 
     key_array = keys.split('+').collect do |key|
       case key
+      when 'up'
+        :arrow_up
       when 'meta'
         :command
       when 'esc'
@@ -269,8 +271,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   def assert_composer_blank(msg = nil)
     msg ||= "Composer input did not clear"
     assert_true msg do
-      find("#composer textarea").value.blank?
+      composer.value.blank?
     end
+  end
+
+  def composer
+    find(composer_selector)
+  end
+
+  def composer_selector
+    "#composer textarea"
   end
 
   def hover_last_message

--- a/test/support/morphing_helper.rb
+++ b/test/support/morphing_helper.rb
@@ -1,0 +1,54 @@
+module MorphingHelper
+  private
+
+  def assert_page_morphed
+    raise "No block given" unless block_given?
+    watch_page_for_morphing
+
+    yield
+
+    sleep 1 # this delay is so long b/c we wait 0.5s before scrolling the page down
+    assert get_scroll_position("section #messages") > @messages_scroll_position, "The page should have scrolled down further"
+    assert_hidden "#scroll-button", "The page did not scroll all the way down"
+    assert tagged?("nav"), "The page did not morph; a tagged element got replaced."
+    assert tagged?(first_message), "The page did not morph; a tagged element got replaced."
+    assert_equal @nav_scroll_position, get_scroll_position("nav"), "The left column lost it's scroll position"
+  end
+
+  def watch_page_for_morphing
+    # Within automated system tests, it's difficult to know if a page morphed or not. When a page does morph
+    # it should only replace the DOM elements which changed. This has the side effect of preserving scroll position.
+    # However, full page Turbo transitions also have other hacks in place to preserve scroll position so that
+    # is not enough. The best solution I found was to test for the scroll position *and* to test if a couple
+    # elements we expect NOT to be replaced stay put. The way I test this is by "tagging" an element; this adds an
+    # attribute to the element which morphdom ignores so it does not recognize this as a changed element. A full
+    # page body replacement or a turbo-frame replacement does not re-add these attributes, so if the tag is no longer
+    # present then we know morphing did not occur.
+    tag("nav")
+    tag(first_message)
+    @nav_scroll_position = get_scroll_position("nav")
+    sleep 1 # this delay is so long b/c we wait 0.5s before scrolling the page down
+    @messages_scroll_position = get_scroll_position("section #messages")
+    assert_not_equal 0, @messages_scroll_position, "The page should be scrolled down before acting on it"
+  end
+
+  def tag(selector_or_element)
+    element = if selector_or_element.is_a?(Capybara::Node::Element)
+      selector_or_element
+    else
+      find(selector_or_element)
+    end
+
+    page.execute_script("arguments[0]._morphMonitor = true", element)
+  end
+
+  def tagged?(selector_or_element)
+    element = if selector_or_element.is_a?(Capybara::Node::Element)
+      selector_or_element
+    else
+      find(selector_or_element)
+    end
+
+    element[:'_morphMonitor']
+  end
+end

--- a/test/system/conversations/messages_test.rb
+++ b/test/system/conversations/messages_test.rb
@@ -1,6 +1,8 @@
 require "application_system_test_case"
 
 class ConversationMessagesTest < ApplicationSystemTestCase
+  include MorphingHelper
+
   setup do
     15.times { |i| users(:keith).conversations.create!(assistant: assistants(:samantha), title: "Conversation #{i+1}") }
 
@@ -57,7 +59,7 @@ class ConversationMessagesTest < ApplicationSystemTestCase
       send_keys "Watch me appear"
       send_keys "enter"
 
-      assert_true "The last user message should have contained the submitted text" do
+      assert_true "The last user message should contain the submitted text" do
         len = find_messages.length
         find_messages[len-2].text.include?("Watch me appear")
       end
@@ -80,58 +82,5 @@ class ConversationMessagesTest < ApplicationSystemTestCase
       end
       @new_message.save!
     end
-  end
-
-  private
-
-  def assert_page_morphed
-    raise "No block given" unless block_given?
-    watch_page_for_morphing
-
-    yield
-
-    sleep 1 # this delay is so long b/c we wait 0.5s before scrolling the page down
-    assert get_scroll_position("section #messages") > @messages_scroll_position, "The page should have scrolled down further"
-    assert_hidden "#scroll-button", "The page did not scroll all the way down"
-    assert tagged?("nav"), "The page did not morph; a tagged element got replaced."
-    assert tagged?(first_message), "The page did not morph; a tagged element got replaced."
-    assert_equal @nav_scroll_position, get_scroll_position("nav"), "The left column lost it's scroll position"
-  end
-
-  def watch_page_for_morphing
-    # Within automated system tests, it's difficult to know if a page morphed or not. When a page does morph
-    # it should only replace the DOM elements which changed. This has the side effect of preserving scroll position.
-    # However, full page Turbo transitions also have other hacks in place to preserve scroll position so that
-    # is not enough. The best solution I found was to test for the scroll position *and* to test if a couple
-    # elements we expect NOT to be replaced stay put. The way I test this is by "tagging" an element; this adds an
-    # attribute to the element which morphdom ignores so it does not recognize this as a changed element. A full
-    # page body replacement or a turbo-frame replacement does not re-add these attributes, so if the tag is no longer
-    # present then we know morphing did not occur.
-    tag("nav")
-    tag(first_message)
-    @nav_scroll_position = get_scroll_position("nav")
-    sleep 1 # this delay is so long b/c we wait 0.5s before scrolling the page down
-    @messages_scroll_position = get_scroll_position("section #messages")
-    assert_not_equal 0, @messages_scroll_position, "The page should be scrolled down before acting on it"
-  end
-
-  def tag(selector_or_element)
-    element = if selector_or_element.is_a?(Capybara::Node::Element)
-      selector_or_element
-    else
-      find(selector_or_element)
-    end
-
-    page.execute_script("arguments[0]._morphMonitor = true", element)
-  end
-
-  def tagged?(selector_or_element)
-    element = if selector_or_element.is_a?(Capybara::Node::Element)
-      selector_or_element
-    else
-      find(selector_or_element)
-    end
-
-    element[:'_morphMonitor']
   end
 end

--- a/test/system/messages/composer/edit_previous_test.rb
+++ b/test/system/messages/composer/edit_previous_test.rb
@@ -1,0 +1,30 @@
+require "application_system_test_case"
+
+class MessagesComposerEditPreviousTest < ApplicationSystemTestCase
+  include MorphingHelper
+
+  setup do
+    login_as users(:keith)
+    @conversation = conversations(:greeting)
+    visit_and_scroll_wait conversation_messages_path(@conversation)
+  end
+
+  test "pressing up while focused in composer edits the previous message" do
+    assert_active composer_selector
+
+    refute_text "Cancel"
+    send_keys "up"
+    assert_text "Cancel"
+
+    assert last_user_message.find_role("cancel")
+  end
+
+  test "pressing up once text has been entered into the composer does not edit the previous message" do
+    assert_active composer_selector
+    send_keys "Starting to type a question..."
+
+    refute_text "Cancel"
+    send_keys "up"
+    refute_text "Cancel"
+  end
+end

--- a/test/system/messages/composer/resetting_test.rb
+++ b/test/system/messages/composer/resetting_test.rb
@@ -1,0 +1,36 @@
+require "application_system_test_case"
+
+class MessagesComposerResettingTest < ApplicationSystemTestCase
+  include MorphingHelper
+
+  setup do
+    login_as users(:keith)
+    @conversation = conversations(:greeting)
+    visit_and_scroll_wait conversation_messages_path(@conversation)
+  end
+
+  test "the composer clears after the user presses submit, but if they start typing really quickly it won't clear with the final morph" do
+    assert_page_morphed do
+      send_keys "Text has been entered"
+      send_keys "enter"
+    end
+
+    assistant_reply = Message.last
+    assistant_reply.content_text = "Assistant reply"
+    GetNextAIMessageJob.broadcast_updated_message(assistant_reply)
+
+    assert_composer_blank
+    send_keys "New text"
+    assert_equal "New text", composer.value
+
+    assert_page_morphed do
+      assistant_reply.content_text = "Assistant reply has gotten really long so that I can ensure it wraps and the page " +
+        "will need to scroll down in order to accomodate the wrapped lines. The quick brown fox jumped over the lazy dog. " +
+        "The quick brown fox jumped over the lazy dog."
+      assistant_reply.save!
+      @conversation.broadcast_refresh_to @conversation
+    end
+
+    assert_equal "New text", composer.value, "Composer should not have cleared what the user typed"
+  end
+end

--- a/test/system/messages/composer_test.rb
+++ b/test/system/messages/composer_test.rb
@@ -5,13 +5,12 @@ class MessagesComposerTest < ApplicationSystemTestCase
     @user = users(:keith)
     login_as @user
     @submit = find("#composer #send", visible: :all) # oddly, when I changed id="submit" on the button the form fails to submit
-    @input_selector = "#composer textarea"
     @long_conversation = conversations(:greeting)
   end
 
   test "the cursor is auto-focused in the text input for a new conversation and selecting existing conversation and ESC unfocuses" do
     sleep 0.2
-    assert_active @input_selector
+    assert_active composer_selector
     send_keys "esc"
     assert_active "body"
 
@@ -19,7 +18,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
 
     click_text @long_conversation.title
     wait_for_images_to_load
-    assert_active @input_selector
+    assert_active composer_selector
   end
 
   test "when cursor is not focused in the text input, / focuses it and then an accidental second / does not appear" do
@@ -27,17 +26,17 @@ class MessagesComposerTest < ApplicationSystemTestCase
     assert_active "body"
 
     send_keys "/"
-    assert_active input
-    assert_equal "", input.value
+    assert_active composer
+    assert_equal "", composer.value
 
     send_keys "/"
-    assert_equal "", input.value
+    assert_equal "", composer.value
   end
 
   test "when cursor is focused in the text input, ? works as a key press" do
-    assert_equal "", input.value
+    assert_equal "", composer.value
     send_keys "?"
-    assert_equal "?", input.value
+    assert_equal "?", composer.value
   end
 
   test "when not in text input, ? opens the keyboard shortcuts and ESC dismisses it and keyboard shortcuts work normally" do
@@ -52,7 +51,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     refute_text "Keyboard shortcuts"
 
     send_keys "/"
-    assert_active input
+    assert_active composer
   end
 
   test "when not in text input, ? opens the keyboard shortcuts and CLICKING OUTSIDE dismisses it and keyboard shortcuts work normally" do
@@ -67,7 +66,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     refute_text "Keyboard shortcuts"
 
     send_keys "/"
-    assert_active input
+    assert_active composer
   end
 
   test "submit button is hidden and can only be clicked when text is entered" do
@@ -103,7 +102,7 @@ class MessagesComposerTest < ApplicationSystemTestCase
     send_keys "First line"
     send_keys "shift+enter"
     send_keys "Second line"
-    assert_equal "First line\nSecond line", input.value
+    assert_equal "First line\nSecond line", composer.value
     assert_equal path, current_path, "Path should not have changed because form should not submit"
 
     send_keys "enter"
@@ -118,53 +117,53 @@ class MessagesComposerTest < ApplicationSystemTestCase
 
     send_keys "1"
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys "shift+enter"
       sleep 0.3
     end
-    assert input.native.property('clientHeight') > height, "Input should have grown taller"
+    assert composer.native.property('clientHeight') > height, "Input should have grown taller"
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys "2"
       send_keys "shift+enter"
       sleep 0.3
     end
-    assert input.native.property('clientHeight') > height, "Input should have grown taller"
+    assert composer.native.property('clientHeight') > height, "Input should have grown taller"
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys "backspace"
       sleep 0.3
     end
-    assert input.native.property('clientHeight') < height, "Input should have gotten shorter"
+    assert composer.native.property('clientHeight') < height, "Input should have gotten shorter"
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys "backspace+backspace"
       sleep 0.3
     end
-    assert input.native.property('clientHeight') < height, "Input should have gotten shorter"
+    assert composer.native.property('clientHeight') < height, "Input should have gotten shorter"
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys "backspace+backspace"
       sleep 0.3
     end
-    assert input.native.property('clientHeight') == height, "Input should not have changed height"
+    assert composer.native.property('clientHeight') == height, "Input should not have changed height"
   end
 
   test "when large block of text is pasted, textarea grows in height and auto-scrolls to stay at the bottom" do
     click_text @long_conversation.title
     wait_for_images_to_load
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_stays_at_bottom do
       send_keys long_input_text
 
       assert_true "Input should have grown taller" do
-        input.native.property('clientHeight') > height
+        composer.native.property('clientHeight') > height
       end
     end
   end
@@ -176,12 +175,12 @@ class MessagesComposerTest < ApplicationSystemTestCase
     assert_at_bottom
     assert_scrolled_up { scroll_to find_messages.second }
 
-    height = input.native.property('clientHeight')
+    height = composer.native.property('clientHeight')
     assert_did_not_scroll do
       send_keys long_input_text
 
       assert_true "Input should have grown taller" do
-        input.native.property('clientHeight') > height
+        composer.native.property('clientHeight') > height
       end
     end
   end
@@ -226,10 +225,6 @@ class MessagesComposerTest < ApplicationSystemTestCase
   # TODO: We do not have a test for the smart paste. I'm not sure how to programmatically paste from within capybara
 
   private
-
-  def input
-    find(@input_selector)
-  end
 
   def long_input_text
     text = <<~END


### PR DESCRIPTION
* Ensure up-to-edit does not trigger when text is entered
Fixes #448 

* Fix issue with automatically clearing new composer text
Fixes #291 