### PR TITLE
adds ability to add exceptions for logging filters

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,8 +1,30 @@
 # Be sure to restart your server when you modify this file.
 
+def filter_regexp(filter_key, exemptions = [])
+  filter_key_pattern = Regexp.escape(filter_key.to_s)
+
+  # Join the exemptions array into a pattern for negative look-ahead
+  unless exemptions.empty?
+    exemptions_pattern = exemptions.map { |exemption| Regexp.escape(exemption.to_s) }.join("|")
+    pattern = "^(?!.*(?:#{exemptions_pattern})).*(#{filter_key_pattern}).*$"
+  else
+    pattern = ".*(#{filter_key_pattern}).*"
+  end
+
+  Regexp.new(pattern)
+end
+
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+  :passw,
+  :secret,
+  :_key,
+  :crypt,
+  :salt,
+  :certificate,
+  :otp,
+  :ssn,
+  filter_regexp(:token, [:token_count, :token_cost]),
 ]


### PR DESCRIPTION
before:
```
Rails.application.config.filter_parameters += [
  ...
  :token
]
```

->

```
 input_token_count: "[FILTERED]",
 output_token_count: "[FILTERED]",
 input_token_cost: "[FILTERED]",
 output_token_cost: "[FILTERED]",
```

after:

```
Rails.application.config.filter_parameters += [
  ...
  filter_regexp(:token, [:token_count, :token_cost]),
]
```
 ->

```
 input_token_count: 0,
 output_token_count: 0,
 input_token_cost: 0.0,
 output_token_cost: 0.0,
```
