### PR TITLE
Bump rubocop TargetRubyVersion: 3.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.3
   # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
   # to ignore them, so only the ones explicitly set in this file are enabled.
   DisabledByDefault: true

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -50,7 +50,7 @@ class Message < ApplicationRecord
   private
 
   def create_conversation
-    self.conversation = Conversation.create!(user: Current.user, assistant: assistant)
+    self.conversation = Conversation.create!(user: Current.user, assistant:)
   end
 
   def validate_conversation
@@ -62,12 +62,12 @@ class Message < ApplicationRecord
   end
 
   def start_assistant_reply
-    m = conversation.messages.create!(
-      assistant: assistant,
+    conversation.messages.create!(
+      assistant:,
       role: :assistant,
       content_text: nil,
-      version: version,
-      index: index+1
+      version:,
+      index: index + 1
     )
   end
 
@@ -77,7 +77,7 @@ class Message < ApplicationRecord
 
   def update_assistant_on_conversation
     return if conversation.assistant == assistant
-    conversation.update!(assistant: assistant)
+    conversation.update!(assistant:)
   end
 
   def update_input_token_cost

--- a/app/models/user/registerable.rb
+++ b/app/models/user/registerable.rb
@@ -54,13 +54,13 @@ module User::Registerable
       output_token_cost_cents = output_token_cost_per_million/million
 
       language_models.create!(
-        api_name: api_name,
-        api_service: api_service,
-        name: name,
+        api_name:,
+        api_service:,
+        name:,
         supports_tools: true,
-        supports_images: supports_images,
-        input_token_cost_cents: input_token_cost_cents,
-        output_token_cost_cents: output_token_cost_cents,
+        supports_images:,
+        input_token_cost_cents:,
+        output_token_cost_cents:,
       )
     end
 
@@ -73,7 +73,7 @@ module User::Registerable
       input_token_cost_cents = input_token_cost_per_million/million
       output_token_cost_cents = output_token_cost_per_million/million
 
-      language_models.create!(api_name: api_name, api_service: api_service, name: name, supports_tools: false, supports_images: supports_images, input_token_cost_cents: input_token_cost_cents, output_token_cost_cents: output_token_cost_cents)
+      language_models.create!(api_name:, api_service:, name:, supports_tools: false, supports_images:, input_token_cost_cents:, output_token_cost_cents:)
     end
 
     assistants.create! name: "GPT-4o", language_model: language_models.find_by(api_name: LanguageModel::BEST_GPT)


### PR DESCRIPTION
Also, start upgrading syntax to use implicit variables in named parameters

Note, we could also bump rubocop related gems; but my environment cannot install ffi 1.15.5; so I'm a bit stuck touching `Gemfile.lock`