### PR TITLE
Register test requires password_authentication; test login pages

### DIFF
--- a/test/controllers/users/google_auth_test.rb
+++ b/test/controllers/users/google_auth_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class UsersController::GoogleAuthTest < ActionDispatch::IntegrationTest
   test "should NOT display a Google button when the feature is DISABLED" do
-    stub_features(google_authentication: false) do
+    stub_features(google_authentication: false, password_authentication: true) do
       get register_url
       assert_response :success
       assert_no_match "Sign Up with Google", response.body
@@ -10,10 +10,35 @@ class UsersController::GoogleAuthTest < ActionDispatch::IntegrationTest
   end
 
   test "should SHOW the Google button when the feature is ENABLED" do
-    stub_features(google_authentication: true) do
+    stub_features(google_authentication: true, password_authentication: true) do
       get register_url
       assert_response :success
       assert_match "Sign Up with Google", response.body
+    end
+  end
+
+  test "authentication - should NOT display a Google button when the feature is DISABLED" do
+    stub_features(google_authentication: false, password_authentication: true) do
+      get login_url
+      assert_response :success
+      assert_no_match "Log In with Google", response.body
+    end
+  end
+
+  test "authentication - should SHOW the Google button when the feature is ENABLED" do
+    stub_features(google_authentication: true, password_authentication: true) do
+      get login_url
+      assert_response :success
+      assert_match "Log In with Google", response.body
+    end
+  end
+
+  # even if password authentication is turned off, we still want to show the Microsoft button
+  test "authentication - should SHOW the Google button when password authentication is DISABLED" do
+    stub_features(google_authentication: true, password_authentication: false) do
+      get login_url
+      assert_response :success
+      assert_match "Log In with Google", response.body
     end
   end
 end

--- a/test/controllers/users/microsoft_auth_test.rb
+++ b/test/controllers/users/microsoft_auth_test.rb
@@ -1,19 +1,44 @@
 require "test_helper"
 
 class UsersController::MicrosoftAuthTest < ActionDispatch::IntegrationTest
-  test "should NOT display a Microsoft button when the feature is DISABLED" do
-    stub_features(microsoft_graph_authentication: false) do
+  test "register - should NOT display a Microsoft button when the feature is DISABLED" do
+    stub_features(microsoft_graph_authentication: false, password_authentication: true) do
       get register_url
       assert_response :success
       assert_no_match "Sign Up with Microsoft", response.body
     end
   end
 
-  test "should SHOW the Microsoft button when the feature is ENABLED" do
-    stub_features(microsoft_graph_authentication: true) do
+  test "register - should SHOW the Microsoft button when the feature is ENABLED" do
+    stub_features(microsoft_graph_authentication: true, password_authentication: true) do
       get register_url
       assert_response :success
       assert_match "Sign Up with Microsoft", response.body
+    end
+  end
+
+  test "authentication - should NOT display a Microsoft button when the feature is DISABLED" do
+    stub_features(microsoft_graph_authentication: false, password_authentication: true) do
+      get login_url
+      assert_response :success
+      assert_no_match "Log In with Microsoft", response.body
+    end
+  end
+
+  test "authentication - should SHOW the Microsoft button when the feature is ENABLED" do
+    stub_features(microsoft_graph_authentication: true, password_authentication: true) do
+      get login_url
+      assert_response :success
+      assert_match "Log In with Microsoft", response.body
+    end
+  end
+
+  # even if password authentication is turned off, we still want to show the Microsoft button
+  test "authentication - should SHOW the Microsoft button when password authentication is DISABLED" do
+    stub_features(microsoft_graph_authentication: true, password_authentication: false) do
+      get login_url
+      assert_response :success
+      assert_match "Log In with Microsoft", response.body
     end
   end
 end


### PR DESCRIPTION
I discovered these specs might fail when I had password auth disabled locally. Fleshed out more tests for `login_url` too.