### PR TITLE
Eliminate "Live API" warnings when test suite runs

### DIFF
--- a/app/services/sdk/verb.rb
+++ b/app/services/sdk/verb.rb
@@ -128,6 +128,9 @@ class SDK::Verb
   end
 
   def possible_test_warning(verb)
-    puts "WARNING: live API call in test. USE: stub_#{verb}_response(:#{@calling_method}, status: ___, response: _______) do; ...; end" if Rails.env.test?
+    return if !Rails.env.test?
+    return if self.class.send("allow_#{verb}_#{@calling_method}") rescue false
+
+    puts "WARNING: live API call in test. USE: stub_#{verb}_response(:#{@calling_method}, status: ___, response: _______) do; ...; end"
   end
 end

--- a/test/services/toolbox/open_meteo_test.rb
+++ b/test/services/toolbox/open_meteo_test.rb
@@ -26,12 +26,20 @@ class Toolbox::OpenMeteoTest < ActiveSupport::TestCase
   end
 
   test "get_current_and_todays_weather hits the API and doesn't fail" do
-    result = @open_meteo.get_current_and_todays_weather(city_s: "Austin", state_province_or_region_s: "Texas")
-    assert result.values.all? { |value| value.present? }
+    allow_request(:get, :get_location) do
+      allow_request(:get, :get_current_and_todays_weather) do
+        result = @open_meteo.get_current_and_todays_weather(city_s: "Austin", state_province_or_region_s: "Texas")
+        assert result.values.all? { |value| value.present? }
+      end
+    end
   end
 
   test "get_current_and_todays_weather works as a tool call" do
-    result = Toolbox.call("openmeteo_get_current_and_todays_weather", city: "Austin", state_province_or_region: "Texas")
-    assert result.values.all? { |value| value.present? }
+    allow_request(:get, :get_location) do
+      allow_request(:get, :get_current_and_todays_weather) do
+        result = Toolbox.call("openmeteo_get_current_and_todays_weather", city: "Austin", state_province_or_region: "Texas")
+        assert result.values.all? { |value| value.present? }
+      end
+    end
   end
 end

--- a/test/support/sdk_helper.rb
+++ b/test/support/sdk_helper.rb
@@ -2,6 +2,14 @@ module SDKHelpers
 
   private
 
+  def allow_request(verb, method)
+    stubbed_method = "allow_#{verb}_#{method}"
+    SDK::Verb.define_singleton_method(stubbed_method) { {} }
+    SDK::Verb.stub stubbed_method, true do
+      yield
+    end
+  end
+
   def stub_response(verb, method, status:, response: {}, &block)
     stubbed_method = "mocked_response_#{verb}_#{method}"
 


### PR DESCRIPTION
Add an explicit assertion to allow live API calls in a test. If this assertion is in place it suppresses the warning.