### PR TITLE
Allow configuring production host via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You may want to read about [configuring optional features](#configure-optional-f
 
 There are a number of optional feature flags that can be set and settings that can be configured. All of these can be seen in the file `options.yml`, however each is explained below and can be activated by setting environment variables.
 
+- `PRODUCTION_HOST` is blank but you should ideally set this if you are deploying the app with a public domain to protect against host header attacks. For example, set it to `example.com` (leave off https). You may add multiple host names separated by comma, `example.fly.dev, example.com` (whitespace is ignored).
 - `REGISTRATON_FEATURE` is `true` by default, but you can set to `false` to prevent any new people from creating an account.
 - `DEFAULT_LLM_KEYS` is `false` by default so each user is expected to add LLM API keys to their user settings. Set this to `true` if you want to configure LLM API keys that will be shared by all users. Set one or more of the additional variables in order to use this feature. The app will still check if the user has added their own API keys for any services and will use those instead of the default ones.
   - `DEFAULT_OPENAI_KEY` will be used by the pre-configured OpenAI API Service

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,6 +92,8 @@ Rails.application.configure do
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
   # ]
+  config.hosts = ENV["PRODUCTION_HOST"].split(",").map(&:strip) if ENV["PRODUCTION_HOST"]
+
   # Skip DNS rebinding protection for the default health check endpoint.
   config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
It's a good practice to set the config.hosts (within production.rb), but currently this cannot be done without someone diverging their fork from main. This allows it to be set with an PRODUCTION_HOST env.