### PR TITLE
truncate long names so nav-container does not grow

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,6 @@ module ApplicationHelper
   # If the name on the nav-container is long truncate it to 20 characters
   # So it does not grow the left menu
   def truncate_long_name(name)
-    return name if name.nil? || name.length <= 20
     truncate(name, length: 20)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,5 @@
 module ApplicationHelper
 
-  # If the name on the nav-container is long truncate it to 20 characters
-  # So it does not grow the left menu
   def truncate_long_name(name)
     truncate(name, length: 20)
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,12 @@
 module ApplicationHelper
 
+  # If the name on the nav-container is long truncate it to 20 characters
+  # So it does not grow the left menu
+  def truncate_long_name(name)
+    return name if name.nil? || name.length <= 20
+    truncate(name, length: 20)
+  end
+
   def at_most_two_initials(initials)
     return initials if initials.nil? || initials.length <= 2
     initials[0] + initials[-1]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
               <div tabindex="0" role="button" class="flex items-center justify-between w-full h-10 pr-2 mb-1 rounded-lg cursor-pointer scale-down hover:bg-gray-100 dark:hover:bg-gray-700 group !outline-0">
                 <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "ml-2 mr-2" } %>
                 <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100">
-                  <%= Current.user.name.full || "Profile" %>
+                 <%= truncate_long_name(Current.user.name.full || "Profile") %>
                 </div>
                 <%= icon "chevron-up", variant: :mini, class: 'text-gray-500 ml-[2px]' %>
               </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
               <div tabindex="0" role="button" class="flex items-center justify-between w-full h-10 pr-2 mb-1 rounded-lg cursor-pointer scale-down hover:bg-gray-100 dark:hover:bg-gray-700 group !outline-0">
                 <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "ml-2 mr-2" } %>
                 <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100">
-                 <%= truncate_long_name(Current.user.name.full || "Profile") %>
+                 <%= truncate_long_name(Current.user.name.full) || "Profile" %>
                 </div>
                 <%= icon "chevron-up", variant: :mini, class: 'text-gray-500 ml-[2px]' %>
               </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_11_11_131751) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_11_131751) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -172,8 +172,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_11_11_131751) do
     t.boolean "supports_tools", default: false
     t.decimal "input_token_cost_cents", precision: 30, scale: 15
     t.decimal "output_token_cost_cents", precision: 30, scale: 15
-    t.boolean "supports_system_message", default: false
     t.boolean "best", default: false
+    t.boolean "supports_system_message", default: false
     t.index ["api_service_id"], name: "index_language_models_on_api_service_id"
     t.index ["user_id", "deleted_at"], name: "index_language_models_on_user_id_and_deleted_at"
     t.index ["user_id"], name: "index_language_models_on_user_id"

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -29,4 +29,13 @@ class ApplicationHelperTest < ActionView::TestCase
   test "can have spaces" do
     assert_equal "pQ", at_most_two_initials("p v Q")
   end
+
+  test "truncates long names" do
+    assert_equal "John D. Z. Smith ...", truncate_long_name("John D. Z. Smith Jane Doe")
+  end
+
+  test "short names are not truncated" do
+    assert_equal "John D. Doe", truncate_long_name("John D. Doe")
+  end
+
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -38,4 +38,8 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "John D. Doe", truncate_long_name("John D. Doe")
   end
 
+  test "handles nil" do
+    assert_nil truncate_long_name(nil)
+  end
+
 end


### PR DESCRIPTION
1) Long names make the nav-container grow
2) Truncates the name to 20 chars
3) Rubocop worked :) 373 files inspected, 1 offense detected, 1 offense autocorrectable
4) Hopefully, no glass chewing

