### PR TITLE
Default assistants from file + models from file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "turbo-rails", "~> 2.0.5"
 gem "stimulus-rails", "~> 1.3.3"
 gem "tailwindcss-rails", "~> 2.7.2"
 gem "rack-cors"
-gem "ostruct"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 # gem "jbuilder"

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -73,7 +73,7 @@ class MessagesController < ApplicationController
   end
 
   def set_assistant
-    @assistant = Current.user.assistants_including_deleted.find_by(id: params[:assistant_id])
+    @assistant = Current.user.assistants_including_deleted.find_by(slug: params[:assistant_id])
     @assistant ||= @conversation.latest_message_for_version(@version).assistant
   end
 

--- a/app/controllers/settings/assistants_controller.rb
+++ b/app/controllers/settings/assistants_controller.rb
@@ -49,6 +49,6 @@ class Settings::AssistantsController < Settings::ApplicationController
   end
 
   def assistant_params
-    params.require(:assistant).permit(:name, :description, :instructions, :language_model_id)
+    params.require(:assistant).permit(:name, :slug, :description, :instructions, :language_model_id)
   end
 end

--- a/app/controllers/settings/assistants_controller.rb
+++ b/app/controllers/settings/assistants_controller.rb
@@ -38,7 +38,7 @@ class Settings::AssistantsController < Settings::ApplicationController
   private
 
   def set_assistant
-    @assistant = Current.user.assistants.find_by(id: params[:id])
+    @assistant = Current.user.assistants.find_by(slug: params[:id])
     if @assistant.nil?
       redirect_to new_settings_assistant_url, notice: "The assistant was deleted", status: :see_other
     end

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -1,4 +1,6 @@
 class Assistant < ApplicationRecord
+  include Export
+
   MAX_LIST_DISPLAY = 5
 
   belongs_to :user
@@ -19,6 +21,8 @@ class Assistant < ApplicationRecord
 
   scope :ordered, -> { order(:id) }
 
+  delegate :api_name, to: :language_model, prefix: true, allow_nil: true
+
   def initials
     return nil if name.blank?
 
@@ -30,5 +34,9 @@ class Assistant < ApplicationRecord
 
   def to_s
     name
+  end
+
+  def language_model_api_name=(api_name)
+    self.language_model = LanguageModel.find_by(api_name:)
   end
 end

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -49,6 +49,7 @@ class Assistant < ApplicationRecord
   # If the slug is not unique for the user, append "-2", "-3", etc.
   def set_default_slug
     return if slug.present?
+    return if name.blank?
 
     base_slug = name.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/-$/, "")
 

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -38,6 +38,10 @@ class Assistant < ApplicationRecord
     name
   end
 
+  def to_param
+    slug
+  end
+
   def language_model_api_name=(api_name)
     self.language_model = LanguageModel.find_by(api_name:)
   end

--- a/app/models/assistant.rb
+++ b/app/models/assistant.rb
@@ -23,6 +23,8 @@ class Assistant < ApplicationRecord
 
   delegate :api_name, to: :language_model, prefix: true, allow_nil: true
 
+  before_validation :set_default_slug
+
   def initials
     return nil if name.blank?
 
@@ -38,5 +40,11 @@ class Assistant < ApplicationRecord
 
   def language_model_api_name=(api_name)
     self.language_model = LanguageModel.find_by(api_name:)
+  end
+
+  private
+
+  def set_default_slug
+    self.slug ||= name.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/-$/, "")
   end
 end

--- a/app/models/assistant/export.rb
+++ b/app/models/assistant/export.rb
@@ -3,10 +3,9 @@ module Assistant::Export
 
   DEFAULT_EXPORT_ONLY = %i[
     name
+    slug
     description
     instructions
-    tools
-    external_id
     language_model_api_name
   ]
 

--- a/app/models/assistant/export.rb
+++ b/app/models/assistant/export.rb
@@ -42,8 +42,8 @@ module Assistant::Export
       assistants.each do |assistant|
         assistant = assistant.with_indifferent_access
         users.each do |user|
-          asst = user.assistants.find_or_create_by(name: assistant["name"])
-          asst.assign_attributes(assistant.except("name"))
+          asst = user.assistants.find_or_create_by(slug: assistant["slug"])
+          asst.assign_attributes(assistant.except("slug"))
           asst.save!
         end
       end

--- a/app/models/assistant/export.rb
+++ b/app/models/assistant/export.rb
@@ -1,0 +1,53 @@
+module Assistant::Export
+  extend ActiveSupport::Concern
+
+  DEFAULT_EXPORT_ONLY = %i[
+    name
+    description
+    instructions
+    tools
+    external_id
+    language_model_api_name
+  ]
+
+  DEFAULT_ASSISTANT_FILE = "assistants.yml"
+
+  def attributes
+    super.merge("language_model_api_name" => language_model_api_name)
+  end
+
+  # Unsure why this needs to re-defined, but the original ActiveModel::Serialization
+  # implementation is ignoring the #attributes method above.
+  def attribute_names_for_serialization
+    attributes.keys
+  end
+
+  class_methods do
+    def export_to_file(path: Rails.root.join(DEFAULT_ASSISTANT_FILE), assistants:, only: DEFAULT_EXPORT_ONLY)
+      path = path.to_s
+      storage = {
+        "assistants" => assistants.as_json(only:).map(&:compact)
+      }
+      if path.ends_with?(".json")
+        File.write(path, storage.to_json)
+      else
+        File.write(path, storage.to_yaml)
+      end
+    end
+
+    def import_from_file(path: Rails.root.join(DEFAULT_ASSISTANT_FILE), users: User.all)
+      users = Array.wrap(users)
+
+      storage = YAML.load_file(path)
+      assistants = storage["assistants"]
+      assistants.each do |assistant|
+        assistant = assistant.with_indifferent_access
+        users.each do |user|
+          asst = user.assistants.find_or_create_by(name: assistant["name"])
+          asst.assign_attributes(assistant.except("name"))
+          asst.save!
+        end
+      end
+    end
+  end
+end

--- a/app/models/user/registerable.rb
+++ b/app/models/user/registerable.rb
@@ -8,14 +8,11 @@ module User::Registerable
   private
 
   def create_initial_assistants_etc
-    open_ai_api_service = api_services.create!(url: APIService::URL_OPEN_AI, driver: :openai, name: "OpenAI")
-    anthropic_api_service = api_services.create!(url: APIService::URL_ANTHROPIC, driver: :anthropic, name: "Anthropic")
-    groq_api_service = api_services.create!(url: APIService::URL_GROQ, driver: :openai, name: "Groq")
+    api_services.create!(url: APIService::URL_OPEN_AI, driver: :openai, name: "OpenAI")
+    api_services.create!(url: APIService::URL_ANTHROPIC, driver: :anthropic, name: "Anthropic")
+    api_services.create!(url: APIService::URL_GROQ, driver: :openai, name: "Groq")
 
     LanguageModel.import_from_file(users: [self])
-
-    assistants.create! name: "GPT-4o", language_model: language_models.best_for_api_service(open_ai_api_service).first
-    assistants.create! name: "Claude 3.5 Sonnet", language_model: language_models.best_for_api_service(anthropic_api_service).first
-    assistants.create! name: "Meta Llama", language_model: language_models.best_for_api_service(groq_api_service).first
+    Assistant.import_from_file(users: [self])
   end
 end

--- a/app/views/settings/assistants/_form.html.erb
+++ b/app/views/settings/assistants/_form.html.erb
@@ -24,6 +24,21 @@
       | %>
   </div>
 
+  <% unless assistant.new_record? %>
+    <div class="my-5">
+      <%= form.label :slug %>
+      <%= form.text_field :slug,
+        autofocus: assistant.new_record?,
+        class: %|
+          block w-full
+          border border-gray-200 outline-none
+          shadow rounded-md
+          px-3 py-2 mt-2
+          dark:text-black
+        | %>
+    </div>
+  <% end %>
+
   <div class="my-5">
     <%= form.label :language_model_id  %><br/>
     <%= form.select :language_model_id,

--- a/assistants.yml
+++ b/assistants.yml
@@ -1,14 +1,11 @@
 ---
 assistants:
-- slug: gpt-4o
-  name: GPT-4o
+- name: GPT-4o
+  slug: gpt-4o
   language_model_api_name: gpt-4o
-- slug: gpt-4o-mini
-  name: GPT-4o Mini
-  language_model_api_name: gpt-4o-mini
-- slug: claude-3-5-sonnet
-  name: Claude 3.5 Sonnet
+- name: Claude 3.5 Sonnet
+  slug: claude-sonnet
   language_model_api_name: claude-3-5-sonnet-20241022
-- slug: llama-3-70b
-  name: Meta Llama 70b
+- name: Meta Llama
+  slug: llama-3-70b
   language_model_api_name: llama-3.1-70b-versatile

--- a/assistants.yml
+++ b/assistants.yml
@@ -1,0 +1,14 @@
+---
+assistants:
+- name: GPT-4o
+  tools: []
+  language_model_api_name: gpt-4o
+- name: GPT-4o Mini
+  tools: []
+  language_model_api_name: gpt-4o-mini
+- name: Claude 3.5 Sonnet
+  tools: []
+  language_model_api_name: claude-3-5-sonnet-20241022
+- name: Meta Llama
+  tools: []
+  language_model_api_name: llama-3.1-70b-versatile

--- a/assistants.yml
+++ b/assistants.yml
@@ -3,6 +3,9 @@ assistants:
 - name: GPT-4o
   slug: gpt-4o
   language_model_api_name: gpt-4o
+- name: GPT-4o Mini
+  slug: gpt-4o-mini
+  language_model_api_name: gpt-4o-mini
 - name: Claude 3.5 Sonnet
   slug: claude-sonnet
   language_model_api_name: claude-3-5-sonnet-20241022

--- a/assistants.yml
+++ b/assistants.yml
@@ -1,14 +1,14 @@
 ---
 assistants:
-- name: GPT-4o
-  tools: []
+- slug: gpt-4o
+  name: GPT-4o
   language_model_api_name: gpt-4o
-- name: GPT-4o Mini
-  tools: []
+- slug: gpt-4o-mini
+  name: GPT-4o Mini
   language_model_api_name: gpt-4o-mini
-- name: Claude 3.5 Sonnet
-  tools: []
+- slug: claude-3-5-sonnet
+  name: Claude 3.5 Sonnet
   language_model_api_name: claude-3-5-sonnet-20241022
-- name: Meta Llama
-  tools: []
+- slug: llama-3-70b
+  name: Meta Llama 70b
   language_model_api_name: llama-3.1-70b-versatile

--- a/db/migrate/20240624100000_add_groq.rb
+++ b/db/migrate/20240624100000_add_groq.rb
@@ -6,9 +6,7 @@ class AddGroq < ActiveRecord::Migration[7.0]
     APIService.reset_column_information
 
     User.all.find_each do |user|
-      groq_api_service = user.api_services.create!(url: APIService::URL_GROQ, driver: :openai, name: "Groq")
-
-      user.assistants.create! name: "Meta Llama 3 70b", language_model: language_models.best_for_api_service(groq_api_service).first
+      user.api_services.create!(url: APIService::URL_GROQ, driver: :openai, name: "Groq")
     end
   end
 

--- a/db/migrate/20241126084627_add_slug_to_assistants.rb
+++ b/db/migrate/20241126084627_add_slug_to_assistants.rb
@@ -1,0 +1,35 @@
+class AddSlugToAssistants < ActiveRecord::Migration[7.2]
+  def change
+    add_column :assistants, :slug, :string, null: true
+    add_index :assistants, [:user_id, :slug], unique: true, where: "slug IS NOT NULL"
+
+    # Update User's assistants to use the default slugs in assistants.yml
+    User.find_each do |user|
+      gpt4o = LanguageModel.find_by(api_name: "gpt-4o")
+      gpt4o_mini = LanguageModel.find_by(api_name: "gpt-4o-mini")
+      claude_3_5_sonnet_20241022 = LanguageModel.find_by(api_name: "claude-3-5-sonnet-20241022")
+      claude_3_5_sonnet_20240620 = LanguageModel.find_by(api_name: "claude-3-5-sonnet-20240620")
+      llama_3_1_70b = LanguageModel.find_by(api_name: "llama-3.1-70b")
+      llama_3_70b = LanguageModel.find_by(api_name: "llama3-70b-8192")
+
+      if gpt4o && (assistant = user.assistants.find_by(language_model: gpt4o))
+        assistant.update(slug: "gpt-4o")
+      end
+      if gpt4o_mini && (assistant = user.assistants.find_by(language_model: gpt4o_mini))
+        assistant.update(slug: "gpt-4o-mini")
+      end
+
+      if claude_3_5_sonnet_20241022 && (assistant = user.assistants.find_by(language_model: claude_3_5_sonnet_20241022))
+        assistant.update(slug: "claude-sonnet")
+      elsif claude_3_5_sonnet_20240620 && (assistant = user.assistants.find_by(language_model: claude_3_5_sonnet_20240620))
+        assistant.update(slug: "claude-sonnet")
+      end
+
+      if llama_3_1_70b && (assistant = user.assistants.find_by(language_model: llama_3_1_70b))
+        assistant.update(slug: "llama-3-70b")
+      elsif llama_3_70b && (assistant = user.assistants.find_by(language_model: llama_3_70b))
+        assistant.update(slug: "llama-3-70b")
+      end
+    end
+  end
+end

--- a/db/migrate/20241126084627_add_slug_to_assistants.rb
+++ b/db/migrate/20241126084627_add_slug_to_assistants.rb
@@ -1,35 +1,43 @@
 class AddSlugToAssistants < ActiveRecord::Migration[7.2]
-  def change
+  def up
     add_column :assistants, :slug, :string, null: true
     add_index :assistants, [:user_id, :slug], unique: true, where: "slug IS NOT NULL"
 
     # Update User's assistants to use the default slugs in assistants.yml
     User.find_each do |user|
-      gpt4o = user.language_models.find_by(api_name: "gpt-4o")
-      gpt4o_mini = user.language_models.find_by(api_name: "gpt-4o-mini")
-      claude_3_5_sonnet_20241022 = user.language_models.find_by(api_name: "claude-3-5-sonnet-20241022")
-      claude_3_5_sonnet_20240620 = user.language_models.find_by(api_name: "claude-3-5-sonnet-20240620")
-      llama_3_1_70b = user.language_models.find_by(api_name: "llama-3.1-70b-versatile")
-      llama_3_70b = user.language_models.find_by(api_name: "llama3-70b-8192")
+      language_models = user.language_models
+      gpt4o = language_models.find_by(api_name: "gpt-4o")
+      gpt4o_mini = language_models.find_by(api_name: "gpt-4o-mini")
+      claude_3_5_sonnet_20241022 = language_models.find_by(api_name: "claude-3-5-sonnet-20241022")
+      claude_3_5_sonnet_20240620 = language_models.find_by(api_name: "claude-3-5-sonnet-20240620")
+      llama_3_1_70b = language_models.find_by(api_name: "llama-3.1-70b-versatile")
+      llama_3_70b = language_models.find_by(api_name: "llama3-70b-8192")
 
-      if gpt4o && (assistant = user.assistants.find_by(language_model: gpt4o))
+      ordered_assistants = user.assistants.order(created_at: :asc)
+      if gpt4o && (assistant = ordered_assistants.find_by(language_model: gpt4o))
         assistant.update(slug: "gpt-4o")
       end
-      if gpt4o_mini && (assistant = user.assistants.find_by(language_model: gpt4o_mini))
+      if gpt4o_mini && (assistant = ordered_assistants.find_by(language_model: gpt4o_mini))
         assistant.update(slug: "gpt-4o-mini")
       end
 
-      if claude_3_5_sonnet_20241022 && (assistant = user.assistants.find_by(language_model: claude_3_5_sonnet_20241022))
+      if claude_3_5_sonnet_20241022 && (assistant = ordered_assistants.find_by(language_model: claude_3_5_sonnet_20241022))
         assistant.update(slug: "claude-sonnet")
-      elsif claude_3_5_sonnet_20240620 && (assistant = user.assistants.find_by(language_model: claude_3_5_sonnet_20240620))
+      elsif claude_3_5_sonnet_20240620 && (assistant = ordered_assistants.find_by(language_model: claude_3_5_sonnet_20240620))
         assistant.update(slug: "claude-sonnet")
       end
 
-      if llama_3_1_70b && (assistant = user.assistants.find_by(language_model: llama_3_1_70b))
+      if llama_3_1_70b && (assistant = ordered_assistants.find_by(language_model: llama_3_1_70b))
         assistant.update(slug: "llama-3-70b")
-      elsif llama_3_70b && (assistant = user.assistants.find_by(language_model: llama_3_70b))
+      elsif llama_3_70b && (assistant = ordered_assistants.find_by(language_model: llama_3_70b))
         assistant.update(slug: "llama-3-70b")
       end
+
+      user.assistants.where(slug: nil).find_each(&:save!)
     end
+  end
+
+  def down
+    remove_column :assistants, :slug
   end
 end

--- a/db/migrate/20241126084627_add_slug_to_assistants.rb
+++ b/db/migrate/20241126084627_add_slug_to_assistants.rb
@@ -5,12 +5,12 @@ class AddSlugToAssistants < ActiveRecord::Migration[7.2]
 
     # Update User's assistants to use the default slugs in assistants.yml
     User.find_each do |user|
-      gpt4o = LanguageModel.find_by(api_name: "gpt-4o")
-      gpt4o_mini = LanguageModel.find_by(api_name: "gpt-4o-mini")
-      claude_3_5_sonnet_20241022 = LanguageModel.find_by(api_name: "claude-3-5-sonnet-20241022")
-      claude_3_5_sonnet_20240620 = LanguageModel.find_by(api_name: "claude-3-5-sonnet-20240620")
-      llama_3_1_70b = LanguageModel.find_by(api_name: "llama-3.1-70b")
-      llama_3_70b = LanguageModel.find_by(api_name: "llama3-70b-8192")
+      gpt4o = user.language_models.find_by(api_name: "gpt-4o")
+      gpt4o_mini = user.language_models.find_by(api_name: "gpt-4o-mini")
+      claude_3_5_sonnet_20241022 = user.language_models.find_by(api_name: "claude-3-5-sonnet-20241022")
+      claude_3_5_sonnet_20240620 = user.language_models.find_by(api_name: "claude-3-5-sonnet-20240620")
+      llama_3_1_70b = user.language_models.find_by(api_name: "llama-3.1-70b-versatile")
+      llama_3_70b = user.language_models.find_by(api_name: "llama3-70b-8192")
 
       if gpt4o && (assistant = user.assistants.find_by(language_model: gpt4o))
         assistant.update(slug: "gpt-4o")

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_11_131751) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_26_084627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,9 +72,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_11_131751) do
     t.bigint "language_model_id"
     t.datetime "deleted_at", precision: nil
     t.text "external_id", comment: "The Backend AI's (e.g OpenAI) assistant id"
+    t.string "slug"
     t.index ["external_id"], name: "index_assistants_on_external_id", unique: true
     t.index ["language_model_id"], name: "index_assistants_on_language_model_id"
     t.index ["user_id", "deleted_at"], name: "index_assistants_on_user_id_and_deleted_at"
+    t.index ["user_id", "slug"], name: "index_assistants_on_user_id_and_slug", unique: true, where: "(slug IS NOT NULL)"
     t.index ["user_id"], name: "index_assistants_on_user_id"
   end
 

--- a/lib/tasks/assistants.rake
+++ b/lib/tasks/assistants.rake
@@ -1,0 +1,28 @@
+namespace :assistants do
+  desc "Export assistants to a file, defaulting to assistants.yml"
+  task :export, [:path] => :environment do |t, args|
+    args.with_defaults(path: Rails.root.join(Assistant::Export::DEFAULT_ASSISTANT_FILE))
+    warn "Exporting assistants to #{args[:path]}"
+    unless User.first
+      warn "No users found, unable to export assistants"
+      exit 1
+    end
+    assistants = User.first.assistants.ordered.not_deleted
+    Assistant.export_to_file(path: args[:path], assistants:)
+  end
+
+  desc "Import assistants to all users from a file, defaulting to assistants.yml"
+  task :import, [:path] => :environment do |t, args|
+    args.with_defaults(path: Rails.root.join(Assistant::Export::DEFAULT_ASSISTANT_FILE))
+    warn "Importing assistants from #{args[:path]}"
+    users = User.all
+    Assistant.import_from_file(path: args[:path], users:)
+  end
+
+end
+
+Rake::Task["db:prepare"].enhance do
+  Rake::Task["assistants:import"].invoke
+end
+
+

--- a/lib/tasks/models.rake
+++ b/lib/tasks/models.rake
@@ -3,6 +3,10 @@ namespace :models do
   task :export, [:path] => :environment do |t, args|
     args.with_defaults(path: Rails.root.join(LanguageModel::Export::DEFAULT_MODEL_FILE))
     warn "Exporting language models to #{args[:path]}"
+    unless User.first
+      warn "No users found, unable to export language models"
+      exit 1
+    end
     models = User.first.language_models.ordered.not_deleted.includes(:api_service)
     LanguageModel.export_to_file(path: args[:path], models:)
   end

--- a/test/controllers/password_resets_controller_test.rb
+++ b/test/controllers/password_resets_controller_test.rb
@@ -31,7 +31,10 @@ class PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
     email = @person.email
 
-      # set the user agent in the request headers
+    # Test can flap on CI if we don't clear the queue
+    clear_enqueued_jobs
+
+    # set the user agent in the request headers
     ActionDispatch::Request.stub_any_instance(:user_agent, "#{browser} on #{operating_system}") do
       post password_resets_url, params: { email: email }
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -58,7 +58,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = Person.find_by(email: email).user
     assert_equal "John", user.first_name
     assert_equal "Doe", user.last_name
-    assert_equal 3, user.assistants.count, "This new user did not get the expected number of assistants"
+    assert_equal 4, user.assistants.count, "This new user did not get the expected number of assistants"
 
     assistant = user.assistants.ordered.first
 

--- a/test/fixtures/assistants.yml
+++ b/test/fixtures/assistants.yml
@@ -1,5 +1,6 @@
 samantha:
   user: keith
+  slug: samantha
   language_model: gpt_4o
   name: Samantha
   description: My personal assistant
@@ -8,14 +9,16 @@ samantha:
 
 keith_gpt4:
   user: keith
+  slug: gpt-4o
   language_model: gpt_4o
-  name: OpenAI's GPT-4
-  description: OpenAI's GPT-4
+  name: OpenAI GPT-4o
+  description: OpenAI's GPT-4o
   instructions:
   tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 keith_claude3:
   user: keith
+  slug: claude-opus
   language_model: claude_3_opus_20240229
   name: Claude 3 Opus
   description: Claude 3, Opus version
@@ -24,6 +27,7 @@ keith_claude3:
 
 keith_claude35:
   user: keith
+  slug: claude-sonnet
   language_model: claude_3_5_sonnet_20240620
   name: Claude 3.5 Sonnet
   description: Claude 3.5, Sonnet version
@@ -32,6 +36,7 @@ keith_claude35:
 
 keith_gpt3:
   user: keith
+  slug: gpt-3-5-turbo
   language_model: gpt_3_5_turbo
   name: GPT 3.5
   description: OpenAI's GPT-3 but with Zen
@@ -41,6 +46,7 @@ keith_gpt3:
 
 rob_gpt4:
   user: rob
+  slug: gpt-4o
   language_model: rob_gpt
   name: GPT-4
   description: OpenAI's GPT
@@ -49,6 +55,7 @@ rob_gpt4:
 
 mandela_gpt4:
   user: rob
+  slug: mandela
   language_model: rob_gpt
   name: Mandela
   description: OpenAI assistant GPT4
@@ -59,6 +66,7 @@ mandela_gpt4:
 
 alpaca_asst:
   user: taylor
+  slug: alpaca
   language_model: alpaca
   name: Game Alpaca
   description: Play games (Alpaca backed)
@@ -68,6 +76,7 @@ alpaca_asst:
 
 pacos_asst:
   user: taylor
+  slug: pacos
   language_model: pacos
   name: Travel/Flowers
   description: Flowers themed travel advice (Pacos backed)

--- a/test/models/assistant/export_test.rb
+++ b/test/models/assistant/export_test.rb
@@ -1,0 +1,106 @@
+require "test_helper"
+
+class Assistant::ExportTest < ActiveSupport::TestCase
+  test "as_json includes language_model_api_name" do
+    assistant = assistants(:keith_gpt4)
+    assert assistant.as_json.key?("language_model_api_name")
+  end
+
+  test "language_model can be nil" do
+    assert_nil Assistant.new(language_model: nil).as_json["language_model_api_name"]
+  end
+
+  test "except api_service_name" do
+    assistant = assistants(:rob_gpt4)
+    assert_nil assistant.as_json(except: ["language_model_api_name"])["language_model_api_name"]
+  end
+
+  test "export_to_file json" do
+    path = Rails.root.join("tmp/assistants.json")
+    Assistant.export_to_file(path:, assistants: users(:keith).assistants.not_deleted)
+    assert File.exist?(path)
+    storage = JSON.load_file(path)
+    assistants = storage["assistants"]
+    assert_equal assistants.first.keys.sort, %w[name description instructions tools language_model_api_name].sort
+  end
+
+  test "export_to_file yaml" do
+    path = Rails.root.join("tmp/assistants.yml")
+    Assistant.export_to_file(path:, assistants: users(:keith).assistants.not_deleted)
+    assert File.exist?(path)
+    storage = YAML.load_file(path)
+    assistants = storage["assistants"]
+    assert_equal assistants.first.keys.sort, %w[name description instructions tools language_model_api_name].sort
+  end
+
+  test "import_from_file with only new models" do
+    user = users(:keith)
+    user.assistants.destroy_all
+    assistants = [{
+      name: "new assistant",
+      description: "new description",
+      instructions: "new instructions",
+      tools: "new tools",
+      external_id: "new external_id",
+      language_model_api_name: language_models(:gpt_4o).api_name
+    }]
+    storage = {
+      "assistants" => assistants
+    }
+    path = Rails.root.join("tmp/newmodels.yml")
+    File.write(path, storage.to_yaml)
+    assert_difference "Assistant.count", 1 do
+      Assistant.import_from_file(path:, users: [user])
+    end
+    assert user.assistants.find_by(external_id: "new external_id")
+  end
+
+  test "import_from_file json with only new models" do
+    user = users(:keith)
+    user.assistants.destroy_all
+    assistants = [{
+      name: "new assistant",
+      description: "new description",
+      instructions: "new instructions",
+      tools: "new tools",
+      external_id: "new external_id",
+      language_model_api_name: language_models(:gpt_4o).api_name
+    }]
+    storage = {
+      "assistants" => assistants
+    }
+    path = Rails.root.join("tmp/newmodels.json")
+    File.write(path, storage.to_json)
+    assert_difference "Assistant.count", 1 do
+      Assistant.import_from_file(path:, users: [user])
+    end
+    assert user.assistants.find_by(external_id: "new external_id")
+  end
+
+  test "import_from_file with existing models by name" do
+    user = users(:keith)
+    assistant = user.assistants.not_deleted.first
+    assistants = [{
+      name: assistant.name,
+      description: "new description",
+      instructions: "new instructions",
+      tools: "new tools",
+      external_id: "new external_id",
+      language_model_api_name: language_models(:gpt_4o).api_name
+    }]
+    storage = {
+      "assistants" => assistants
+    }
+    path = Rails.root.join("tmp/newmodels.yml")
+    File.write(path, storage.to_yaml)
+    assert_no_difference "Assistant.count" do
+      Assistant.import_from_file(path:, users: [user])
+    end
+    assistant.reload
+    assert_equal "new description", assistant.description
+    assert_equal "new instructions", assistant.instructions
+    assert_equal "new tools", assistant.tools
+    assert_equal "new external_id", assistant.external_id
+    assert_equal language_models(:gpt_4o).api_name, assistant.language_model_api_name
+  end
+end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -1,6 +1,20 @@
 require "test_helper"
 
 class AssistantTest < ActiveSupport::TestCase
+  test "has default slug" do
+    samantha = assistants(:samantha)
+    assert_equal "samantha", samantha.slug
+    samantha.slug = nil
+    samantha.save!
+    assert_equal "samantha", samantha.slug
+
+    keith_gpt4 = assistants(:keith_gpt4)
+    assert_equal "gpt-4o", keith_gpt4.slug
+    keith_gpt4.slug = nil
+    keith_gpt4.save!
+    assert_equal "openai-gpt-4o", keith_gpt4.slug
+  end
+
   test "has an associated user" do
     assert_instance_of User, assistants(:samantha).user
   end

--- a/test/models/assistant_test.rb
+++ b/test/models/assistant_test.rb
@@ -4,15 +4,26 @@ class AssistantTest < ActiveSupport::TestCase
   test "has default slug" do
     samantha = assistants(:samantha)
     assert_equal "samantha", samantha.slug
-    samantha.slug = nil
-    samantha.save!
-    assert_equal "samantha", samantha.slug
 
     keith_gpt4 = assistants(:keith_gpt4)
     assert_equal "gpt-4o", keith_gpt4.slug
     keith_gpt4.slug = nil
     keith_gpt4.save!
     assert_equal "openai-gpt-4o", keith_gpt4.slug
+
+    lm = language_models(:gpt_best)
+    user = users(:keith)
+    same_name1 = user.assistants.create!(language_model: lm, name: "Best OpenAI Model")
+    assert_equal "best-openai-model", same_name1.slug
+    same_name2 = user.assistants.create!(language_model: lm, name: "Best OpenAI Model")
+    assert_equal "best-openai-model--1", same_name2.slug
+    same_name3 = user.assistants.create!(language_model: lm, name: "Best OpenAI Model")
+    assert_equal "best-openai-model--2", same_name3.slug
+
+    similar_name = user.assistants.create!(language_model: lm, name: "Best OpenAI Model 2")
+    assert_equal "best-openai-model-2", similar_name.slug
+    similar_name2 = user.assistants.create!(language_model: lm, name: "Best OpenAI Model 2")
+    assert_equal "best-openai-model-2--1", similar_name2.slug
   end
 
   test "has an associated user" do

--- a/test/models/language_model/export_test.rb
+++ b/test/models/language_model/export_test.rb
@@ -76,14 +76,16 @@ class LanguageModel::ExportTest < ActiveSupport::TestCase
   end
 
   test "import_from_file with existing models by api_name" do
-    model = users(:rob).language_models.not_deleted.first
+    user = users(:rob)
+    api_name = "gpt-4o"
+    model = user.language_models.find_by(api_name:)
     models = [{
-      api_name: model.api_name,
+      api_name:,
       name: "new name",
       supports_images: false,
       supports_tools: true,
-      input_token_cost_cents: 0.0001,
-      output_token_cost_cents: 0.0001
+      input_token_cost_cents: 0.1234,
+      output_token_cost_cents: 0.5678
     }]
     storage = {
       "models" => models
@@ -91,13 +93,13 @@ class LanguageModel::ExportTest < ActiveSupport::TestCase
     path = Rails.root.join("tmp/newmodels.yml")
     File.write(path, storage.to_yaml)
     assert_no_difference "LanguageModel.count" do
-      LanguageModel.import_from_file(path:, users: users(:rob))
+      LanguageModel.import_from_file(path:, users: [user])
     end
     model.reload
     assert_equal "new name", model.name
     assert_equal false, model.supports_images
     assert_equal true, model.supports_tools
-    assert_equal 0.0001, model.input_token_cost_cents
-    assert_equal 0.0001, model.output_token_cost_cents
+    assert_equal 0.1234, model.input_token_cost_cents
+    assert_equal 0.5678, model.output_token_cost_cents
   end
 end


### PR DESCRIPTION
This PR includes #536 

Instead of new Assistants being defined in code, they are defined in `assistants.yml`.

The PR defines the same Assistants as before, plus a new "GPT-4o Mini" assistant.

Assistants have a unique (per user) slug which is used in urls `/assistants/claude-sonnet/messages/new` and used to match updates from `assistants.yml` to existing Assistant.