### PR TITLE
Workaround: Overmind installing wrong binaries for aarch64-linux

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -7,6 +7,32 @@ if ! gem list overmind -i --silent; then
   gem install overmind
 fi
 
+# Check and fixup for overmind bug on aarch64-linux
+# Remove once #185 is fixed for overmind
+# https://github.com/DarthSim/overmind/issues/185
+RUBY_PLATFORM=$(ruby -e "puts Gem::Platform.local")
+if [[ $RUBY_PLATFORM == aarch64-linux* ]]; then
+
+  OVERMIND_DIR=$(ruby -e 'puts Gem::Specification.find_by_name("overmind").gem_dir')
+  OVERMIND_BIN=$(ruby -e 'puts Gem::bin_path("overmind", "overmind")')
+
+  # Probe the binary to see if it fails to execute
+  if ! "$OVERMIND_BIN" -v >/dev/null 2>&1 || ! "$OVERMIND_DIR/libexec/prebuilt-tmux/bin/tmux" -V >/dev/null 2>&1 ; then
+    echo "Overmind or tmux failed to excute correctly, perhaps wrong arch."
+    echo "WORKAROUND: Forcefully overwriting wrong overmind binaries for arm64 linux..."
+    wget -qO- https://github.com/DarthSim/overmind/releases/download/v2.5.1/overmind-v2.5.1-linux-arm64.gz | zcat > "$OVERMIND_DIR/libexec/overmind"
+    wget -qO- https://github.com/DarthSim/overmind/releases/download/v2.4.0/tmux-v3.4-linux-arm64.tar.gz | tar xvz -C "$OVERMIND_DIR/libexec/prebuilt-tmux"
+
+    # Confirm that our workaround works
+    if ! "$OVERMIND_BIN" -v >/dev/null 2>&1 || ! "$OVERMIND_DIR/libexec/prebuilt-tmux/bin/tmux" -V >/dev/null 2>&1; then
+      echo "Somehow the workaround for Overmind didn't work, either. Unable to proceed."
+      echo "Please visit https://github.com/AllYourBot/hostedgpt/discussions/406 to see if there is anything you can do."
+      exit 1
+    fi
+  fi
+fi
+
+
 bundle install
 bin/rails db:prepare
 


### PR DESCRIPTION
When we run on aarch64-linux*, overmind downloads and installs the wrong binary for the architecture. Detect if that's the case, and then download the correct binaries.

This originally came up when installing the app on a Raspberry Pi. An issue has been opened with the Overmind project: https://github.com/DarthSim/overmind/issues/185