### PR TITLE
Eliminate final two warning messages when tests are running

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "puma", ">= 5.0"
 gem "importmap-rails" # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
 gem "turbo-rails", "~> 2.0.5"
 gem "stimulus-rails", "~> 1.3.3"
-gem "tailwindcss-rails", "~> 2.6.0"
+gem "tailwindcss-rails", "~> 2.7.2"
 gem "rack-cors"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
@@ -35,7 +35,7 @@ gem "bootsnap", require: false
 gem "redcarpet", "~> 3.6.0"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.13.0"
 gem "amatch", "~> 0.4.1" # enables fuzzy comparison of strings, a tool uses this
 gem "rails_heroicon", "~> 2.2.0"
 gem "ruby-openai", "~> 7.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,13 +141,16 @@ GEM
     faraday-multipart (1.0.4)
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
-    ffi (1.16.3)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
-    image_processing (1.12.2)
+    image_processing (1.13.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
     importmap-rails (1.2.3)
@@ -176,7 +179,7 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.0.0)
-    mini_magick (4.12.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.22.3)
     minitest-stub_any_instance (1.0.3)
@@ -350,8 +353,9 @@ GEM
       faraday (>= 1)
       faraday-multipart (>= 1)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.0)
+    ruby-vips (2.2.2)
       ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     ruby_parser (3.21.0)
       racc (~> 1.5)
@@ -393,13 +397,13 @@ GEM
       railties (>= 6.0.0)
     stringio (3.1.0)
     sync (0.5.0)
-    tailwindcss-rails (2.6.0-aarch64-linux)
+    tailwindcss-rails (2.7.2-aarch64-linux)
       railties (>= 7.0.0)
-    tailwindcss-rails (2.6.0-arm64-darwin)
+    tailwindcss-rails (2.7.2-arm64-darwin)
       railties (>= 7.0.0)
-    tailwindcss-rails (2.6.0-x86_64-darwin)
+    tailwindcss-rails (2.7.2-x86_64-darwin)
       railties (>= 7.0.0)
-    tailwindcss-rails (2.6.0-x86_64-linux)
+    tailwindcss-rails (2.7.2-x86_64-linux)
       railties (>= 7.0.0)
     thor (1.3.1)
     tiktoken_ruby (0.0.6-aarch64-linux)
@@ -452,7 +456,7 @@ DEPENDENCIES
   capybara
   debug
   dockerfile-rails (>= 1.6)
-  image_processing (~> 1.2)
+  image_processing (~> 1.13.0)
   importmap-rails
   minitest-stub_any_instance
   name_of_person
@@ -479,7 +483,7 @@ DEPENDENCIES
   sprockets-rails
   standard
   stimulus-rails (~> 1.3.3)
-  tailwindcss-rails (~> 2.6.0)
+  tailwindcss-rails (~> 2.7.2)
   tiktoken_ruby (~> 0.0.6)
   timecop
   turbo-rails (~> 2.0.5)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,7 +8,11 @@ class Setting
 
     def method_missing(method_name, *arguments, &block)
       if settings.keys.exclude?(method_name.to_sym)
-        abort "ERROR: no setting found for #{method_name}. Please check settings in options.yml"
+        if ENV["RAILS_ENV"] == "test"
+          abort
+        else
+          abort "ERROR: no setting found for #{method_name}. Please check settings in options.yml"
+        end
       end
 
       ActiveRecord::Type::ImmutableString.new.cast(


### PR DESCRIPTION
@jlvallelonga I was annoyed with a variety of warning messages while tests run. I merged in a couple PRs that fix them, this is the last of them. Now when tests run locally it should be just a row of green dots. :)