### PR TITLE
User can only have 2 initials in UI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,6 +437,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -437,7 +437,6 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
-  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,21 @@
 module ApplicationHelper
+
+  def only_user_initials(initials, limit: 2)
+    words = initials.to_s.strip.split(/\s+/)
+    case words.length
+    when 0
+      ""
+    when 1
+      words.first[0].to_s.upcase
+    else
+      if words.length <= limit
+        words.map(&:first).join.upcase
+      else
+        [words.first[0], words.last[0]].join.upcase
+      end
+    end
+  end
+
   def spinner(opts = {})
     html = <<~HTML
       <svg class="animate-spin -ml-1 mr-3 h-#{opts[:size]} w-#{opts[:size]} #{opts[:class]}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,17 +1,17 @@
 module ApplicationHelper
 
   def only_user_initials(initials, limit: 2)
-    letters = initials.to_s.strip.split("")
+    letters = initials.to_s.downcase.strip.split("")
     case letters.length
     when 0
       ""
     when 1
-      letters.first.to_s.upcase
+      letters.first
     else
       if letters.length <= limit
-        words.map(&:first).join.upcase
+        letters.map(&:first).join
       else
-        [letters.first, letters.last].join.upcase
+        [letters.first, letters.last].join
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
 
   def at_most_two_initials(initials)
     return initials if initials.nil? || initials.length <= 2
-    initials[0] + initials[-1]  
+    initials[0] + initials[-1]
   end
 
   def spinner(opts = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,17 +1,17 @@
 module ApplicationHelper
 
   def only_user_initials(initials, limit: 2)
-    words = initials.to_s.strip.split(/\s+/)
-    case words.length
+    letters = initials.to_s.strip.split("")
+    case letters.length
     when 0
       ""
     when 1
-      words.first[0].to_s.upcase
+      letters.first.to_s.upcase
     else
-      if words.length <= limit
+      if letters.length <= limit
         words.map(&:first).join.upcase
       else
-        [words.first[0], words.last[0]].join.upcase
+        [letters.first, letters.last].join.upcase
       end
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,19 +1,8 @@
 module ApplicationHelper
 
-  def only_user_initials(initials, limit: 2)
-    letters = initials.to_s.downcase.strip.split("")
-    case letters.length
-    when 0
-      ""
-    when 1
-      letters.first
-    else
-      if letters.length <= limit
-        letters.map(&:first).join
-      else
-        [letters.first, letters.last].join
-      end
-    end
+  def only_two_initials(initials)
+    return initials if initials.nil? || initials.length <= 2
+    initials[0] + initials[-1]  
   end
 
   def spinner(opts = {})

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
 
-  def only_two_initials(initials)
+  def at_most_two_initials(initials)
     return initials if initials.nil? || initials.length <= 2
     initials[0] + initials[-1]  
   end

--- a/app/views/layouts/_user_avatar.erb
+++ b/app/views/layouts/_user_avatar.erb
@@ -11,5 +11,5 @@
         <%= classes %>
         "
 >
-  <%= only_two_initials(user.name.initials)&.upcase %>
+  <%= at_most_two_initials(user.name.initials)&.upcase %>
 </picture>

--- a/app/views/layouts/_user_avatar.erb
+++ b/app/views/layouts/_user_avatar.erb
@@ -11,5 +11,5 @@
         <%= classes %>
         "
 >
-  <%= only_user_initials(user.name.initials) %>
+  <%= only_user_initials(user.name.initials).upcase %>
 </picture>

--- a/app/views/layouts/_user_avatar.erb
+++ b/app/views/layouts/_user_avatar.erb
@@ -11,5 +11,5 @@
         <%= classes %>
         "
 >
-  <%= only_user_initials(user.name.initials).upcase %>
+  <%= only_two_initials(user.name.initials)&.upcase %>
 </picture>

--- a/app/views/layouts/_user_avatar.erb
+++ b/app/views/layouts/_user_avatar.erb
@@ -11,5 +11,5 @@
         <%= classes %>
         "
 >
-  <%= user.name.initials&.upcase %>
+  <%= only_user_initials(user.name.initials) %>
 </picture>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -2,30 +2,30 @@ require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
   
-test "only at most 2 initials with default limit" do
-    assert_equal "jz", only_two_initials("jdz")
+test "only at most 2 initials" do
+    assert_equal "jz", at_most_two_initials("jdz")
   end
   
 
   test "single initials allowed" do
-    assert_equal "q", only_two_initials("q")
+    assert_equal "q", at_most_two_initials("q")
   end  
 
 
   test "nil returns nil" do
-    assert_nil only_two_initials(nil)
+    assert_nil at_most_two_initials(nil)
   end   
 
   test "can have numbers" do
-    assert_equal "P2", only_two_initials("PV2")
+    assert_equal "P2", at_most_two_initials("P2")
   end  
 
   test "does not change case" do
-    assert_equal "p2", only_two_initials("pV2")
+    assert_equal "p2", at_most_two_initials("p2")
   end  
 
   test "can have spaces" do
-    assert_equal "pQ", only_two_initials("p v Q")
+    assert_equal "pQ", at_most_two_initials("p v Q")
   end  
 
 end 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -29,4 +29,4 @@ class ApplicationHelperTest < ActionView::TestCase
   test "can have spaces" do
     assert_equal "pQ", at_most_two_initials("p v Q")
   end
-end 
+end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -22,6 +22,10 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "p2", at_most_two_initials("p2")
   end
 
+  test "returns the correct two initials when there are more than two" do
+    assert_equal "kS", at_most_two_initials("kRxS")
+  end
+
   test "can have spaces" do
     assert_equal "pQ", at_most_two_initials("p v Q")
   end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,25 +1,16 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
-  test "only_user_initials returns correct initials with default limit" do
-    assert_equal "JD", only_user_initials("John Doe")
-    assert_equal "JS", only_user_initials("John Smith")
-    assert_equal "J", only_user_initials("John")
+  test "only at most 2 initials with default limit" do
+    assert_equal "JZ", only_user_initials("jdz")
+    assert_equal "PL", only_user_initials("Plllll")
   end
+  test "single initials allowed" do
+    assert_equal "Q", only_user_initials("q")
+  end  
 
-  test "only_user_initials returns correct initials with more words than limit" do
-    assert_equal "AC", only_user_initials("Able Baby Commie")
-    assert_equal "AC", only_user_initials("Able Baby Commie", limit: 2)
-  end
+  test "can have numbers" do
+    assert_equal "P2", only_user_initials("Pvv2")
+  end  
 
-  test "only_user_initials respects custom limit" do
-    assert_equal "ABC", only_user_initials("Able Baby Commie", limit: 3)
-    assert_equal "AB", only_user_initials("Able Baby", limit: 3)
-    assert_equal "", only_user_initials("", limit: 2)
-  end
-
-  test "only_user_initials handles extra whitespace" do
-    assert_equal "JD", only_user_initials("  John   Doe  ")
-    assert_equal "JS", only_user_initials("John    Smith")
-  end
 end 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ApplicationHelperTest < ActionView::TestCase
+  test "only_user_initials returns correct initials with default limit" do
+    assert_equal "JD", only_user_initials("John Doe")
+    assert_equal "JS", only_user_initials("John Smith")
+    assert_equal "J", only_user_initials("John")
+  end
+
+  test "only_user_initials returns correct initials with more words than limit" do
+    assert_equal "AC", only_user_initials("Able Baby Commie")
+    assert_equal "AC", only_user_initials("Able Baby Commie", limit: 2)
+  end
+
+  test "only_user_initials respects custom limit" do
+    assert_equal "ABC", only_user_initials("Able Baby Commie", limit: 3)
+    assert_equal "AB", only_user_initials("Able Baby", limit: 3)
+    assert_equal "", only_user_initials("", limit: 2)
+  end
+
+  test "only_user_initials handles extra whitespace" do
+    assert_equal "JD", only_user_initials("  John   Doe  ")
+    assert_equal "JS", only_user_initials("John    Smith")
+  end
+end 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,31 +1,28 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
-  
-test "only at most 2 initials" do
+
+  test "only at most 2 initials" do
     assert_equal "jz", at_most_two_initials("jdz")
   end
-  
 
   test "single initials allowed" do
     assert_equal "q", at_most_two_initials("q")
-  end  
-
+  end
 
   test "nil returns nil" do
     assert_nil at_most_two_initials(nil)
-  end   
+  end
 
   test "can have numbers" do
     assert_equal "P2", at_most_two_initials("P2")
-  end  
+  end
 
   test "does not change case" do
     assert_equal "p2", at_most_two_initials("p2")
-  end  
+  end
 
   test "can have spaces" do
     assert_equal "pQ", at_most_two_initials("p v Q")
-  end  
-
+  end
 end 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -20,7 +20,7 @@ test "only at most 2 initials with default limit" do
     assert_equal "p2", only_user_initials("Pvv2")
   end  
 
-  test "cab gave spaces" do
+  test "can gave spaces" do
     assert_equal "pq", only_user_initials("P vv qQ")
   end  
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,25 +3,29 @@ require "test_helper"
 class ApplicationHelperTest < ActionView::TestCase
   
 test "only at most 2 initials with default limit" do
-    assert_equal "jz", only_user_initials("jdz")
-    assert_equal "pl", only_user_initials("Plllll")
+    assert_equal "jz", only_two_initials("jdz")
   end
   
 
   test "single initials allowed" do
-    assert_equal "q", only_user_initials("q")
+    assert_equal "q", only_two_initials("q")
   end  
 
-  test "should down case" do
-    assert_equal "q", only_user_initials("Q")
-  end    
+
+  test "nil returns nil" do
+    assert_nil only_two_initials(nil)
+  end   
 
   test "can have numbers" do
-    assert_equal "p2", only_user_initials("Pvv2")
+    assert_equal "P2", only_two_initials("PV2")
+  end  
+
+  test "does not change case" do
+    assert_equal "p2", only_two_initials("pV2")
   end  
 
   test "can have spaces" do
-    assert_equal "pq", only_user_initials("P vv qQ")
+    assert_equal "pQ", only_two_initials("p v Q")
   end  
 
 end 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -20,7 +20,7 @@ test "only at most 2 initials with default limit" do
     assert_equal "p2", only_user_initials("Pvv2")
   end  
 
-  test "can gave spaces" do
+  test "can have spaces" do
     assert_equal "pq", only_user_initials("P vv qQ")
   end  
 

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,16 +1,27 @@
 require "test_helper"
 
 class ApplicationHelperTest < ActionView::TestCase
-  test "only at most 2 initials with default limit" do
-    assert_equal "JZ", only_user_initials("jdz")
-    assert_equal "PL", only_user_initials("Plllll")
+  
+test "only at most 2 initials with default limit" do
+    assert_equal "jz", only_user_initials("jdz")
+    assert_equal "pl", only_user_initials("Plllll")
   end
+  
+
   test "single initials allowed" do
-    assert_equal "Q", only_user_initials("q")
+    assert_equal "q", only_user_initials("q")
   end  
 
+  test "should down case" do
+    assert_equal "q", only_user_initials("Q")
+  end    
+
   test "can have numbers" do
-    assert_equal "P2", only_user_initials("Pvv2")
+    assert_equal "p2", only_user_initials("Pvv2")
+  end  
+
+  test "cab gave spaces" do
+    assert_equal "pq", only_user_initials("P vv qQ")
   end  
 
 end 


### PR DESCRIPTION
Addresses:  "You should create a method that takes user.name.initials as its argument. We are already properly extracting initials, we just want fewer of them. So make a helper like you’ve done that takes in all initials and returns a max of two. If there are more than two, keep the first and last initial and drop any in the middle."

I think this kind of works - but I've not done this type of process in a while so I expect it is not perfect ... yet.