### PR TITLE
MicrosoftGraphCredential#token is always a refreshed token

### DIFF
--- a/app/models/microsoft_graph_credential.rb
+++ b/app/models/microsoft_graph_credential.rb
@@ -7,4 +7,46 @@ class MicrosoftGraphCredential < Credential
   validates :oauth_email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   normalizes :oauth_email, with: -> email { email.downcase.strip }
+
+  # Use this method to retrieve the latest oauth_token.
+  # Token will be automatically renewed as necessary
+  def token
+    renew_token! if expired?
+    oauth_token
+  end
+
+  def expires_at
+    Time.at(properties[:expires_at]) if properties[:expires_at]
+  rescue
+    nil
+  end
+
+  def expired?
+    expires_at && expires_at < Time.current
+  end
+
+  def renew_token!
+    new_token = current_token.refresh!
+    update(
+      oauth_token: new_token.token,
+      oauth_refresh_token: new_token.refresh_token,
+      properties: { expires_at: new_token.expires_at }
+    )
+  end
+
+  private
+
+  def current_token
+    OAuth2::AccessToken.new(
+      strategy.client,
+      oauth_token,
+      refresh_token: oauth_refresh_token
+    )
+  end
+
+  def strategy
+    client_id = Setting.microsoft_graph_auth_client_id
+    client_secret = Setting.microsoft_graph_auth_client_secret
+    OmniAuth::Strategies::MicrosoftGraph.new(nil, client_id, client_secret)
+  end
 end

--- a/test/controllers/authentications/microsoft_graph_oauth_controller_test.rb
+++ b/test/controllers/authentications/microsoft_graph_oauth_controller_test.rb
@@ -161,6 +161,7 @@ class Authentications::MicrosoftGraphOauthControllerTest < ActionDispatch::Integ
       credentials: {
         token: "new_token",
         refresh_token: "new_refresh_token",
+        expires_at: 30.minutes.from_now.to_i,
         scope: "openid profile email offline_access user.read mailboxsettings.read"
       }
     }

--- a/test/fixtures/credentials.yml
+++ b/test/fixtures/credentials.yml
@@ -39,6 +39,9 @@ keith_microsoft_graph:
   type: MicrosoftGraphCredential
   external_id: microsoft_id123
   oauth_email: keith@hostedgpt.com
+  oauth_token: some-token
+  oauth_refresh_token: some-refresh-token
+  properties: {"expires_at":<%= 30.minutes.from_now.to_i %>}
 
 rob_password:
   user: rob

--- a/test/models/microsoft_graph_credential_test.rb
+++ b/test/models/microsoft_graph_credential_test.rb
@@ -10,4 +10,19 @@ class MicrosoftGraphCredentialTest < ActiveSupport::TestCase
   test "confirm that one of the MicrosoftGraphApp included changes is working" do
     assert_equal credentials(:keith_microsoft_graph).external_id, credentials(:keith_microsoft_graph).oauth_id
   end
+
+  test "token not expired so not renewed" do
+    credential = credentials(:keith_microsoft_graph)
+    refute credential.expired?
+    token = credential.token
+    assert token
+    credential.reload
+    assert_equal token, credential.token
+  end
+
+  test "token expired" do
+    credential = credentials(:keith_microsoft_graph)
+    credential.update(properties: { expires_at: 1.minute.ago.to_i })
+    assert credential.expired?
+  end
 end


### PR DESCRIPTION
This approach to requesting an access `token` and ensuring it is always refreshed is different from your Google code. I've left the code in the `MicrosoftGraphCredential` for now; but it can be moved into `Credential` or a concern if you wanted other subclasses to use it too, in a future PR.