### PR TITLE
UI: Show conversation vertical scrollbar

### DIFF
--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -108,7 +108,7 @@
     data-speaker-playback-outlet="[data-subrole='assistant-message']"
     data-scrollable-not-bottom-class="!block"
   >
-    <div id="messages" class="relative flex-grow overflow-y-auto overflow-x-clip scrollbar-hide overscroll-contain" data-scrollable-target="scrollable" data-action="scroll->scrollable#scrolled">
+    <div id="messages" class="relative flex-grow overflow-y-auto overscroll-contain" data-scrollable-target="scrollable" data-action="scroll->scrollable#scrolled">
       <div id="messages-container" class="w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px] mx-auto mt-2">
         <%= yield :messages %>
       </div>


### PR DESCRIPTION
Showing the vertical scrollbar:
- Improves navigation in long conversations
- Aligns with ChatGPT and Claude.ai interfaces (so provides familiarities with new users who just switched over)
- Removes need for excessive middle-mouse scrolling

Previously, scrolling to the start of long conversations was cumbersome without a visible scrollbar.