### PR TITLE
Minimal template for first-time 'rails credentials:edit'

### DIFF
--- a/lib/templates/rails/credentials/credentials.yml.tt
+++ b/lib/templates/rails/credentials/credentials.yml.tt
@@ -1,0 +1,7 @@
+# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
+secret_key_base: <%= secret_key_base %>
+
+active_record_encryption:
+  primary_key: <%= SecureRandom.alphanumeric(32) %>
+  deterministic_key: <%= SecureRandom.alphanumeric(32) %>
+  key_derivation_salt: <%= SecureRandom.alphanumeric(32) %>


### PR DESCRIPTION
For example, run in a fresh clone:

```
rails credentials:edit --environment production
```

And the new credentials file will look like:

```yaml
# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.
secret_key_base: 937c27fe90d226df6ae2240fec996b07c9ff59ee220d3c8ebb77fd8c91b55f750c18a2a1ac2c128b491a770eca31b61e40ee76d3cd7fffd662dca40c3d8fe804

active_record_encryption:
  primary_key: Q3BAWVGwI6b7hZ1zhIMPIkiLHJAM3aKE
  deterministic_key: UppSQI7oclRFsMakMv4QAO2KmVgUJKje
  key_derivation_salt: 0hJxhKY7Tw5HnlnaiW7hBJE6tQ9qIBRw
```