### PR TITLE
Dynamic "best" Language Model

### DIFF
--- a/app/controllers/settings/language_models_controller.rb
+++ b/app/controllers/settings/language_models_controller.rb
@@ -3,7 +3,7 @@ class Settings::LanguageModelsController < Settings::ApplicationController
   before_action :set_system_language_model, only: [:show]
 
   def index
-    @language_models = LanguageModel.for_user(Current.user).order(updated_at: :desc)
+    @language_models = LanguageModel.for_user(Current.user).ordered
   end
 
   def edit

--- a/app/controllers/settings/language_models_controller.rb
+++ b/app/controllers/settings/language_models_controller.rb
@@ -53,6 +53,6 @@ class Settings::LanguageModelsController < Settings::ApplicationController
   end
 
   def language_model_params
-    params.require(:language_model).permit(:api_name, :name, :supports_images, :supports_tools, :api_service_id)
+    params.require(:language_model).permit(:api_name, :name, :best, :supports_images, :supports_tools, :api_service_id)
   end
 end

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -1,27 +1,5 @@
 # We don"t care about large or not
 class LanguageModel < ApplicationRecord
-  BEST_GPT = "gpt-best"
-  BEST_CLAUDE = "claude-best"
-  BEST_GROQ = "groq-best"
-
-  BEST_MODELS = {
-    BEST_GPT => "gpt-4o-2024-08-06",
-    BEST_CLAUDE => "claude-3-5-sonnet-20240620",
-    BEST_GROQ => "llama3-70b-8192",
-  }
-
-  BEST_MODEL_INPUT_PRICES = {
-    BEST_GPT => 250,
-    BEST_CLAUDE => 300,
-    BEST_GROQ => 59,
-  }
-
-  BEST_MODEL_OUTPUT_PRICES = {
-    BEST_GPT => 1000,
-    BEST_CLAUDE => 1500,
-    BEST_GROQ => 79,
-  }
-
   belongs_to :user
   belongs_to :api_service
 
@@ -36,12 +14,9 @@ class LanguageModel < ApplicationRecord
 
   scope :ordered, -> { order(:position) }
   scope :for_user, ->(user) { where(user_id: user.id).not_deleted }
+  scope :best_for_api_service, ->(api_service) { where(best: true, api_service: api_service) }
 
   delegate :ai_backend, to: :api_service
-
-  def provider_name
-    BEST_MODELS[api_name] || api_name
-  end
 
   def created_by_current_user?
     user == Current.user

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -13,7 +13,7 @@ class LanguageModel < ApplicationRecord
   before_save :soft_delete_assistants, if: -> { has_attribute?(:deleted_at) && deleted_at && deleted_at_changed? && deleted_at_was.nil? }
   after_save :update_best_language_model_for_api_service
 
-  scope :ordered, -> { order(:position) }
+  scope :ordered, -> { order(Arel.sql("CASE WHEN best THEN 0 ELSE position END")).order(:position) }
   scope :for_user, ->(user) { where(user_id: user.id).not_deleted }
   scope :best_for_api_service, ->(api_service) { where(best: true, api_service: api_service) }
 

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -11,6 +11,7 @@ class LanguageModel < ApplicationRecord
   validates :api_name, :name, :position, presence: true
 
   before_save :soft_delete_assistants, if: -> { has_attribute?(:deleted_at) && deleted_at && deleted_at_changed? && deleted_at_was.nil? }
+  after_save :update_best_language_model_for_api_service
 
   scope :ordered, -> { order(:position) }
   scope :for_user, ->(user) { where(user_id: user.id).not_deleted }
@@ -35,5 +36,13 @@ class LanguageModel < ApplicationRecord
 
   def soft_delete_assistants
     assistants.update_all(deleted_at: Time.current)
+  end
+
+  # Only one best language model per API service
+  def update_best_language_model_for_api_service
+    if best?
+      api_service.language_models.update_all(best: false)
+      update_column(:best, true)
+    end
   end
 end

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -14,6 +14,6 @@ class Run < ApplicationRecord
   private
 
   def set_model
-    self.model = assistant&.language_model&.provider_name
+    self.model = assistant&.language_model&.api_name
   end
 end

--- a/app/models/user/registerable.rb
+++ b/app/models/user/registerable.rb
@@ -12,11 +12,8 @@ module User::Registerable
     anthropic_api_service = api_services.create!(url: APIService::URL_ANTHROPIC, driver: :anthropic, name: "Anthropic")
     groq_api_service = api_services.create!(url: APIService::URL_GROQ, driver: :openai, name: "Groq")
 
+    best_models = %w[gpt-4o claude-3-5-sonnet-20240620 llama3-70b-8192]
     [
-      [LanguageModel::BEST_GPT, "Best OpenAI Model", true, open_ai_api_service, LanguageModel::BEST_MODEL_INPUT_PRICES[LanguageModel::BEST_GPT], LanguageModel::BEST_MODEL_OUTPUT_PRICES[LanguageModel::BEST_GPT]],
-      [LanguageModel::BEST_CLAUDE, "Best Anthropic Model", true, anthropic_api_service, LanguageModel::BEST_MODEL_INPUT_PRICES[LanguageModel::BEST_CLAUDE], LanguageModel::BEST_MODEL_OUTPUT_PRICES[LanguageModel::BEST_CLAUDE]],
-      [LanguageModel::BEST_GROQ, "Best Open-Source Model", true, groq_api_service, LanguageModel::BEST_MODEL_INPUT_PRICES[LanguageModel::BEST_GROQ], LanguageModel::BEST_MODEL_OUTPUT_PRICES[LanguageModel::BEST_GROQ]],
-
       ["gpt-4o", "GPT-4o (latest)", true, open_ai_api_service, 250, 1000],
       ["gpt-4o-2024-08-06", "GPT-4o Omni Multimodal (2024-08-06)", true, open_ai_api_service, 250, 1000],
       ["gpt-4o-2024-05-13", "GPT-4o Omni Multimodal (2024-05-13)", true, open_ai_api_service, 500, 1500],
@@ -57,6 +54,7 @@ module User::Registerable
         api_name:,
         api_service:,
         name:,
+        best: best_models.include?(api_name),
         supports_tools: true,
         supports_images:,
         input_token_cost_cents:,
@@ -76,8 +74,8 @@ module User::Registerable
       language_models.create!(api_name:, api_service:, name:, supports_tools: false, supports_images:, input_token_cost_cents:, output_token_cost_cents:)
     end
 
-    assistants.create! name: "GPT-4o", language_model: language_models.find_by(api_name: LanguageModel::BEST_GPT)
-    assistants.create! name: "Claude 3.5 Sonnet", language_model: language_models.find_by(api_name: LanguageModel::BEST_CLAUDE)
-    assistants.create! name: "Meta Llama 3 70b", language_model: language_models.find_by(api_name: LanguageModel::BEST_GROQ)
+    assistants.create! name: "GPT-4o", language_model: language_models.best_for_api_service(open_ai_api_service).first
+    assistants.create! name: "Claude 3.5 Sonnet", language_model: language_models.best_for_api_service(anthropic_api_service).first
+    assistants.create! name: "Meta Llama 3 70b", language_model: language_models.best_for_api_service(groq_api_service).first
   end
 end

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -39,7 +39,7 @@ class AIBackend::Anthropic < AIBackend
     super(config)
 
     @client_config = {
-      model: @assistant.language_model.provider_name,
+      model: @assistant.language_model.api_name,
       system: config[:instructions],
       messages: config[:messages],
       parameters: {

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -40,7 +40,7 @@ class AIBackend::OpenAI < AIBackend
 
     @client_config = {
       parameters: {
-        model: @assistant.language_model.provider_name,
+        model: @assistant.language_model.api_name,
         messages: system_message(config[:instructions]) + config[:messages],
         stream: config[:streaming] && @response_handler || nil,
         max_tokens: 2000, # we should really set this dynamically, based on the model, to the max

--- a/app/views/settings/language_models/_form.html.erb
+++ b/app/views/settings/language_models/_form.html.erb
@@ -39,6 +39,12 @@
       %>
     </div>
   <% end %>
+
+  <div class="my-5">
+    <%= form.check_box :best %>
+    <%= form.label :best, "Best?" %>
+  </div>
+
   <div class="my-5">
     <%= form.check_box :supports_images %>
     <%= form.label :supports_images, "Supports Images?" %>

--- a/app/views/settings/language_models/index.html.erb
+++ b/app/views/settings/language_models/index.html.erb
@@ -15,6 +15,7 @@
   <thead>
     <tr class="bg-gray-200 dark:bg-gray-900">
       <th>Name</th>
+      <th>Best?</th>
       <th>Description</th>
       <th>API Service</th>
     </tr>
@@ -25,6 +26,7 @@
       <%= turbo_frame_tag dom_id(language_model) do %>
         <tr class="<%= cycle('bg-gray-100 dark:bg-gray-600', 'bg-white dark:bg-gray-900') %> cursor-pointer" data-href="<%= edit_settings_language_model_path(language_model) %>">
           <td class="underline"><%= language_model.api_name %></td>
+          <td><%= language_model.best? ? "Yes" : "No" %></td>
           <td><%= language_model.name %></td>
           <td><%= n_a_if_blank(language_model.api_service.name) %></td>
         </tr>

--- a/db/migrate/20241106213119_add_best_to_language_models.rb
+++ b/db/migrate/20241106213119_add_best_to_language_models.rb
@@ -1,0 +1,5 @@
+class AddBestToLanguageModels < ActiveRecord::Migration[7.2]
+  def change
+    add_column :language_models, :best, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_22_053212) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_06_213119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -172,6 +172,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_22_053212) do
     t.boolean "supports_tools", default: false
     t.decimal "input_token_cost_cents", precision: 30, scale: 15
     t.decimal "output_token_cost_cents", precision: 30, scale: 15
+    t.boolean "best", default: false
     t.index ["api_service_id"], name: "index_language_models_on_api_service_id"
     t.index ["user_id", "deleted_at"], name: "index_language_models_on_user_id_and_deleted_at"
     t.index ["user_id"], name: "index_language_models_on_user_id"

--- a/test/fixtures/language_models.yml
+++ b/test/fixtures/language_models.yml
@@ -135,6 +135,7 @@ gpt_best:
   position: 1
   user: keith
   name: Best OpenAI Model
+  best: true
   api_name: gpt-best
   api_service: keith_openai_service
   supports_images: true
@@ -146,6 +147,7 @@ claude_best:
   position: 2
   user: keith
   name: Best Anthropic Model
+  best: true
   api_service: keith_anthropic_service
   api_name: claude-best
   supports_images: true

--- a/test/jobs/get_next_ai_message_job_anthropic_test.rb
+++ b/test/jobs/get_next_ai_message_job_anthropic_test.rb
@@ -37,11 +37,13 @@ class GetNextAIMessageJobAnthropicTest < ActiveJob::TestCase
   end
 
   test "when anthropic key is blank, a nice error message is displayed" do
-    api_service = @conversation.assistant.language_model.api_service
-    api_service.update!(token: "")
+    stub_features(default_llm_keys: false) do
+      api_service = @conversation.assistant.language_model.api_service
+      api_service.update!(token: "")
 
-    assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @conversation.assistant.id)
-    assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for Anthropic"
+      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @conversation.assistant.id)
+      assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for Anthropic"
+    end
   end
 
   test "when API response key is, a nice error message is displayed" do

--- a/test/jobs/get_next_ai_message_job_openai_test.rb
+++ b/test/jobs/get_next_ai_message_job_openai_test.rb
@@ -75,11 +75,13 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
   end
 
   test "when openai key is blank, a nice error message is displayed" do
-    api_service = @assistant.language_model.api_service
-    api_service.update!(token: "")
+    stub_features(default_llm_keys: false) do
+      api_service = @assistant.language_model.api_service
+      api_service.update!(token: "")
 
-    assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
-    assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for OpenAI"
+      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+      assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for OpenAI"
+    end
   end
 
   test "when API response key is missing, a nice error message is displayed" do

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -22,26 +22,6 @@ class LanguageModelTest < ActiveSupport::TestCase
     assert_equal AIBackend::OpenAI, language_models(:gpt_best).ai_backend
   end
 
-  test "provider_name for Anthropic models" do
-    assert_equal "claude-3-sonnet-20240229", language_models(:claude_3_sonnet_20240229).provider_name
-    assert_equal "claude-3-opus-20240229", language_models(:claude_3_opus_20240229).provider_name
-  end
-
-  test "provider_name for OpenAI models" do
-    assert_equal "gpt-3.5-turbo-0125", language_models(:gpt_3_5_turbo_0125).provider_name
-    assert_equal "gpt-4o", language_models(:gpt_4o).provider_name
-  end
-
-  test "provider_name for best models" do
-    assert_equal "gpt-4o-2024-08-06", language_models(:gpt_best).provider_name
-    assert_equal "claude-3-5-sonnet-20240620", language_models(:claude_best).provider_name
-  end
-
-  test "provider_name for non-best models" do
-    assert_equal "gpt-4o", language_models(:gpt_4o).provider_name
-    assert_equal "claude-3-opus-20240229", language_models(:claude_3_opus_20240229).provider_name
-  end
-
   test "validates api_name" do
     record = LanguageModel.new(api_name: "")
     refute record.valid?


### PR DESCRIPTION
Instead of constants in code, adding a `LanguageModel#best?` field. Only one LanguageModel per APIService can be the best.

Best models are at top of table, then ordered by position:

<img width="1209" alt="Screenshot 2024-11-07 at 8 24 09 am" src="https://github.com/user-attachments/assets/09b2f493-3735-4170-98ad-91b089ce7f48">

Toggle a language model to be the new "best" model for that API Service:

<img width="631" alt="Screenshot 2024-11-07 at 8 16 45 am" src="https://github.com/user-attachments/assets/bbda3781-369e-4f04-ac6d-69bc1f35b1fd">

The language model used for an assistant is now clear, rather than "Anthropic Best", etc:

<img width="1186" alt="Screenshot 2024-11-07 at 8 02 20 am" src="https://github.com/user-attachments/assets/6a82ea26-aec8-4b48-9556-3fbbf116624d">
