### PR TITLE
Draft: Add token counting per message

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -101,6 +101,8 @@ class MessagesController < ApplicationController
       :cancelled_at,
       :branched,
       :branched_from_version,
+      :input_token_count,
+      :output_token_count,
       documents_attributes: [:file]
     )
     if modified_params.has_key?(:content_text) && modified_params[:content_text].blank?

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,5 @@
 class Message < ApplicationRecord
-  include DocumentImage, Version, Cancellable, Toolable
+  include DocumentImage, Version, Cancellable, Toolable, TokenCount
 
   belongs_to :assistant
   belongs_to :conversation

--- a/app/models/message/token_count.rb
+++ b/app/models/message/token_count.rb
@@ -1,0 +1,7 @@
+module Message::TokenCount
+  extend ActiveSupport::Concern
+  included do
+    attribute :input_token_count, :integer, default: 0
+    attribute :output_token_count, :integer, default: 0
+  end
+end

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -28,6 +28,15 @@ class AIBackend::Anthropic < AIBackend
 
     response_handler = proc do |intermediate_response, bytesize|
       chunk = intermediate_response.dig("delta", "text")
+
+      # input and output tokens are sent in different responses
+      if (input_tokens = intermediate_response.dig("message", "usage", "input_tokens"))
+        @message.input_token_count += input_tokens
+      end
+      if (output_tokens = intermediate_response.dig("message", "usage", "output_tokens"))
+        @message.output_token_count += output_tokens
+      end
+
       print chunk if Rails.env.development?
       if chunk
         stream_response_text += chunk

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -245,6 +245,24 @@ end
                 <% end %>
               </menu>
             </div>
+            <% if last_message %>
+              <% input_tokens = conversation.messages.sum(:input_token_count) %>
+              <% output_tokens = conversation.messages.sum(:output_token_count) %>
+
+              <div class="dropdown dropdown-top flex items-center ml-2">
+                <%= button_tag "$",
+                               tabindex: 0,
+                               role: :button,
+                               class: "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white",
+                               data: { role: "show-token-info" }
+                %>
+
+                <div tabindex="0" class="dropdown-content -ml-6 z-10 p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
+                  <p class="py-1 px-2 text-sm text-gray-700 dark:text-gray-300">Input tokens: <%= input_tokens %></p>
+                  <p class="py-1 px-2 text-sm text-gray-700 dark:text-gray-300">Output tokens: <%= output_tokens %></p>
+                </div>
+              </div>
+            <% end %>
           <% end %>
         </div>
       </turbo-frame>

--- a/db/migrate/20240713130357_add_token_counts_to_messages.rb
+++ b/db/migrate/20240713130357_add_token_counts_to_messages.rb
@@ -1,0 +1,6 @@
+class AddTokenCountsToMessages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :messages, :input_token_count, :integer, default: 0, null: false
+    add_column :messages, :output_token_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_100000) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_13_130357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -197,6 +197,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_100000) do
     t.integer "branched_from_version"
     t.jsonb "content_tool_calls"
     t.string "tool_call_id"
+    t.integer "input_token_count", default: 0, null: false
+    t.integer "output_token_count", default: 0, null: false
     t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
     t.index ["conversation_id", "index", "version"], name: "index_messages_on_conversation_id_and_index_and_version", unique: true


### PR DESCRIPTION
Implement token counting per message by using the returned usage stats from the LLM API backend. Anthropic sends token stats already by default. As for OpenAI, the stream needs to be first configured to return those.

- Add migration for new Message attributes input_token_count, output_token_count
- Add concern Message::TokenCount for Message model
- Implement capturing of returned token count from Anthropic & OpenAI and set Message attributes inside the async API-specific jobs. For OpenAI, configure the stream to return usage stats
- Add basic usage dropdown-menu beneath last message that shows the number of input/output tokens when clicked on the "$" sign. This is just a quick demo for the functionality and will likely be changed to something else


This MR is related to #402 