### PR TITLE
Set OpenAI ApiVersion to empty on initialization

### DIFF
--- a/app/models/api_service.rb
+++ b/app/models/api_service.rb
@@ -1,5 +1,5 @@
 class APIService < ApplicationRecord
-  URL_OPEN_AI = "https://api.openai.com/"
+  URL_OPEN_AI = "https://api.openai.com/v1/"
   URL_ANTHROPIC = "https://api.anthropic.com/"
   URL_GROQ = "https://api.groq.com/openai/v1/"
   URL_GEMINI = "https://generativelanguage.googleapis.com/v1beta/"

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -19,7 +19,7 @@ class AIBackend::OpenAI < AIBackend
     begin
       raise ::OpenAI::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
       Rails.logger.info "Connecting to OpenAI API server at #{assistant.api_service.url} with access token of length #{assistant.api_service.effective_token.to_s.length}"
-      @client = self.class.client.new(uri_base: assistant.api_service.url, access_token: assistant.api_service.effective_token)
+      @client = self.class.client.new(uri_base: assistant.api_service.url, access_token: assistant.api_service.effective_token, api_version: "")
     rescue ::Faraday::UnauthorizedError => e
       raise ::OpenAI::ConfigurationError
     end

--- a/db/migrate/20240622100000_move_system_language_models_to_users.rb
+++ b/db/migrate/20240622100000_move_system_language_models_to_users.rb
@@ -14,7 +14,7 @@ class MoveSystemLanguageModelsToUsers < ActiveRecord::Migration[7.1]
     Rails.logger.info "Create api_services/language_models records for all #{User.count} users records"
     User.all.find_each do |user|
       Rails.logger.info "Create api_services records for OpenAI for user #{user.id}"
-      openai_api_service = user.api_services.create!(name: "OpenAI", driver: :openai, url: "https://api.openai.com/", token: user.openai_key)
+      openai_api_service = user.api_services.create!(name: "OpenAI", driver: :openai, url: "https://api.openai.com/v1/", token: user.openai_key)
       Rails.logger.info "Create api_services records for Anthropic for user #{user.id}"
       anthropic_api_service = user.api_services.create!(name: "Anthropic", driver: :anthropic, url: "https://api.anthropic.com/", token: user.anthropic_key)
 

--- a/db/migrate/20241212091318_add_v1_to_api_services_url.rb
+++ b/db/migrate/20241212091318_add_v1_to_api_services_url.rb
@@ -1,0 +1,12 @@
+class AddV1ToAPIServicesURL < ActiveRecord::Migration[7.2]
+  def up
+    APIService.where(url: "https://api.openai.com/").each do |api_service|
+      api_service.update(url: api_service.url+"v1/")
+    end
+  end
+  def down
+    APIService.where(url: "https://api.openai.com/v1/").each do |api_service|
+      api_service.update(url: api_service.url.gsub("v1/",""))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_26_084628) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_12_091318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/test/fixtures/api_services.yml
+++ b/test/fixtures/api_services.yml
@@ -1,7 +1,7 @@
 keith_openai_service:
   name: OpenAI
   user: keith
-  url: https://api.openai.com/
+  url: https://api.openai.com/v1/
   token: abc-secret
   driver: openai
 
@@ -30,7 +30,7 @@ keith_other_service:
 rob_openai_service:
   name: OpenAI
   user: rob
-  url: https://api.openai.com/
+  url: https://api.openai.com/v1/
   token: rob-secret
   driver: openai
 

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -19,7 +19,7 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
   end
 
   test "openai url is properly set" do
-    assert_equal "https://api.openai.com/", @openai.client.uri_base
+    assert_equal "https://api.openai.com/v1/", @openai.client.uri_base
   end
 
   test "get_oneoff_message responds with a reply" do

--- a/test/support/test_client/open_ai.rb
+++ b/test/support/test_client/open_ai.rb
@@ -2,7 +2,7 @@ module TestClient
   class OpenAI
     attr_reader :uri_base
 
-    def initialize(access_token:, uri_base:nil)
+    def initialize(access_token:, uri_base:nil, api_version: "")
       @uri_base = uri_base
     end
 


### PR DESCRIPTION
Set OpenAI ApiVersion to be empty during initialization; otherwise the Ruby-Openai gem will force v1 in the URL