### PR TITLE
Truncate profile name using CSS instead of rails helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,5 @@
 module ApplicationHelper
 
-  def truncate_long_name(name)
-    truncate(name, length: 20)
-  end
-
   def at_most_two_initials(initials)
     return initials if initials.nil? || initials.length <= 2
     initials[0] + initials[-1]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,8 +35,8 @@
             <div class="w-full dropdown dropdown-top dropdown-end">
               <div tabindex="0" role="button" class="flex items-center justify-between w-full h-10 pr-2 mb-1 rounded-lg cursor-pointer scale-down hover:bg-gray-100 dark:hover:bg-gray-700 group !outline-0">
                 <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "ml-2 mr-2" } %>
-                <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100">
-                 <%= truncate_long_name(Current.user.name.full) || "Profile" %>
+                <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100 w-20">
+                 <%= Current.user.name.full || "Profile" %>
                 </div>
                 <%= icon "chevron-up", variant: :mini, class: 'text-gray-500 ml-[2px]' %>
               </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
             <div class="w-full dropdown dropdown-top dropdown-end">
               <div tabindex="0" role="button" class="flex items-center justify-between w-full h-10 pr-2 mb-1 rounded-lg cursor-pointer scale-down hover:bg-gray-100 dark:hover:bg-gray-700 group !outline-0">
                 <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "ml-2 mr-2" } %>
-                <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100 w-20">
+                <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100">
                  <%= Current.user.name.full || "Profile" %>
                 </div>
                 <%= icon "chevron-up", variant: :mini, class: 'text-gray-500 ml-[2px]' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,7 +35,7 @@
             <div class="w-full dropdown dropdown-top dropdown-end">
               <div tabindex="0" role="button" class="flex items-center justify-between w-full h-10 pr-2 mb-1 rounded-lg cursor-pointer scale-down hover:bg-gray-100 dark:hover:bg-gray-700 group !outline-0">
                 <%= render partial: "layouts/user_avatar", locals: { user: Current.user, size: 7, classes: "ml-2 mr-2" } %>
-                <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100">
+                <div class="flex-1 text-sm truncate text-gray-950 dark:text-gray-100 w-20">
                  <%= Current.user.name.full || "Profile" %>
                 </div>
                 <%= icon "chevron-up", variant: :mini, class: 'text-gray-500 ml-[2px]' %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -30,16 +30,4 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "pQ", at_most_two_initials("p v Q")
   end
 
-  test "truncates long names" do
-    assert_equal "John D. Z. Smith ...", truncate_long_name("John D. Z. Smith Jane Doe")
-  end
-
-  test "short names are not truncated" do
-    assert_equal "John D. Doe", truncate_long_name("John D. Doe")
-  end
-
-  test "handles nil" do
-    assert_nil truncate_long_name(nil)
-  end
-
 end


### PR DESCRIPTION
This was generated with a system test. I'm not seeing how we can tests the value in that field. It does not see the ... from truncate.


![failures_test_should_truncate_the_name](https://github.com/user-attachments/assets/dbbf4e88-0b3d-4c4f-8805-28f4c77b5587)
