### PR TITLE
Store the function call with the function response

### DIFF
--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -105,7 +105,7 @@ class GetNextAIMessageJob < ApplicationJob
       else
         error_text = nil
         begin
-          error_text = e&.response&.dig(:body, "error", "message")
+          error_text = e&.response&.dig(:body, "error", "message") rescue e&.response&.dig(:body)
         end
         set_unexpected_error(msg&.slice(0...1500), error_text)
         wrap_up_the_message
@@ -196,6 +196,7 @@ class GetNextAIMessageJob < ApplicationJob
         role: tool_message[:role],
         content_text: tool_message[:content],
         tool_call_id: tool_message[:tool_call_id],
+        content_tool_calls: tool_message[:content_tool_calls],
         version: @message.version,
         index: index += 1,
         processed_at: Time.current,

--- a/app/models/message/toolable.rb
+++ b/app/models/message/toolable.rb
@@ -7,6 +7,7 @@ module Message::Toolable
     serialize :content_tool_calls, coder: JsonSerializer
 
     validates :tool_call_id, presence: true, if: :tool?
+    validates :content_tool_calls, presence: true, if: :tool?
 
     normalizes :tool_call_id, with: -> tool_call_id { tool_call_id[0...40] }
   end

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -111,7 +111,7 @@ class AIBackend::OpenAI < AIBackend
           role: message.role,
           name: message.name_for_api,
           content: message.content_text,
-          tool_calls: message.content_tool_calls, # only for some assistant messages
+          tool_calls: message.assistant? ? message.content_tool_calls : nil, # only for some assistant messages
           tool_call_id: message.tool_call_id,     # only for tool messages
         }.compact.except( message.content_tool_calls.blank? && :tool_calls )
       end

--- a/app/services/ai_backend/tools.rb
+++ b/app/services/ai_backend/tools.rb
@@ -29,6 +29,7 @@ module AIBackend::Tools
         {
           role: "tool",
           content: function_response.to_json,
+          content_tool_calls: tool_call.to_json,
           tool_call_id: id,
         }
       end

--- a/app/services/toolbox/memory.rb
+++ b/app/services/toolbox/memory.rb
@@ -15,6 +15,6 @@ class Toolbox::Memory < Toolbox
     conversation_messages = Current.message.conversation.messages.for_conversation_version(Current.message.version)
     related_message = conversation_messages.where("messages.id < ?", Current.message.id).last
     Current.user.memories.create!(detail: detail_s, message: related_message)
-    "This has been remembered"
+    "Memory updated"
   end
 end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -40,7 +40,7 @@ end %>
   > <!-- this inner div is replaced during streaming updates (inner_html of dom_id message) -->
 
     <!-- Left Column -->
-    <div class="w-6 ml-1 flex">
+    <div class="w-7 ml-1 flex">
       <%= render_avatar_for(message) %>
     </div>
 

--- a/test/fixtures/messages.yml
+++ b/test/fixtures/messages.yml
@@ -647,7 +647,7 @@ weather_tool_result:
   role: tool
   tool_call_id: abc123
   content_text: weather is
-  content_tool_calls:
+  content_tool_calls: '{"index": 0, "id": "abc123", "type": "function", "function": {"name": "helloworld_hi", "arguments": {"name": "World"}}}'
   content_document:
   created_at: 2023-12-30 1:02:00
   processed_at: 2023-12-30 1:02:00

--- a/test/jobs/get_next_ai_message_job_openai_test.rb
+++ b/test/jobs/get_next_ai_message_job_openai_test.rb
@@ -43,7 +43,7 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
     assert first_new_message.tool?
     assert_equal "Hello, Keith!".to_json, first_new_message.content_text, "First new message should have the result of calling the tool"
     assert first_new_message.tool_call_id.present?
-    assert first_new_message.content_tool_calls.blank?
+    assert first_new_message.content_tool_calls.present?
     assert_equal @message.content_tool_calls.dig(0, :id), first_new_message.tool_call_id, "ID of tool execution should have matched decision to call the tool"
     assert first_new_message.finished?, "This message SHOULD HAVE been considered finished"
 

--- a/test/models/message/toolable_test.rb
+++ b/test/models/message/toolable_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Message::ToolableTest < ActiveSupport::TestCase
   setup do
-    @has_tool_response = { role: :tool, tool_call_id: "abc123", content_text: "success" }
+    @has_tool_response = { role: :tool, tool_call_id: "abc123", content_text: "success", content_tool_calls: { function: "hello" } }
     @has_tool_calls = { content_tool_calls: { func: "hello" } }
     @has_content_text = { content_text: "Hello" }
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -91,6 +91,7 @@ class MessageTest < ActiveSupport::TestCase
         assistant: assistants(:samantha),
         role: :tool,
         content_text: "tool response",
+        content_tool_calls: { type: "function", function: { name: "memory", arguments: "memory" } },
       )
     end
   end
@@ -101,17 +102,30 @@ class MessageTest < ActiveSupport::TestCase
         assistant: assistants(:samantha),
         role: :tool,
         tool_call_id: "tool_1234",
+        content_tool_calls: { type: "function", function: { name: "memory", arguments: "memory" } },
       )
     end
   end
 
-  test "creating a tool message succeeds with both tool_call_id and content_text" do
+  test "creating a tool message fails without a content_tool_calls" do
+    assert_raises ActiveRecord::RecordInvalid do
+      conversations(:weather).messages.create!(
+        assistant: assistants(:samantha),
+        role: :tool,
+        content_text: "tool response",
+        tool_call_id: "tool_1234",
+      )
+    end
+  end
+
+  test "creating a tool message succeeds with tool_call_id, content_text, and content_tool_calls" do
     assert_nothing_raised do
       conversations(:weather).messages.create!(
         assistant: assistants(:samantha),
         role: :tool,
         content_text: "tool response",
         tool_call_id: "tool_1234",
+        content_tool_calls: { type: "function", function: { name: "memory", arguments: "memory" } },
       )
     end
   end

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -56,6 +56,7 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
       role: "tool",
       content: "\"Hello, World!\"",
       tool_call_id: "abc123",
+      content_tool_calls: messages(:weather_tool_call).content_tool_calls.first.to_json,
     }
     assert_equal [tool_message], AIBackend::OpenAI.get_tool_messages_by_calling(messages(:weather_tool_call).content_tool_calls)
   end

--- a/test/services/ai_backend/tools_test.rb
+++ b/test/services/ai_backend/tools_test.rb
@@ -6,6 +6,7 @@ class AIBackend::ToolsTest < ActiveSupport::TestCase
       role: "tool",
       content: "\"Hello, World!\"",
       tool_call_id: "abc123",
+      content_tool_calls: messages(:weather_tool_call).content_tool_calls.first.to_json,
     }
     assert_equal [tool_message], AIBackend.get_tool_messages_by_calling(messages(:weather_tool_call).content_tool_calls)
   end
@@ -18,6 +19,7 @@ class AIBackend::ToolsTest < ActiveSupport::TestCase
     msg = AIBackend::OpenAI.get_tool_messages_by_calling(tool_calls).first
     assert_equal "tool", msg[:role]
     assert_equal "abc123", msg[:tool_call_id]
+    assert_equal messages(:weather_tool_call).content_tool_calls.first.to_json, msg[:content_tool_calls]
     assert msg[:content].starts_with?('"An unexpected error occurred')
   end
 
@@ -29,6 +31,7 @@ class AIBackend::ToolsTest < ActiveSupport::TestCase
     msg = AIBackend::OpenAI.get_tool_messages_by_calling(tool_calls).first
     assert_equal "tool", msg[:role]
     assert_equal "abc123", msg[:tool_call_id]
+    assert_equal messages(:weather_tool_call).content_tool_calls.first.to_json, msg[:content_tool_calls]
     assert msg[:content].starts_with?('"An unexpected error occurred')
   end
 end


### PR DESCRIPTION
With OpenAI, when functions are called, there is a response for each function call. We store these as messages in the `conversation.messages` history. When we do this, one thing that is tricky about parsing the response is knowing which function this response is from.

OpenAI gives us back a `tool_call_id` so if you look at the preceding message in the conversation history you can use this to match it up and see which tool/function that was. But this is a little tricky within the context of a single message.

So, this PR improves matters by populating the `content_tool_calls` attribute on response messages.

To summarize:

* OpenAI gives us back a tool_calls JSON block which indicates what tools it wants to call. This is an array since it can be multiple calls.
* We call those tools and create! a new message for each response from the tool calls, and **we now populate the tool_calls attribute for each of these responses so that it's easy to see what call this is a response to.**