### PR TITLE
Cloudflare R2 file storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "tiktoken_ruby", "~> 0.0.6"
 gem "solid_queue", "~> 0.2.1"
 gem "name_of_person"
 gem "actioncable-enhanced-postgresql-adapter" # longer paylaods w/ postgresql actioncable
+gem "aws-sdk-s3", require: false
 
 gem "omniauth", "~> 2.1"
 gem "omniauth-google-oauth2", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,22 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.956.0)
+    aws-sdk-core (3.201.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.88.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.156.0)
+      aws-sdk-core (~> 3, >= 3.201.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.7)
@@ -142,6 +158,7 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.7.1)
     jwt (2.8.1)
       base64
@@ -416,6 +433,7 @@ DEPENDENCIES
   actioncable-enhanced-postgresql-adapter
   amatch (~> 0.4.1)
   anthropic (~> 0.1.0)
+  aws-sdk-s3
   bcrypt (~> 3.1.7)
   bootsnap
   byebug

--- a/README.md
+++ b/README.md
@@ -115,6 +115,31 @@ The file `options.yml` contains a number of Features and Settings you can config
 - `VOICE_FEATURE` - This is an experimental feature to have spoken conversation with your assistant. It's still a bit buggy but it's coming along.
 - `GOOGLE_TOOLS_FEATURE` — This is an experimental feature that enables your assistant to access your Gmail (and soon Google Tasks and Calendar).
 
+Additionally, certain features can only be configured with environment variables. These are:
+
+- `CLOUDFLARE_STORAGE_FEATURE` - This is a feature that allows you to store message attachments in Cloudflare's R2 storage. By default this is false, but you can set it to `true` to enable it. You must configure Cloudflare first for it to work.
+
+### Configuring Cloudflare Storage
+
+First you need to sign up for Cloudflare. The free tier allows 10 GB of storage. After you sign up, you need to create a new bucket and an API token. The API token should have "Object Read and Write" access to your bucket. Take note of your Access Key ID and your Secret Access Key along with your Account ID. Set the following environment variables:
+
+- `CLOUDFLARE_ACCOUNT_ID` - Your Cloudflare Account ID
+- `CLOUDFLARE_ACCESS_KEY_ID` - Your Cloudflare Access Key ID
+- `CLOUDFLARE_SECRET_ACCESS_KEY` - Your Cloudflare Secret Access Key
+- `CLOUDFLARE_BUCKET` - The name of the bucket you created
+
+or you can add these to your Rails credentials file:
+
+```yaml
+cloudflare:
+  account_id: "your-account-id"
+  access_key_id: "your-access-key-id"
+  secret_access_key: "your-secret-access-key"
+  bucket: "your-bucket-name"
+```
+
+Then be sure to set the `CLOUDFLARE_STORAGE_FEATURE` environment variable to `true`.
+
 ### Configuring Google Tools
 
 You first need to follow all the steps in the [Google OAuth instructions](#google-oauth-authentication). The only step that is optional is that you can leave `GOOGLE_AUTHENTICATION_FEATURE` set to false, which means you don't have to enable new users to register with Google. However, following all the steps will also set up Google Auth so you can connect Google Tools to your assistants. After, you complete those steps, here is the additional configuration you need to do in order to enable the Google tools:

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,13 @@ module HostedGPT
     config.time_zone = "Central Time (US & Canada)"
     config.eager_load_paths << Rails.root.join("lib")
 
+    # Active Storage
+    if ENV["CLOUDFLARE_STORAGE_FEATURE"] == "true"
+      config.active_storage.service = :cloudflare
+    else
+      config.active_storage.service = :local
+    end
+
     config.options = config_for(:options)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,9 +34,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
-  config.active_storage.variant_processor = :mini_magick # vips is better but does not work on Mac Apple Silicon so using this in dev & test
+  # vips is better but does not work on Mac Apple Silicon so using this in dev & test
+  config.active_storage.variant_processor = :mini_magick
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,8 +36,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
   # config.active_storage.variant_processor = :mini_magick  vips is the default, it's better and faster, but this means prod is different than dev
 
   # Mount Action Cable outside main process or domain.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,9 +36,10 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Store uploaded files on the local file system in a temporary directory.
+  # Store uploaded files in the db for testing
   config.active_storage.service = :test
-  config.active_storage.variant_processor = :mini_magick # vips is better but does not work on Mac Apple Silicon so using this in dev & test
+  # vips is better but does not work on Mac Apple Silicon so using this in dev & test
+  config.active_storage.variant_processor = :mini_magick
 
   config.action_mailer.perform_caching = false
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,3 +7,11 @@ local:
 local_public:
   service: Postgresql
   public: true # the generated URLs will not expire
+
+cloudflare:
+  service: S3
+  endpoint: https://<%= ENV["CLOUDFLARE_ACCOUNT_ID"] || Rails.application.credentials.dig(:cloudflare, :account_id) %>.r2.cloudflarestorage.com
+  access_key_id: <%= ENV["CLOUDFLARE_ACCESS_KEY_ID"] || Rails.application.credentials.dig(:cloudflare, :access_key_id) %>
+  secret_access_key: <%= ENV["CLOUDFLARE_SECRET_ACCESS_KEY"] || Rails.application.credentials.dig(:cloudflare, :secret_access_key) %>
+  region: auto
+  bucket: <%= ENV["CLOUDFLARE_BUCKET"] || Rails.application.credentials.dig(:cloudflare, :bucket) %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       POSTGRES_PASSWORD: secret
     volumes:
     - hostedgpt_pgdata:/var/lib/postgresql/data
+    ports:
+    - 5433:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "app", "-d", "app_development"]
       interval: 1s
@@ -42,6 +44,11 @@ services:
       - HTTP_HEADER_AUTH_EMAIL
       - HTTP_HEADER_AUTH_NAME
       - HTTP_HEADER_AUTH_UID
+      - CLOUDFLARE_STORAGE_FEATURE=true
+      - CLOUDFLARE_ACCOUNT_ID
+      - CLOUDFLARE_ACCESS_KEY_ID
+      - CLOUDFLARE_SECRET_ACCESS_KEY
+      - CLOUDFLARE_BUCKET
     ports: ["3000:3000"]
     volumes:
       - .:/rails


### PR DESCRIPTION
Adds Cloudflare R2 as option for storing files with Active Storage.

Task from here: https://github.com/AllYourBot/hostedgpt/wiki/Draft-project-plan

```
Changing ActiveStorage config from Postgres to Cloudflare's S3 alternative. Regardless of what we learn from our load test, we need to get these big files out of the database)
```

Starting this as an optional change, but happy to modify this to make it a requirement or change it to be the default if we want.