### PR TITLE
Refactor the conversation menu in the left nav

### DIFF
--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -12,10 +12,11 @@ class AutotitleConversationJob < ApplicationJob
     messages = conversation.messages.ordered.limit(4)
     raise ConversationNotReady  if messages.empty?
 
-    new_title = generate_title_for(messages.map(&:content_text).join("\n"))
+    Current.set(user: conversation.user) do
+      new_title = generate_title_for(messages.map(&:content_text).join("\n"))
+    end
     conversation.update!(title: new_title)
   end
-
 
   private
 

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -12,8 +12,8 @@ class AutotitleConversationJob < ApplicationJob
     messages = conversation.messages.ordered.limit(4)
     raise ConversationNotReady  if messages.empty?
 
-    Current.set(user: conversation.user) do
-      new_title = generate_title_for(messages.map(&:content_text).join("\n"))
+    new_title = Current.set(user: conversation.user) do
+      generate_title_for(messages.map(&:content_text).join("\n"))
     end
     conversation.update!(title: new_title)
   end

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -26,31 +26,12 @@
     %>
 
     <div class="items-center hidden gap-2 pl-2 relationship:flex group-hover:flex">
-      <%= link_to edit_conversation_path(conversation),
-        data: {
-          controller: "nested-pointer",
-          action: "nested-pointer#addParentClickable",
-          role: "edit"
-        },
-        class: %|
-          cursor-pointer
-          invisible group-hover:visible
-          hover:text-gray-600 dark:hover:text-gray-300
-      | do %>
-        <%= icon "pencil",
-          variant: :outline,
-          size: 16,
-          title: "Rename",
-          tooltip: :top
-        %>
-      <% end %>
-
       <div class="dropdown !inline-flex dropdown-end outline-none pr-2">
-        <%= icon "x-mark",
+        <%= icon "ellipsis-horizontal",
           tabindex: 0,
           role: :button,
-          variant: :outline,
-          size: 22,
+          variant: :micro,
+          size: 18,
           class: %|
             outline-none cursor-pointer group-hover:visible
             hover:text-gray-600 dark:hover:text-gray-300
@@ -58,18 +39,34 @@
           |,
           data: {
             controller: "nested-pointer",
-            role: "delete"
+            role: "options"
           },
-          title: "Delete",
+          title: "Options",
           tooltip: :top
         %>
 
         <menu tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 mt-7 dark:text-white dark:!bg-gray-700" data-controller="nested-pointer">
           <li>
+            <%= link_to edit_conversation_path(conversation),
+              data: {
+                role: "edit",
+              },
+              class: "flex gap-2 w-full py-2 px-4" do
+            %>
+              <%= icon "pencil",
+                variant: :outline,
+                size: 16,
+                title: "Rename",
+                tooltip: :top,
+                class: "mx-[1px]"
+              %>Rename
+            <% end %>
+          </li>
+          <li>
             <%= button_to conversation_path(conversation),
               method: :delete,
               data: {
-                role: "confirm-delete",
+                role: "delete",
               },
               form: {
                 class: "inline-block p-0",
@@ -80,6 +77,22 @@
               <%= icon "trash", variant: :outline, size: 18 %>Delete
             <% end %>
           </li>
+          <footer class="hidden py-3 px-4 mt-1 border-t-2 border-gray-100 dark:border-gray-600 gap-2 flex flex-col">
+            <table class="w-full text-left">
+              <tr>
+                <td class="pb-2 whitespace-nowrap">Conversation</td>
+                <td class="pb-2">$444.44</td>
+              </tr>
+              <tr>
+                <td class="pb-2">Input Tokens</td>
+                <td class="pb-2">100</td>
+              </tr>
+              <tr>
+                <td>Output Tokens</td>
+                <td>100</td>
+              </tr>
+            </table>
+          </footer>
         </menu>
       </div>
 

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -250,7 +250,6 @@
 
           <%= form.text_area :content_text,
             id: "composer-input",
-            placeholder: "RETURN to submit   ↑ to edit last message",
             data: {
               composer_target: "input",
               image_upload_target: "content",

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_24_100000) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_13_130357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -197,6 +197,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_24_100000) do
     t.integer "branched_from_version"
     t.jsonb "content_tool_calls"
     t.string "tool_call_id"
+    t.integer "input_token_count"
+    t.integer "output_token_count"
     t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
     t.index ["conversation_id", "index", "version"], name: "index_messages_on_conversation_id_and_index_and_version", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_13_130357) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -197,8 +197,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_13_130357) do
     t.integer "branched_from_version"
     t.jsonb "content_tool_calls"
     t.string "tool_call_id"
-    t.integer "input_token_count"
-    t.integer "output_token_count"
     t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
     t.index ["conversation_id", "index", "version"], name: "index_messages_on_conversation_id_and_index_and_version", unique: true

--- a/test/system/conversations_test.rb
+++ b/test/system/conversations_test.rb
@@ -6,14 +6,18 @@ class ConversationsTest < ApplicationSystemTestCase
     @starting_path = current_path
   end
 
-  test "edit icon shows a tooltip" do
+  test "options icon shows a tooltip" do
     convo = hover_conversation conversations(:greeting)
-    assert_shows_tooltip convo.find_role("edit"), "Rename"
+    assert_shows_tooltip convo.find_role("options"), "Options"
   end
 
-  test "clicking conversation edits icon enables edit, unfocusing submits it" do
+  test "clicking conversation edit option enables edit, unfocusing submits it" do
     convo = hover_conversation conversations(:greeting)
-    convo.find_role("edit").click
+    edit = convo.find_role("edit")
+
+    convo.find_role("options").click
+    assert_true { edit.visible? }
+    edit.click
 
     fill_in "edit-conversation", with: "Meeting Samantha Jones"
     find("body").click
@@ -25,7 +29,11 @@ class ConversationsTest < ApplicationSystemTestCase
 
   test "clicking conversation edits icon enables edit, pressing Enter submits it" do
     convo = hover_conversation conversations(:greeting)
-    convo.find_role("edit").click
+    edit = convo.find_role("edit")
+
+    convo.find_role("options").click
+    assert_true { edit.visible? }
+    edit.click
 
     fill_in "edit-conversation", with: "Meeting Samantha Jones"
     send_keys "enter"
@@ -37,7 +45,11 @@ class ConversationsTest < ApplicationSystemTestCase
 
   test "clicking conversation edits it and pressing Esc aborts the edit and does not save" do
     convo = hover_conversation conversations(:greeting)
-    convo.find_role("edit").click
+    edit = convo.find_role("edit")
+
+    convo.find_role("options").click
+    assert_true { edit.visible? }
+    edit.click
 
     fill_in "edit-conversation", with: "Meeting Samantha Jones"
     send_keys "esc"
@@ -47,19 +59,13 @@ class ConversationsTest < ApplicationSystemTestCase
     assert_equal "Meeting Samantha", conversations(:greeting).reload.title
   end
 
-  test "delete icon shows a tooltip" do
-    convo = hover_conversation conversations(:greeting)
-    assert_shows_tooltip convo.find_role("delete"), "Delete"
-  end
-
   test "clicking the conversation delete, when you ARE NOT on this conversation, deletes it and the url does not change" do
     convo = hover_conversation conversations(:greeting)
     delete = convo.find_role("delete")
-    confirm_delete = convo.find_role("confirm-delete")
 
+    convo.find_role("options").click
+    assert_true { delete.visible? }
     delete.click
-    assert_true { confirm_delete.visible? }
-    confirm_delete.click
 
     assert_toast "Deleted conversation"
     assert_current_path(@starting_path)
@@ -68,12 +74,12 @@ class ConversationsTest < ApplicationSystemTestCase
   test "clicking the conversation delete, when you ARE not on this conversation, deletes it and redirects you to a new conversation" do
     visit_and_scroll_wait conversation_messages_path(conversations(:greeting))
     convo = hover_conversation conversations(:greeting)
+    options = convo.find_role("options")
     delete = convo.find_role("delete")
-    confirm_delete = convo.find_role("confirm-delete")
 
+    options.click
+    assert_true { delete.visible? }
     delete.click
-    assert_true { confirm_delete.visible? }
-    confirm_delete.click
 
     assert_toast "Deleted conversation"
     assert_current_path new_assistant_message_path(users(:keith).assistants.ordered.first)


### PR DESCRIPTION
* Put all convo options in drop-down menu (no more separate edit icon)
* Add a section within the drop-down to show token information
* Fix bug with worker not setting conversation title
* Random fix: Move all composer placeholder setting to JS

The menu looks like this:
<img width="252" alt="image" src="https://github.com/user-attachments/assets/3bb943a4-5e0c-4f46-beab-bb6883a0ca02">
