### PR TITLE
Better support local dev - local DB documentation & env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,10 @@ Every time you pull new changes down, kill docker (if it's running) and re-run:
 HostedGPT requires these services to be running:
 
 - Postgres ([installation instructions](https://www.postgresql.org/download/))
-  - Default database username: `app`
-  - Default database password: `secret`
-  - Default dev database: `hostedgpt_development`
-  - Default test database: `hostedgpt_test`
-  - You can override via environment variables - see `config/database.yml`
-  - *Note that the docker compose workflow uses `DATABASE_URL` instead, which overrides anything in `config/database.yml`*
+  - Use environment variable `DATABASE_URL` to specify the connection parameters
+  - *Make sure to set that environment variable in your setup!*
+  - Recommended (development): `DATABASE_URL=postgres://app:secret@localhost/hostedgpt_development`
+  - Recommended (test): `DATABASE_URL=postgres://app:secret@localhost/hostedgpt_test`
 - rbenv ([installation instructions](https://github.com/rbenv/rbenv))
 - ImageMagick (`brew install imagemagick` should work on Mac )
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,8 @@ Every time you pull new changes down, kill docker (if it's running) and re-run:
 
 HostedGPT requires these services to be running:
 
-- Postgres ([installation instructions](https://www.postgresql.org/download/))
-  - Use environment variable `DATABASE_URL` to specify the connection parameters
-  - *Make sure to set that environment variable in your setup!*
-  - Recommended (development): `DATABASE_URL=postgres://app:secret@localhost/hostedgpt_development`
-  - Recommended (test): `DATABASE_URL=postgres://app:secret@localhost/hostedgpt_test`
+- Postgres (`brew install imagemagick` or other [install instructions](https://www.postgresql.org/download/))
+  - By default postgres will create a default user and following the instructions below to run the app should just work without any additional config, but if you want to set a specific username and password for your database then set the environment variable `DATABASE_URL=postgres://username:password@localhost/hostedgpt_development` (replacing `username`, `password`, and `hostedgpt_development` (database name) as appropriate
 - rbenv ([installation instructions](https://github.com/rbenv/rbenv))
 - ImageMagick (`brew install imagemagick` should work on Mac )
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Every time you pull new changes down, kill docker (if it's running) and re-run:
 
 HostedGPT requires these services to be running:
 
-- Postgres (`brew install imagemagick` or other [install instructions](https://www.postgresql.org/download/))
+- Postgres (`brew install postgresql@16` or other [install instructions](https://www.postgresql.org/download/))
   - By default postgres will create a default user and following the instructions below to run the app should just work without any additional config, but if you want to set a specific username and password for your database then set the environment variable `DATABASE_URL=postgres://username:password@localhost/hostedgpt_development` (replacing `username`, `password`, and `hostedgpt_development` (database name) as appropriate
 - rbenv ([installation instructions](https://github.com/rbenv/rbenv))
 - ImageMagick (`brew install imagemagick` should work on Mac )

--- a/README.md
+++ b/README.md
@@ -229,6 +229,12 @@ Every time you pull new changes down, kill docker (if it's running) and re-run:
 HostedGPT requires these services to be running:
 
 - Postgres ([installation instructions](https://www.postgresql.org/download/))
+  - Default database username: `app`
+  - Default database password: `secret`
+  - Default dev database: `hostedgpt_development`
+  - Default test database: `hostedgpt_test`
+  - You can override via environment variables - see `config/database.yml`
+  - *Note that the docker compose workflow uses `DATABASE_URL` instead, which overrides anything in `config/database.yml`*
 - rbenv ([installation instructions](https://github.com/rbenv/rbenv))
 - ImageMagick (`brew install imagemagick` should work on Mac )
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,18 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: localhost
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   port: <%= ENV['HOSTEDGPT_DATABASE_PORT'] || 5432 %>
-  username: <%= ENV['HOSTEDGPT_DB_USERNAME'] || "app" %>
-  password: <%= ENV["HOSTEDGPT_PB_PASSWORD"] || "secret" %>
 <% if RUBY_PLATFORM =~ /darwin/ %>
   gssencmode: disable
 <% end %>
+  url: <%= ENV['DATABASE_URL'] %>
 
 development:
   <<: *default
-  database: <%= ENV['HOSTEDGPT_DEV_DB'] || "hostedgpt_development" %>
 
 test:
   <<: *default
-  database: <%= ENV['HOSTEDGPT_TEST_DB'] || "hostedgpt_test" %>
 
 production:
   <<: *default
-  database: hostedgpt_production
-  username: hostedgpt
-  password: <%= ENV["HOSTEDGPT_DATABASE_PASSWORD"] %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,8 @@ default: &default
   host: localhost
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   port: <%= ENV['HOSTEDGPT_DATABASE_PORT'] || 5432 %>
+  username: <%= ENV['HOSTEDGPT_DB_USERNAME'] || "app" %>
+  password: <%= ENV["HOSTEDGPT_PB_PASSWORD"] || "secret" %>
 <% if RUBY_PLATFORM =~ /darwin/ %>
   gssencmode: disable
 <% end %>
@@ -21,4 +23,3 @@ production:
   database: hostedgpt_production
   username: hostedgpt
   password: <%= ENV["HOSTEDGPT_DATABASE_PASSWORD"] %>
-  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       target: development
     environment:
       # Be sure to add environment variables to config/options.yml
-      - DATABASE_URL=postgres://app:secret@postgres/app_development
+      - DATABASE_URL
       - DEV_HOST=${DEV_HOST:-localhost} # Set if you want to use a different hostname
       - OVERMIND_COLORS=2,3,5
       - VOICE_FEATURE


### PR DESCRIPTION
Update README to better document db setup for local dev, and update database.yml to support local username+password.

NOTE: This *does* change the default username + password for local (non-Docker) dev, so there's a potential compatibility issue there. Not sure if there's a good way around it?