### PR TITLE
Cleanup message partial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "pg", "~> 1.1"
 gem "puma", ">= 5.0"
 gem "importmap-rails" # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "turbo-rails", "~> 2.0.5"
-gem "stimulus-rails"
+gem "stimulus-rails", "~> 1.3.3"
 gem "tailwindcss-rails", "~> 2.6.0"
 gem "rack-cors"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,7 +360,7 @@ GEM
     standard-performance (1.2.1)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.19.1)
-    stimulus-rails (1.3.0)
+    stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
     sync (0.5.0)
@@ -446,7 +446,7 @@ DEPENDENCIES
   solid_queue (~> 0.2.1)
   sprockets-rails
   standard
-  stimulus-rails
+  stimulus-rails (~> 1.3.3)
   tailwindcss-rails (~> 2.6.0)
   tiktoken_ruby (~> 0.0.6)
   timecop

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -38,6 +38,27 @@ module MessagesHelper
     return html.html_safe
   end
 
+  def thinking_html(message, thinking)
+    span_tag("", class: %|
+      animate-breathe
+      w-3 h-3
+      rounded-full
+      bg-black dark:bg-white
+      inline-block
+      ml-1
+      #{!thinking && 'hidden'}
+    |) +
+    span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
+    icon("stop",
+      variant: :solid,
+      size: 17,
+      title: "Stopped",
+      tooltip: :top,
+      data: { role: "cancelled" },
+      class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
+    )
+  end
+
   private
 
   def block_code

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,6 +1,22 @@
 require "./lib/markdown_renderer"
 
 module MessagesHelper
+  def render_avatar_for(message)
+    if message.user?
+      render partial: "layouts/user_avatar",      locals: { user: Current.user,           size: 7, classes: "mt-1" }
+    else
+      render partial: "layouts/assistant_avatar", locals: { assistant: message.assistant, size: 7, classes: "mt-1" }
+    end
+  end
+
+  def from_name_for(message)
+    case message.role
+      when "user" then "You"
+      when "assistant" then message.assistant.name
+      when "tool" then "Tool"
+    end
+  end
+
   def format_for_copying(text)
     text
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,22 +1,16 @@
 import "@hotwired/turbo-rails"
-// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import("blocks").then(() => {
+  import("stimulus")
+})
 
+// Utilities for test environment
+window.imageLoadingForSystemTestsToCheck = {}
+window.logs = []
 
-// BEGIN debug code
-let oldTimestamp
-
+// Debug code
 // console.log('Document: refresh')
-// document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}`))
+// document.addEventListener('turbo:visit', (event) => console.log(`Document: visit ${event.detail.action}, path = ${window.location.pathname} vs ${event.detail.url}`))
 // document.addEventListener('turbo:morph', () => console.log('Document: morph render'))
 // document.addEventListener('turbo:before-morph-element', (e) => { if (document.getElementById('composer').contains(e.target)) console.log('Document: before-morph', e.target) })
 // document.addEventListener('turbo:frame-render', () => console.log('Document: frame render'))
 // document.addEventListener('turbo:before-stream-render', (event) => console.log(`Document: stream render (${event.target.getAttribute('action')} event)`, event.target, event.detail.newStream.querySelector('template').content?.firstChild?.nextSibling?.querySelector('[data-speaker-target="text assistantText"]')))
-
-window.imageLoadingForSystemTestsToCheck = {}
-window.logs = []
-// END debug code
-
-
-import("blocks").then(() => {
-  import("stimulus")
-})

--- a/app/javascript/stimulus/composer_controller.js
+++ b/app/javascript/stimulus/composer_controller.js
@@ -108,7 +108,11 @@ export default class extends Controller {
     Dismiss.Listener()
   }
 
-  disableMicrophone() {
+  userDisableMicrophone() {
+    this.disableMicrophone(true)
+  }
+
+  disableMicrophone(userClicked = false) {
     this.microphoneEnableTarget.classList.remove('hidden')
     this.microphoneDisableTarget.classList.add('hidden')
     this.enableComposer()

--- a/app/javascript/stimulus/permanent_value_controller.js
+++ b/app/javascript/stimulus/permanent_value_controller.js
@@ -2,7 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   connect() {
-    console.log('## connecting...')
     this.element.addEventListener('turbo:before-morph-element', this.boundSaveValue)
     this.element.addEventListener('turbo:morph-element', this.boundRestoreValue)
     this.savedValue = null

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -1,4 +1,8 @@
+include ActionView::RecordIdentifier
+require "nokogiri/xml/node"
+
 class GetNextAIMessageJob < ApplicationJob
+  include ActionView::Helpers::RenderingHelper
   class ResponseCancelled < StandardError; end
   class WaitForPrevious < StandardError; end
 
@@ -23,7 +27,7 @@ class GetNextAIMessageJob < ApplicationJob
 
     last_sent_at = Time.current
     @message.update!(processed_at: Time.current, content_text: "")
-    GetNextAIMessageJob.broadcast_updated_message(@message, thinking: true) # signal to user that we're waiting on API
+    GetNextAIMessageJob.broadcast_updated_message(@message, thinking: true) # thinking shows dot, signaling to user that we're waiting now on ai_backend
 
     puts "\n### Wait for reply" unless Rails.env.test?
 
@@ -111,11 +115,18 @@ class GetNextAIMessageJob < ApplicationJob
   end
 
   def self.broadcast_updated_message(message, locals = {})
-    message.broadcast_replace_to message.conversation, locals: {
-      only_scroll_down_if_was_bottom: true,
-      timestamp: (Time.current.to_f*1000).to_i,
-      streamed: true,
-    }.merge(locals)
+    html = ApplicationController.render(
+      partial: 'messages/message',
+      locals: {
+        message: message,
+        only_scroll_down_if_was_bottom: true,
+        streamed: true,
+        message_counter: message.index
+      }.merge(locals)
+    )
+    dom = Nokogiri::HTML.fragment(html)
+    html = dom.at_id(dom_id message).inner_html
+    message.broadcast_update_to message.conversation, target: message, html: html
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -26,7 +26,8 @@ class Message < ApplicationRecord
 
   scope :ordered, -> { latest_version_for_conversation }
 
-  def name
+  def name_for_api
+    # TODO: We should sanitize name within the database since we don't need to support crazy characters
     case role
     when "user" then user.first_name[/\A[a-zA-Z0-9_-]+/]
     when "assistant" then assistant.name[/\A[a-zA-Z0-9_-]+/]

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -95,13 +95,13 @@ class AIBackend::OpenAI < AIBackend
 
         {
           role: message.role,
-          name: message.name,
+          name: message.name_for_api,
           content: content_with_images,
         }.compact
       else
         {
           role: message.role,
-          name: message.name,
+          name: message.name_for_api,
           content: message.content_text,
           tool_calls: message.content_tool_calls, # only for some assistant messages
           tool_call_id: message.tool_call_id,     # only for tool messages

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -304,7 +304,7 @@
             <%= form.button type: "button",
               data: {
                 composer_target: "microphoneDisable",
-                action: "composer#disableMicrophone"
+                action: "composer#userDisableMicrophone"
               },
               id: "microphone-disable",
               class: %w|
@@ -398,7 +398,7 @@
           <div
             id="composer-overlay"
             data-composer-target="overlay"
-            data-action="click->composer#disableMicrophone"
+            data-action="click->composer#userDisableMicrophone"
             class="absolute inset-0 bg-white dark:bg-gray-800 !bg-opacity-65 hidden">
           </div>
 

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -25,8 +25,8 @@ end %>
   <div
     class="flex"
     data-role="inner-message"
-    data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
 
+    data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
     data-message-scroller-scroll-down-value="<%= scroll_down %>"
     data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
     data-message-scroller-instantly-value="<%= initial_page_load %>"

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -17,9 +17,15 @@ end %>
 
 <div
   id="<%= dom_id message %>"
+  class="flex mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
   data-role="message"
   data-subrole="<%= message.role %>-message"
-  class="flex mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
+
+  data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
+
+  data-message-scroller-scroll-down-value="<%= scroll_down %>"
+  data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
+  data-message-scroller-instantly-value="<%= initial_page_load %>"
 >
   <!-- Left Column -->
   <div class="w-6 ml-1 flex">
@@ -35,13 +41,8 @@ end %>
       clipboard
       transition
       <%= message.has_document_image? && "modal" %>
-      <%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>
     "
     data-transition-toggle-class="hidden"
-
-    data-message-scroller-scroll-down-value="<%= scroll_down %>"
-    data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
-    data-message-scroller-instantly-value="<%= initial_page_load %>"
   >
     <div class="mt-[6px] mb-1 font-semibold" data-role="from">
       <%= from_name_for(message) %>
@@ -65,58 +66,37 @@ end %>
       >
         <% if message.has_document_image? %>
           <%= button_tag type: "button",
-                class: "w-full h-auto flex focus:outline-none",
-                data: {
-                  controller: "image-loader",
-                  image_loader_message_scroller_outlet: "[data-role='message-contents']",
-                  image_loader_url_value: message.document_image_path(:small),
-                  action: "modal#open",
-                  role: "image-preview",
-                } do
-          %>
+            class: "w-full h-auto flex focus:outline-none",
+            data: {
+              role: "image-preview",
+              controller: "image-loader",
+              image_loader_message_scroller_outlet: "[data-role='message']",
+              image_loader_url_value: message.document_image_path(:small),
+              action: "modal#open",
+          } do %>
             <%= image_tag message.document_image_path(:small, fallback: ""),
-                  data: {
-                    image_loader_target: "image",
-                    action: %|
-                      error->image-loader#retryAfterDelay
-                      load->image-loader#show
-                    |
-                  },
-                  class: %|
-                    my-0
-                    mx-auto
-                    max-w-full
-                    border-2 border-gray-100 dark:border-gray-400
-                    rounded-md
-                  |,
-                  width: 1,
-                  height: 1
-            %>
+              class: %|
+                my-0
+                mx-auto
+                max-w-full
+                border-2 border-gray-100 dark:border-gray-400
+                rounded-md
+              |,
+              width: 1,
+              height: 1,
+              data: {
+                image_loader_target: "image",
+                action: %|
+                  error->image-loader#retryAfterDelay
+                  load->image-loader#show
+                |
+            } %>
             <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
               <%= spinner size: 6, class: "text-black dark:text-white" %>
             </div>
           <% end %>
         <% end %>
-        <%= formatted_text = format_for_display message.content_text,
-              append_inside_tag: span_tag("", class: %|
-                animate-breathe
-                w-3 h-3
-                rounded-full
-                bg-black dark:bg-white
-                inline-block
-                ml-1
-                #{!thinking && 'hidden'}
-              |) +
-              span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
-              icon("stop",
-                variant: :solid,
-                size: 17,
-                title: "Stopped",
-                tooltip: :top,
-                data: { role: "cancelled" },
-                class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
-              )
-        %>
+        <%= formatted_text = format_for_display message.content_text, append_inside_tag: thinking_html(message, thinking) %>
       </div>
 
       <% if debug_tool_messages && message.content_tool_calls.present? %>
@@ -185,16 +165,16 @@ end %>
           <% end %>
         <% elsif message.assistant? && message.assistant.not_deleted? %>
           <%= button_tag type: "button",
-                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
-                data: {
-                  role: "clipboard",
-                  action: %|
-                    clipboard#copy
-                    transition#toggleClassOn
-                    mouseleave->transition#toggleClassOff
-                  |,
-                  keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
-                  # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
+            class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
+            data: {
+              role: "clipboard",
+              action: %|
+                clipboard#copy
+                transition#toggleClassOn
+                mouseleave->transition#toggleClassOff
+              |,
+              keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
+              # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
           } do %>
             <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
             <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
@@ -218,10 +198,6 @@ end %>
                     form_class: "inline-block p-0",
                     class: "truncate w-full py-2 px-4 text-left",
                     method: :post,
-                    data: {
-                      turbo_frame: "_top",
-                      turbo_action: "replace",
-                    },
                     params: { message: {
                       conversation_id: conversation.id,
                       assistant_id: assistant.id,
@@ -229,8 +205,11 @@ end %>
                       index: message.index,
                       branched: true,
                       branched_from_version: message.version
-                    } } do
-                  %>
+                    } },
+                    data: {
+                      turbo_frame: "_top",
+                      turbo_action: "replace",
+                  } do %>
                     Using <%= assistant.name %>
                   <% end %>
                 </li>
@@ -245,22 +224,20 @@ end %>
       <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
         <main class="modal-box max-w-5xl p-0 rounded-none">
           <article
+            class="flex flex-col md:flex-row justify-center"
             data-controller="image-loader"
             data-image-loader-message-scroller-outlet="[data-role='message']"
             data-image-loader-url-value="<%= message.document_image_path(:large) %>"
             data-turbo-permanent
-            class="flex flex-col md:flex-row justify-center"
           >
             <%= image_tag message.document_image_path(:large, fallback: ""),
+              class: "w-full h-auto",
               data: {
                 image_loader_target: "image",
                 action: %|
                   error->image-loader#retryAfterDelay
                   load->image-loader#show
-                |
-              },
-              class: "w-full h-auto"
-            %>
+            | } %>
             <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
               <%= spinner size: 6, class: "text-black dark:text-white" %>
             </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,276 +1,274 @@
-<%# locals: (message:, scroll_down: false, only_scroll_down_if_was_bottom: false, request_id: nil, timestamp: nil, thinking: nil, streamed: false, message_counter: -1) -%>
+<%# locals: (message:, request_id: nil, scroll_down: false, only_scroll_down_if_was_bottom: false, thinking: nil, streamed: false, message_counter: -1) -%>
 <%# request_id is not used, but broadcasting turbo stream messages provides it as a local so it needs to be accepted %>
 
 <% conversation = message.conversation %>
 <% conversation_version = streamed ? message.version : @version %>
-<% max_index = conversation.messages.for_conversation_version(conversation_version).count - 1 %>
-<% last_message = message_counter == max_index %>
-<% initial_page_load = last_message && !scroll_down %>
-<% scroll_down = scroll_down || initial_page_load %>
-<% thinking ||= last_message && message.content_text == "" && message.not_cancelled? %>
-<% last_message_done = last_message && !thinking && message.content_text.present? %>
-<% debug_tool = false %>
-<%
-if message.versions.present?
+<% if message.versions.present?
   previous_version  = message.versions.push(nil)[ message.versions.index(message.version)-1 ]
   next_version      = message.versions.push(nil)[ message.versions.index(message.version)+1 ]
-end
-%>
+end %>
+<% max_index = conversation.messages.for_conversation_version(conversation_version).count - 1 %>
+<% last_message = message_counter == max_index %>
+<% initial_page_load = last_message && !scroll_down # this value is only accurate when rendering last_message %>
+<% scroll_down = scroll_down || initial_page_load %>
+<% thinking ||= last_message && message.content_text == "" && message.not_cancelled? %>
+<% done_thinking = !thinking && message.content_text.present? %>
+<% debug_tool_messages = false %>
 
 <div
   id="<%= dom_id message %>"
-  class="mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool && "hidden" %>"
   data-role="message"
-  data-timestamp="<%= timestamp %>"
-  data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
-  data-message-scroller-scroll-down-value="<%= scroll_down %>"
-  data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
-  data-message-scroller-instantly-value="<%= initial_page_load %>"
+  data-subrole="<%= message.role %>-message"
+  class="flex mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
 >
-  <div class="flex">
-    <!-- Left Column -->
-    <div class="w-6 ml-1 flex">
-      <%= render_avatar_for(message) %>
+  <!-- Left Column -->
+  <div class="w-6 ml-1 flex">
+    <%= render_avatar_for(message) %>
+  </div>
+
+  <!-- Right Column -->
+  <div
+    id="message-contents-<%= message.id %>"
+    class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
+    data-controller="
+      clipboard
+      transition
+      <%= message.has_document_image? && "modal" %>
+      <%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>
+    "
+    data-transition-toggle-class="hidden"
+
+    data-message-scroller-scroll-down-value="<%= scroll_down %>"
+    data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
+    data-message-scroller-instantly-value="<%= initial_page_load %>"
+  >
+    <div class="mt-[6px] mb-1 font-semibold" data-role="from">
+      <%= from_name_for(message) %>
     </div>
 
-    <!-- Right Column -->
-    <div
-      data-controller="
-        clipboard
-        transition
-        <%= message.has_document_image? && "modal" %>
-      "
-      data-transition-toggle-class="hidden"
-      class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100">
+    <turbo-frame id="message-text-<%= message.id %>">
 
-      <div class="mt-[6px] mb-1 font-semibold" data-role="from">
-        <%= from_name_for(message) %>
+      <div
+        class="hidden"
+        data-clipboard-target="text"
+      ><%= format_for_copying message.content_text %></div>
+      <div
+        class="hidden"
+        data-speaker-target="text <%= message.assistant? ? "assistantText" : "userText" %>"
+        data-thinking="<%= thinking ? "true" : "false" %>"
+      ><%= format_for_speaking message.content_text %></div>
+
+      <div
+        data-role="content-text"
+        class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
+      >
+        <% if message.has_document_image? %>
+          <%= button_tag type: "button",
+                class: "w-full h-auto flex focus:outline-none",
+                data: {
+                  controller: "image-loader",
+                  image_loader_message_scroller_outlet: "[data-role='message']",
+                  image_loader_url_value: message.document_image_path(:small),
+                  action: "modal#open",
+                  role: "image-preview",
+                } do
+          %>
+            <%= image_tag message.document_image_path(:small, fallback: ""),
+                  data: {
+                    image_loader_target: "image",
+                    action: %|
+                      error->image-loader#retryAfterDelay
+                      load->image-loader#show
+                    |
+                  },
+                  class: %|
+                    my-0
+                    mx-auto
+                    max-w-full
+                    border-2 border-gray-100 dark:border-gray-400
+                    rounded-md
+                  |,
+                  width: 1,
+                  height: 1
+            %>
+            <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
+              <%= spinner size: 6, class: "text-black dark:text-white" %>
+            </div>
+          <% end %>
+        <% end %>
+        <%= formatted_text = format_for_display message.content_text,
+              append_inside_tag: span_tag("", class: %|
+                animate-breathe
+                w-3 h-3
+                rounded-full
+                bg-black dark:bg-white
+                inline-block
+                ml-1
+                #{!thinking && 'hidden'}
+              |) +
+              span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
+              icon("stop",
+                variant: :solid,
+                size: 17,
+                title: "Stopped",
+                tooltip: :top,
+                data: { role: "cancelled" },
+                class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
+              )
+        %>
       </div>
 
-      <turbo-frame id="message-text-<%= message.id %>">
-
-        <div
-          class="hidden"
-          data-clipboard-target="text"
-        ><%= format_for_copying message.content_text %></div>
-        <div
-          class="hidden"
-          data-speaker-target="text <%= message.assistant? ? "assistantText" : "userText" %>"
-          data-thinking="<%= thinking ? "true" : "false" %>"
-        ><%= format_for_speaking message.content_text %></div>
-
+      <% if debug_tool_messages && message.content_tool_calls.present? %>
         <div
           data-role="content-text"
           class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
         >
-          <% if message.has_document_image? %>
-            <%= button_tag type: "button",
-                  class: "w-full h-auto flex focus:outline-none",
-                  data: {
-                    controller: "image-loader",
-                    image_loader_message_scroller_outlet: "[data-role='message']",
-                    image_loader_url_value: message.document_image_path(:small),
-                    action: "modal#open",
-                    role: "image-preview",
-                  } do
-            %>
-              <%= image_tag message.document_image_path(:small, fallback: ""),
-                    data: {
-                      image_loader_target: "image",
-                      action: %|
-                        error->image-loader#retryAfterDelay
-                        load->image-loader#show
-                      |
-                    },
-                    class: %|
-                      my-0
-                      mx-auto
-                      max-w-full
-                      border-2 border-gray-100 dark:border-gray-400
-                      rounded-md
-                    |,
-                    width: 1,
-                    height: 1
-              %>
-              <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
-                <%= spinner size: 6, class: "text-black dark:text-white" %>
-              </div>
-            <% end %>
-          <% end %>
-          <%= formatted_text = format_for_display message.content_text,
-                append_inside_tag: span_tag("", class: %|
-                  animate-breathe
-                  w-3 h-3
-                  rounded-full
-                  bg-black dark:bg-white
-                  inline-block
-                  ml-1
-                  #{!thinking && 'hidden'}
-                |) +
-                span_tag(" ...", class: (message.content_text.blank? || message.not_cancelled?) && 'hidden') +
-                icon("stop",
-                  variant: :solid,
-                  size: 17,
-                  title: "Stopped",
-                  tooltip: :top,
-                  data: { role: "cancelled" },
-                  class: "inline-block pl-1 #{message.not_cancelled? && 'hidden'}"
-                )
-          %>
+          <%= formatted_text = format "```\n#{message.content_tool_calls}\n```" %>
         </div>
+      <% end %>
 
-        <% if debug_tool && message.content_tool_calls.present? %>
-          <div
-            data-role="content-text"
-            class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
-          >
-            <%= formatted_text = format "```\n#{message.content_tool_calls}\n```" %>
-          </div>
+      <div class="
+        flex justify-start
+        gap-2
+        text-gray-600 dark:text-gray-300
+        <%= !last_message && done_thinking && 'invisible' %> group-hover:visible
+      ">
+        <% if message.versions.length > 1 %>
+          <%= button_to message_path(message, version: previous_version),
+            method: :patch,
+            params: { message: { id: message.id } },
+            class: "-ml-1 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
+            disabled: previous_version.nil?,
+            form: {
+              class: "flex items-center",
+              data: {
+                turbo_frame: "_top",
+                turbo_action: "replace",
+              }
+            },
+            data: {
+              role: "previous",
+          } do %>
+            <%= icon "chevron-left", variant: :micro, title: previous_version.present? && "Previous", data: { } %>
+          <% end %>
+
+          v<%= message.version %>
+          <%= button_to message_path(message, version: next_version),
+            method: :patch,
+            params: { message: { id: message.id } },
+            class: "mr-2 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
+            disabled: next_version.nil?,
+            form: {
+              class: "flex items-center",
+              data: {
+                turbo_frame: "_top",
+                turbo_action: "replace",
+              }
+            },
+            data: {
+              role: "next",
+          } do %>
+            <%= icon "chevron-right", variant: :micro, title: next_version.present? && "Next", data: { } %>
+          <% end %>
         <% end %>
 
-        <div class="
-          flex justify-start
-          gap-2
-          text-gray-600 dark:text-gray-300
-          <%= !last_message_done && 'invisible' %> group-hover:visible
-        ">
-          <% if message.versions.length > 1 %>
-            <%= button_to message_path(message, version: previous_version),
-              method: :patch,
-              params: { message: { id: message.id } },
-              class: "-ml-1 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
-              disabled: previous_version.nil?,
-              form: {
-                class: "flex items-center",
-                data: {
-                  turbo_frame: "_top",
-                  turbo_action: "replace",
-                }
-              },
-              data: {
-                role: "previous",
+        <% if message.user? && message.assistant.not_deleted? && !message.has_document_image? %>
+          <%= link_to edit_assistant_message_path(message.assistant, message),
+            class: "cursor-pointer hover:text-gray-900 dark:hover:text-white flex items-center",
+            data: {
+              role: "message-edit",
+              composer_target: "messageEdit",
+              turbo_frame: "message-text-#{message.id}",
             } do %>
-              <%= icon "chevron-left", variant: :micro, title: previous_version.present? && "Previous", data: { } %>
-            <% end %>
-
-            v<%= message.version %>
-            <%= button_to message_path(message, version: next_version),
-              method: :patch,
-              params: { message: { id: message.id } },
-              class: "mr-2 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
-              disabled: next_version.nil?,
-              form: {
-                class: "flex items-center",
-                data: {
-                  turbo_frame: "_top",
-                  turbo_action: "replace",
-                }
-              },
-              data: {
-                role: "next",
-            } do %>
-              <%= icon "chevron-right", variant: :micro, title: next_version.present? && "Next", data: { } %>
-            <% end %>
+            <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
           <% end %>
-
-          <% if message.user? && message.assistant.not_deleted? && !message.has_document_image? %>
-            <%= link_to edit_assistant_message_path(message.assistant, message),
-              class: "cursor-pointer hover:text-gray-900 dark:hover:text-white flex items-center",
-              data: {
-                role: "message-edit",
-                composer_target: "messageEdit",
-                turbo_frame: "message-text-#{message.id}",
-              } do %>
-              <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
-            <% end %>
-          <% elsif message.assistant? && message.assistant.not_deleted? %>
-            <%= button_tag type: "button",
-                  class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
-                  data: {
-                    role: "clipboard",
-                    action: %|
-                      clipboard#copy
-                      transition#toggleClassOn
-                      mouseleave->transition#toggleClassOff
-                    |,
-                    keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
-                    # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
-            } do %>
-              <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
-              <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
-            <% end %>
-
-            <div class="dropdown dropdown-top flex items-center">
-              <%= icon "arrow-path",
-                tabindex: 0,
-                role: :button,
-                variant: :outline,
-                size: 18,
-                title: "Regenerate",
-                data: { role: "regenerate" }
-              %>
-
-              <menu tabindex="0" class="dropdown-content -ml-6 z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
-                <% message.user.assistants.ordered.excluding(message.assistant).to_a.push(message.assistant).each do |assistant| %>
-                  <% last = message.assistant == assistant %>
-                  <li class="overflow-hidden <%= 'border-t border-gray-200 dark:border-gray-500 pt-1 mt-1' if last %>">
-                    <%= button_to assistant_messages_path(assistant),
-                      form_class: "inline-block p-0",
-                      class: "truncate w-full py-2 px-4 text-left",
-                      method: :post,
-                      data: {
-                        turbo_frame: "_top",
-                        turbo_action: "replace",
-                      },
-                      params: { message: {
-                        conversation_id: conversation.id,
-                        assistant_id: assistant.id,
-                        role: "assistant",
-                        index: message.index,
-                        branched: true,
-                        branched_from_version: message.version
-                      } } do
-                    %>
-                      Using <%= assistant.name %>
-                    <% end %>
-                  </li>
-                <% end %>
-              </menu>
-            </div>
-          <% end %>
-        </div>
-      </turbo-frame>
-
-      <% if message.has_document_image? %>
-        <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
-          <main class="modal-box max-w-5xl p-0 rounded-none">
-            <article
-              data-controller="image-loader"
-              data-image-loader-message-scroller-outlet="[data-role='message']"
-              data-image-loader-url-value="<%= message.document_image_path(:large) %>"
-              data-turbo-permanent
-              class="flex flex-col md:flex-row justify-center"
-            >
-              <%= image_tag message.document_image_path(:large, fallback: ""),
+        <% elsif message.assistant? && message.assistant.not_deleted? %>
+          <%= button_tag type: "button",
+                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
                 data: {
-                  image_loader_target: "image",
+                  role: "clipboard",
                   action: %|
-                    error->image-loader#retryAfterDelay
-                    load->image-loader#show
-                  |
-                },
-                class: "w-full h-auto"
-              %>
-              <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
-                <%= spinner size: 6, class: "text-black dark:text-white" %>
-              </div>
-            </article>
-          </main>
-          <form method="dialog" class="modal-backdrop no-focus-outline">
-            <button id="modal-backdrop">close</button>
-          </form>
-        </dialog>
-      <% end %>
-    </div>
+                    clipboard#copy
+                    transition#toggleClassOn
+                    mouseleave->transition#toggleClassOff
+                  |,
+                  keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
+                  # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
+          } do %>
+            <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
+            <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
+          <% end %>
+
+          <div class="dropdown dropdown-top flex items-center">
+            <%= icon "arrow-path",
+              tabindex: 0,
+              role: :button,
+              variant: :outline,
+              size: 18,
+              title: "Regenerate",
+              data: { role: "regenerate" }
+            %>
+
+            <menu tabindex="0" class="dropdown-content -ml-6 z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
+              <% message.user.assistants.ordered.excluding(message.assistant).to_a.push(message.assistant).each do |assistant| %>
+                <% last = message.assistant == assistant %>
+                <li class="overflow-hidden <%= 'border-t border-gray-200 dark:border-gray-500 pt-1 mt-1' if last %>">
+                  <%= button_to assistant_messages_path(assistant),
+                    form_class: "inline-block p-0",
+                    class: "truncate w-full py-2 px-4 text-left",
+                    method: :post,
+                    data: {
+                      turbo_frame: "_top",
+                      turbo_action: "replace",
+                    },
+                    params: { message: {
+                      conversation_id: conversation.id,
+                      assistant_id: assistant.id,
+                      role: "assistant",
+                      index: message.index,
+                      branched: true,
+                      branched_from_version: message.version
+                    } } do
+                  %>
+                    Using <%= assistant.name %>
+                  <% end %>
+                </li>
+              <% end %>
+            </menu>
+          </div>
+        <% end %>
+      </div>
+    </turbo-frame>
+
+    <% if message.has_document_image? %>
+      <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
+        <main class="modal-box max-w-5xl p-0 rounded-none">
+          <article
+            data-controller="image-loader"
+            data-image-loader-message-scroller-outlet="[data-role='message']"
+            data-image-loader-url-value="<%= message.document_image_path(:large) %>"
+            data-turbo-permanent
+            class="flex flex-col md:flex-row justify-center"
+          >
+            <%= image_tag message.document_image_path(:large, fallback: ""),
+              data: {
+                image_loader_target: "image",
+                action: %|
+                  error->image-loader#retryAfterDelay
+                  load->image-loader#show
+                |
+              },
+              class: "w-full h-auto"
+            %>
+            <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
+              <%= spinner size: 6, class: "text-black dark:text-white" %>
+            </div>
+          </article>
+        </main>
+        <form method="dialog" class="modal-backdrop no-focus-outline">
+          <button id="modal-backdrop">close</button>
+        </form>
+      </dialog>
+    <% end %>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -17,236 +17,242 @@ end %>
 
 <div
   id="<%= dom_id message %>"
-  class="flex mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
+  class="mb-5 ml-9 sm:ml-3 md:ml-8 group <%= message.only_tool_response? && !debug_tool_messages && "hidden" %>"
   data-role="message"
   data-subrole="<%= message.role %>-message"
+> <!-- this outer div persists throughout streaming updates -->
 
-  data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
-
-  data-message-scroller-scroll-down-value="<%= scroll_down %>"
-  data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
-  data-message-scroller-instantly-value="<%= initial_page_load %>"
->
-  <!-- Left Column -->
-  <div class="w-6 ml-1 flex">
-    <%= render_avatar_for(message) %>
-  </div>
-
-  <!-- Right Column -->
   <div
-    id="message-contents-<%= message.id %>"
-    data-role="message-contents"
-    class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
-    data-controller="
-      clipboard
-      transition
-      <%= message.has_document_image? && "modal" %>
-    "
-    data-transition-toggle-class="hidden"
-  >
-    <div class="mt-[6px] mb-1 font-semibold" data-role="from">
-      <%= from_name_for(message) %>
+    class="flex"
+    data-role="inner-message"
+    data-controller="<%= (scroll_down || only_scroll_down_if_was_bottom) && "message-scroller" %>"
+
+    data-message-scroller-scroll-down-value="<%= scroll_down %>"
+    data-message-scroller-only-scroll-down-if-scrolled-to-bottom-value="<%= only_scroll_down_if_was_bottom %>"
+    data-message-scroller-instantly-value="<%= initial_page_load %>"
+  > <!-- this inner div is replaced during streaming updates (inner_html of dom_id message) -->
+
+    <!-- Left Column -->
+    <div class="w-6 ml-1 flex">
+      <%= render_avatar_for(message) %>
     </div>
 
-    <turbo-frame id="message-text-<%= message.id %>">
-
-      <div
-        class="hidden"
-        data-clipboard-target="text"
-      ><%= format_for_copying message.content_text %></div>
-      <div
-        class="hidden"
-        data-speaker-target="text <%= message.assistant? ? "assistantText" : "userText" %>"
-        data-thinking="<%= thinking ? "true" : "false" %>"
-      ><%= format_for_speaking message.content_text %></div>
-
-      <div
-        data-role="content-text"
-        class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
-      >
-        <% if message.has_document_image? %>
-          <%= button_tag type: "button",
-            class: "w-full h-auto flex focus:outline-none",
-            data: {
-              role: "image-preview",
-              controller: "image-loader",
-              image_loader_message_scroller_outlet: "[data-role='message']",
-              image_loader_url_value: message.document_image_path(:small),
-              action: "modal#open",
-          } do %>
-            <%= image_tag message.document_image_path(:small, fallback: ""),
-              class: %|
-                my-0
-                mx-auto
-                max-w-full
-                border-2 border-gray-100 dark:border-gray-400
-                rounded-md
-              |,
-              width: 1,
-              height: 1,
-              data: {
-                image_loader_target: "image",
-                action: %|
-                  error->image-loader#retryAfterDelay
-                  load->image-loader#show
-                |
-            } %>
-            <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
-              <%= spinner size: 6, class: "text-black dark:text-white" %>
-            </div>
-          <% end %>
-        <% end %>
-        <%= formatted_text = format_for_display message.content_text, append_inside_tag: thinking_html(message, thinking) %>
+    <!-- Right Column -->
+    <div
+      id="message-contents-<%= message.id %>"
+      data-role="message-contents"
+      class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
+      data-controller="
+        clipboard
+        transition
+        <%= message.has_document_image? && "modal" %>
+      "
+      data-transition-toggle-class="hidden"
+    >
+      <div class="mt-[6px] mb-1 font-semibold" data-role="from">
+        <%= from_name_for(message) %>
       </div>
 
-      <% if debug_tool_messages && message.content_tool_calls.present? %>
+      <turbo-frame id="message-text-<%= message.id %>">
+
+        <div
+          class="hidden"
+          data-clipboard-target="text"
+        ><%= format_for_copying message.content_text %></div>
+        <div
+          class="hidden"
+          data-speaker-target="text <%= message.assistant? ? "assistantText" : "userText" %>"
+          data-thinking="<%= thinking ? "true" : "false" %>"
+        ><%= format_for_speaking message.content_text %></div>
+
         <div
           data-role="content-text"
           class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
         >
-          <%= formatted_text = format "```\n#{message.content_tool_calls}\n```" %>
-        </div>
-      <% end %>
-
-      <div class="
-        flex justify-start
-        gap-2
-        text-gray-600 dark:text-gray-300
-        <%= !last_message && done_thinking && 'invisible' %> group-hover:visible
-      ">
-        <% if message.versions.length > 1 %>
-          <%= button_to message_path(message, version: previous_version),
-            method: :patch,
-            params: { message: { id: message.id } },
-            class: "-ml-1 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
-            disabled: previous_version.nil?,
-            form: {
-              class: "flex items-center",
+          <% if message.has_document_image? %>
+            <%= button_tag type: "button",
+              class: "w-full h-auto flex focus:outline-none",
               data: {
-                turbo_frame: "_top",
-                turbo_action: "replace",
-              }
-            },
-            data: {
-              role: "previous",
-          } do %>
-            <%= icon "chevron-left", variant: :micro, title: previous_version.present? && "Previous", data: { } %>
-          <% end %>
-
-          v<%= message.version %>
-          <%= button_to message_path(message, version: next_version),
-            method: :patch,
-            params: { message: { id: message.id } },
-            class: "mr-2 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
-            disabled: next_version.nil?,
-            form: {
-              class: "flex items-center",
-              data: {
-                turbo_frame: "_top",
-                turbo_action: "replace",
-              }
-            },
-            data: {
-              role: "next",
-          } do %>
-            <%= icon "chevron-right", variant: :micro, title: next_version.present? && "Next", data: { } %>
-          <% end %>
-        <% end %>
-
-        <% if message.user? && message.assistant.not_deleted? && !message.has_document_image? %>
-          <%= link_to edit_assistant_message_path(message.assistant, message),
-            class: "cursor-pointer hover:text-gray-900 dark:hover:text-white flex items-center",
-            data: {
-              role: "message-edit",
-              composer_target: "messageEdit",
-              turbo_frame: "message-text-#{message.id}",
+                role: "image-preview",
+                controller: "image-loader",
+                image_loader_message_scroller_outlet: "[data-role='inner-message']",
+                image_loader_url_value: message.document_image_path(:small),
+                action: "modal#open",
             } do %>
-            <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
+              <%= image_tag message.document_image_path(:small, fallback: ""),
+                class: %|
+                  my-0
+                  mx-auto
+                  max-w-full
+                  border-2 border-gray-100 dark:border-gray-400
+                  rounded-md
+                |,
+                width: 1,
+                height: 1,
+                data: {
+                  image_loader_target: "image",
+                  action: %|
+                    error->image-loader#retryAfterDelay
+                    load->image-loader#show
+                  |
+              } %>
+              <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
+                <%= spinner size: 6, class: "text-black dark:text-white" %>
+              </div>
+            <% end %>
           <% end %>
-        <% elsif message.assistant? && message.assistant.not_deleted? %>
-          <%= button_tag type: "button",
-            class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
-            data: {
-              role: "clipboard",
-              action: %|
-                clipboard#copy
-                transition#toggleClassOn
-                mouseleave->transition#toggleClassOff
-              |,
-              keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
-              # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
-          } do %>
-            <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
-            <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
-          <% end %>
+          <%= formatted_text = format_for_display message.content_text, append_inside_tag: thinking_html(message, thinking) %>
+        </div>
 
-          <div class="dropdown dropdown-top flex items-center">
-            <%= icon "arrow-path",
-              tabindex: 0,
-              role: :button,
-              variant: :outline,
-              size: 18,
-              title: "Regenerate",
-              data: { role: "regenerate" }
-            %>
-
-            <menu tabindex="0" class="dropdown-content -ml-6 z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
-              <% message.user.assistants.ordered.excluding(message.assistant).to_a.push(message.assistant).each do |assistant| %>
-                <% last = message.assistant == assistant %>
-                <li class="overflow-hidden <%= 'border-t border-gray-200 dark:border-gray-500 pt-1 mt-1' if last %>">
-                  <%= button_to assistant_messages_path(assistant),
-                    form_class: "inline-block p-0",
-                    class: "truncate w-full py-2 px-4 text-left",
-                    method: :post,
-                    params: { message: {
-                      conversation_id: conversation.id,
-                      assistant_id: assistant.id,
-                      role: "assistant",
-                      index: message.index,
-                      branched: true,
-                      branched_from_version: message.version
-                    } },
-                    data: {
-                      turbo_frame: "_top",
-                      turbo_action: "replace",
-                  } do %>
-                    Using <%= assistant.name %>
-                  <% end %>
-                </li>
-              <% end %>
-            </menu>
+        <% if debug_tool_messages && message.content_tool_calls.present? %>
+          <div
+            data-role="content-text"
+            class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
+          >
+            <%= formatted_text = format "```\n#{message.content_tool_calls}\n```" %>
           </div>
         <% end %>
-      </div>
-    </turbo-frame>
 
-    <% if message.has_document_image? %>
-      <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
-        <main class="modal-box max-w-5xl p-0 rounded-none">
-          <article
-            class="flex flex-col md:flex-row justify-center"
-            data-controller="image-loader"
-            data-image-loader-message-scroller-outlet="[data-role='message']"
-            data-image-loader-url-value="<%= message.document_image_path(:large) %>"
-            data-turbo-permanent
-          >
-            <%= image_tag message.document_image_path(:large, fallback: ""),
-              class: "w-full h-auto",
+        <div class="
+          flex justify-start
+          gap-2
+          text-gray-600 dark:text-gray-300
+          <%= !last_message && done_thinking && 'invisible' %> group-hover:visible
+        ">
+          <% if message.versions.length > 1 %>
+            <%= button_to message_path(message, version: previous_version),
+              method: :patch,
+              params: { message: { id: message.id } },
+              class: "-ml-1 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
+              disabled: previous_version.nil?,
+              form: {
+                class: "flex items-center",
+                data: {
+                  turbo_frame: "_top",
+                  turbo_action: "replace",
+                }
+              },
               data: {
-                image_loader_target: "image",
+                role: "previous",
+            } do %>
+              <%= icon "chevron-left", variant: :micro, title: previous_version.present? && "Previous", data: { } %>
+            <% end %>
+
+            v<%= message.version %>
+            <%= button_to message_path(message, version: next_version),
+              method: :patch,
+              params: { message: { id: message.id } },
+              class: "mr-2 cursor-pointer hover:text-gray-900 dark:hover:text-white disabled:opacity-25",
+              disabled: next_version.nil?,
+              form: {
+                class: "flex items-center",
+                data: {
+                  turbo_frame: "_top",
+                  turbo_action: "replace",
+                }
+              },
+              data: {
+                role: "next",
+            } do %>
+              <%= icon "chevron-right", variant: :micro, title: next_version.present? && "Next", data: { } %>
+            <% end %>
+          <% end %>
+
+          <% if message.user? && message.assistant.not_deleted? && !message.has_document_image? %>
+            <%= link_to edit_assistant_message_path(message.assistant, message),
+              class: "cursor-pointer hover:text-gray-900 dark:hover:text-white flex items-center",
+              data: {
+                role: "message-edit",
+                composer_target: "messageEdit",
+                turbo_frame: "message-text-#{message.id}",
+              } do %>
+              <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
+            <% end %>
+          <% elsif message.assistant? && message.assistant.not_deleted? %>
+            <%= button_tag type: "button",
+              class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
+              data: {
+                role: "clipboard",
                 action: %|
-                  error->image-loader#retryAfterDelay
-                  load->image-loader#show
-            | } %>
-            <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
-              <%= spinner size: 6, class: "text-black dark:text-white" %>
+                  clipboard#copy
+                  transition#toggleClassOn
+                  mouseleave->transition#toggleClassOff
+                |,
+                keyboard_target: formatted_text.present? && formatted_text.exclude?('keyboard-target') ? "keyboardable" : nil,
+                # ^ ensure the keyboard shortcut is only attached if there is text && if this text does not contain a code block
+            } do %>
+              <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
+              <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
+            <% end %>
+
+            <div class="dropdown dropdown-top flex items-center">
+              <%= icon "arrow-path",
+                tabindex: 0,
+                role: :button,
+                variant: :outline,
+                size: 18,
+                title: "Regenerate",
+                data: { role: "regenerate" }
+              %>
+
+              <menu tabindex="0" class="dropdown-content -ml-6 z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 dark:!bg-gray-700">
+                <% message.user.assistants.ordered.excluding(message.assistant).to_a.push(message.assistant).each do |assistant| %>
+                  <% last = message.assistant == assistant %>
+                  <li class="overflow-hidden <%= 'border-t border-gray-200 dark:border-gray-500 pt-1 mt-1' if last %>">
+                    <%= button_to assistant_messages_path(assistant),
+                      form_class: "inline-block p-0",
+                      class: "truncate w-full py-2 px-4 text-left",
+                      method: :post,
+                      params: { message: {
+                        conversation_id: conversation.id,
+                        assistant_id: assistant.id,
+                        role: "assistant",
+                        index: message.index,
+                        branched: true,
+                        branched_from_version: message.version
+                      } },
+                      data: {
+                        turbo_frame: "_top",
+                        turbo_action: "replace",
+                    } do %>
+                      Using <%= assistant.name %>
+                    <% end %>
+                  </li>
+                <% end %>
+              </menu>
             </div>
-          </article>
-        </main>
-        <form method="dialog" class="modal-backdrop no-focus-outline">
-          <button id="modal-backdrop">close</button>
-        </form>
-      </dialog>
-    <% end %>
+          <% end %>
+        </div>
+      </turbo-frame>
+
+      <% if message.has_document_image? %>
+        <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
+          <main class="modal-box max-w-5xl p-0 rounded-none">
+            <article
+              class="flex flex-col md:flex-row justify-center"
+              data-controller="image-loader"
+              data-image-loader-message-scroller-outlet="[data-role='inner-message']"
+              data-image-loader-url-value="<%= message.document_image_path(:large) %>"
+              data-turbo-permanent
+            >
+              <%= image_tag message.document_image_path(:large, fallback: ""),
+                class: "w-full h-auto",
+                data: {
+                  image_loader_target: "image",
+                  action: %|
+                    error->image-loader#retryAfterDelay
+                    load->image-loader#show
+              | } %>
+              <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
+                <%= spinner size: 6, class: "text-black dark:text-white" %>
+              </div>
+            </article>
+          </main>
+          <form method="dialog" class="modal-backdrop no-focus-outline">
+            <button id="modal-backdrop">close</button>
+          </form>
+        </dialog>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -29,6 +29,7 @@ end %>
   <!-- Right Column -->
   <div
     id="message-contents-<%= message.id %>"
+    data-role="message-contents"
     class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100"
     data-controller="
       clipboard
@@ -67,7 +68,7 @@ end %>
                 class: "w-full h-auto flex focus:outline-none",
                 data: {
                   controller: "image-loader",
-                  image_loader_message_scroller_outlet: "[data-role='message']",
+                  image_loader_message_scroller_outlet: "[data-role='message-contents']",
                   image_loader_url_value: message.document_image_path(:small),
                   action: "modal#open",
                   role: "image-preview",

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -28,12 +28,9 @@ end
   data-message-scroller-instantly-value="<%= initial_page_load %>"
 >
   <div class="flex">
-    <div class="flex flex-col items-center w-6 ml-1">
-      <% if message.user? %>
-        <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "mt-1" } %>
-      <% else %>
-        <%= render partial: "layouts/assistant_avatar", locals: { assistant: message.assistant, size: 7, classes: "mt-1" } %>
-      <% end %>
+    <!-- Left Column -->
+    <div class="w-6 ml-1 flex">
+      <%= render_avatar_for(message) %>
     </div>
 
     <!-- Right Column -->
@@ -47,15 +44,10 @@ end
       class="flex-1 min-w-0 ml-3 mr-8 text-base text-gray-950 dark:text-gray-100">
 
       <div class="mt-[6px] mb-1 font-semibold" data-role="from">
-        <%= case message.role
-          when "user" then "You"
-          when "assistant" then message.assistant.name
-          when "tool" then "Tool"
-          end
-        %>
+        <%= from_name_for(message) %>
       </div>
 
-      <turbo-frame id="message-<%= message.id %>">
+      <turbo-frame id="message-text-<%= message.id %>">
 
         <div
           class="hidden"
@@ -187,7 +179,7 @@ end
               data: {
                 role: "message-edit",
                 composer_target: "messageEdit",
-                turbo_frame: "message-#{message.id}",
+                turbo_frame: "message-text-#{message.id}",
               } do %>
               <%= icon "pencil", variant: :outline, size: 18, title: "Edit" %>
             <% end %>

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">Editing message</h1>
 
-  <turbo-frame id="message-<%= @message.id %>">
+  <turbo-frame id="message-text-<%= @message.id %>">
     <%= form_with(
       model: [@assistant, @new_message],
       class: "content-text",

--- a/lib/nokogiri/xml/node.rb
+++ b/lib/nokogiri/xml/node.rb
@@ -1,0 +1,5 @@
+class Nokogiri::XML::Node
+  def at_id(id)
+    at_css("##{id}")
+  end
+end

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -341,7 +341,7 @@ claude_replying:
 claude_age:
   assistant: keith_claude3
   conversation: hello_claude
-  role: assistant
+  role: user
   content_text: How old are you?
   content_document:
   run:

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -50,11 +50,11 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal h, Message.new.content_tool_calls
   end
 
-  test "name returns a properly formatted string" do
-    assert_equal users(:keith).first_name, messages(:hear_me).name
-    assert_equal "Samantha", messages(:yes_i_do).name
-    assert_equal "OpenAI", messages(:popstate_event).name # strips off non-alphanumeric
-    assert_nil messages(:weather_tool_result).name
+  test "name_for_api returns a properly formatted string" do
+    assert_equal users(:keith).first_name, messages(:hear_me).name_for_api
+    assert_equal "Samantha", messages(:yes_i_do).name_for_api
+    assert_equal "OpenAI", messages(:popstate_event).name_for_api # strips off non-alphanumeric
+    assert_nil messages(:weather_tool_result).name_for_api
   end
 
   test "finished? returns true if processed and missing either content_text or content_tool_calls" do


### PR DESCRIPTION
In preparation for some voice refactoring that I'm doing, this PR cleans up the message partial. Notable changes:

* The key change is that the message-scroller stimulus controller that exists per message (within _message partial) needs to be reconnected each time the partial updates with a streaming response. However, in the next PR I'm going to land, there is a new playback stimulus controller which should NOT reconnect each time the partial updates. The _message partial already has an outer most div and an inner div. Currently, both are replaced each time we do `broadcast_turbo_replace` so I change this to be `broadcast_turbo_update` in the worker. Replace does the whole div whereas update does the innerHTML of the div. I then move the existing message-scroller to the inner div.
* Move some _message logic into message_helper
* Version bump stimulus rails
* Rename a method in composer_controller for clarity
* Rename a method in message.rb for clarity