### PR TITLE
Improve usability of dragging dropping files

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -189,3 +189,15 @@ input:focus {
 nav {
   -webkit-touch-callout: none !important;
 }
+
+#drag-n-drop-shade {
+  outline: 8px dashed #888;
+  outline-offset: -10px;  
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  z-index: 99999;
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -191,8 +191,8 @@ nav {
 }
 
 #drag-n-drop-shade {
-  outline: 8px dashed #888;
-  outline-offset: -10px;  
+  outline: 8px dashed #000;
+  outline-offset: -10px;
   background-color: rgba(0, 0, 0, 0.5);
   position: fixed;
   width: 100%;
@@ -200,4 +200,8 @@ nav {
   top: 0;
   left: 0;
   z-index: 99999;
+}
+
+.dark #drag-n-drop-shade {
+  outline-color: #888;
 }

--- a/app/javascript/stimulus/image_upload_controller.js
+++ b/app/javascript/stimulus/image_upload_controller.js
@@ -39,7 +39,32 @@ export default class extends Controller {
     event.preventDefault() // w/o this chrome opens a new browser tab w/ the image
     let files = event.dataTransfer.files
     this.fileTarget.files = files
+    const shade = this.element.querySelector("#drag-n-drop-shade")
+    if (shade) shade.remove()
     this.previewUpdate()
+  }
+
+  boundDragOver = (event) => this.dragOver(event)
+  dragOver(event) {
+    event.preventDefault()
+    this.insertShadeElement()
+  }
+
+  boundDragLeave = (event) => this.dragLeave(event)
+  dragLeave(event) {
+    event.preventDefault()
+    this.dragCounter--
+    if (this.dragCounter === 0) {
+      const shade = this.element.querySelector("#drag-n-drop-shade")
+      if (shade) shade.remove()
+    }
+  }
+
+  boundDragEnter = (event) => this.dragEnter(event)
+  dragEnter(event) {
+    event.preventDefault()
+    this.dragCounter++
+    this.insertShadeElement()
   }
 
   boundPasted = async (event) => { this.pasted(event) }
@@ -70,6 +95,16 @@ export default class extends Controller {
       }
       reader.readAsDataURL(blob)
     })
+  }
+
+  insertShadeElement() {
+    const existing = this.element.querySelector("#drag-n-drop-shade")
+    if (existing) return
+    
+    this.element.insertAdjacentHTML(
+      'beforeend',
+      '<div id="drag-n-drop-shade"></div>'
+    );
   }
 
   addImageToFileInput(dataURL, fileType) {

--- a/app/javascript/stimulus/image_upload_controller.js
+++ b/app/javascript/stimulus/image_upload_controller.js
@@ -4,15 +4,12 @@ export default class extends Controller {
   static targets = [ "file", "content", "preview" ]
 
   connect() {
-    this.fileTarget.addEventListener("change", this.boundPreviewUpdate)
-    this.contentTarget.addEventListener("drop", this.boundDropped)
-    this.contentTarget.addEventListener("paste", this.boundPasted)
+    this.dragCounter = 0
+    this.element.addEventListener("drop", this.boundDropped)
   }
 
   disconnect() {
-    this.fileTarget.removeEventListener("change", this.boundPreviewUpdate)
-    this.contentTarget.removeEventListener("drop", this.boundDropped)
-    this.contentTarget.removeEventListener("paste", this.boundPasted)
+    this.element.removeEventListener("drop", this.boundDropped)
   }
 
   boundPreviewUpdate = () => { this.previewUpdate() }

--- a/app/javascript/stimulus/image_upload_controller.js
+++ b/app/javascript/stimulus/image_upload_controller.js
@@ -8,12 +8,18 @@ export default class extends Controller {
     this.fileTarget.addEventListener("change", this.boundPreviewUpdate)
     this.element.addEventListener("drop", this.boundDropped)
     this.contentTarget.addEventListener("paste", this.boundPasted)
+    this.element.addEventListener("dragenter", this.boundDragEnter)
+    this.element.addEventListener("dragover", this.boundDragOver)
+    this.element.addEventListener("dragleave", this.boundDragLeave)
   }
 
   disconnect() {
     this.fileTarget.removeEventListener("change", this.boundPreviewUpdate)
     this.element.removeEventListener("drop", this.boundDropped)
     this.contentTarget.removeEventListener("paste", this.boundPasted)
+    this.element.removeEventListener("dragenter", this.boundDragEnter)
+    this.element.removeEventListener("dragover", this.boundDragOver)
+    this.element.removeEventListener("dragleave", this.boundDragLeave)
   }
 
   boundPreviewUpdate = () => { this.previewUpdate() }
@@ -51,7 +57,7 @@ export default class extends Controller {
   boundDragOver = (event) => this.dragOver(event)
   dragOver(event) {
     event.preventDefault()
-    this.insertShadeElement()
+    this.displayDragnDropShade()
   }
 
   boundDragLeave = (event) => this.dragLeave(event)
@@ -68,7 +74,7 @@ export default class extends Controller {
   dragEnter(event) {
     event.preventDefault()
     this.dragCounter++
-    this.insertShadeElement()
+    this.displayDragnDropShade()
   }
 
   boundPasted = async (event) => { this.pasted(event) }
@@ -101,7 +107,7 @@ export default class extends Controller {
     })
   }
 
-  insertShadeElement() {
+  displayDragnDropShade() {
     const existing = this.element.querySelector("#drag-n-drop-shade")
     if (existing) return
     

--- a/app/javascript/stimulus/image_upload_controller.js
+++ b/app/javascript/stimulus/image_upload_controller.js
@@ -5,11 +5,15 @@ export default class extends Controller {
 
   connect() {
     this.dragCounter = 0
+    this.fileTarget.addEventListener("change", this.boundPreviewUpdate)
     this.element.addEventListener("drop", this.boundDropped)
+    this.contentTarget.addEventListener("paste", this.boundPasted)
   }
 
   disconnect() {
+    this.fileTarget.removeEventListener("change", this.boundPreviewUpdate)
     this.element.removeEventListener("drop", this.boundDropped)
+    this.contentTarget.removeEventListener("paste", this.boundPasted)
   }
 
   boundPreviewUpdate = () => { this.previewUpdate() }

--- a/app/javascript/stimulus/image_upload_controller.js
+++ b/app/javascript/stimulus/image_upload_controller.js
@@ -46,11 +46,13 @@ export default class extends Controller {
 
   boundDropped = (event) => { this.dropped(event) }
   dropped(event) {
-    event.preventDefault() // w/o this chrome opens a new browser tab w/ the image
-    let files = event.dataTransfer.files
-    this.fileTarget.files = files
+    event.preventDefault()
+    this.dragCounter = 0
     const shade = this.element.querySelector("#drag-n-drop-shade")
     if (shade) shade.remove()
+  
+    let files = event.dataTransfer.files
+    this.fileTarget.files = files
     this.previewUpdate()
   }
 
@@ -64,7 +66,8 @@ export default class extends Controller {
   dragLeave(event) {
     event.preventDefault()
     this.dragCounter--
-    if (this.dragCounter === 0) {
+    if (this.dragCounter <= 0) {
+      this.dragCounter = 0
       const shade = this.element.querySelector("#drag-n-drop-shade")
       if (shade) shade.remove()
     }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
       class="fixed inset-0 bg-black z-20 bg-opacity-40 md:hidden nav-closed:hidden "
       data-action="click->transition#toggleClass"
       ></div>
-    <main id="main-container" class="flex flex-1 h-full w-full bg-white dark:bg-gray-800 text-gray-950 dark:text-gray-100 px-safe" data-controller="image-upload" data-action="dragover->image-upload#dragOver dragleave->image-upload#dragLeave drop->image-upload#dropped">
+    <main id="main-container" class="flex flex-1 h-full w-full bg-white dark:bg-gray-800 text-gray-950 dark:text-gray-100 px-safe" data-controller="image-upload">
       <%= content_for?(:main) ? yield(:main) : yield %>
     </main>
     <%= render "layouts/alerts" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
       class="fixed inset-0 bg-black z-20 bg-opacity-40 md:hidden nav-closed:hidden "
       data-action="click->transition#toggleClass"
       ></div>
-    <main id="main-container" class="flex flex-1 h-full w-full bg-white dark:bg-gray-800 text-gray-950 dark:text-gray-100 px-safe">
+    <main id="main-container" class="flex flex-1 h-full w-full bg-white dark:bg-gray-800 text-gray-950 dark:text-gray-100 px-safe" data-controller="image-upload" data-action="dragover->image-upload#dragOver dragleave->image-upload#dragLeave drop->image-upload#dropped">
       <%= content_for?(:main) ? yield(:main) : yield %>
     </main>
     <%= render "layouts/alerts" %>

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -173,7 +173,7 @@
             data-role="preview"
           >
             <%= button_tag type: "button",
-              class: "rounded-full absolute -top-2 -right-2 border border-gray-300 bg-gray-200 hidden group-hover:block",
+              class: "rounded-full absolute -top-2 -right-2 border border-gray-300 bg-gray-200 dark:bg-gray-800 hidden group-hover:block",
               data: {
                 action: "image-upload#remove",
                 role: "preview-remove"

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -140,7 +140,7 @@
           pl-6 pr-6 mx-auto mb-6
           w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px]
         "
-        data-controller="composer image-upload"
+        data-controller="composer"
         data-composer-speaker-outlet="[data-controller~='speaker']"
       >
         <%= button_tag type: "button",

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -92,8 +92,6 @@ end %>
                   border-2 border-gray-100 dark:border-gray-400
                   rounded-md
                 |,
-                width: 1,
-                height: 1,
                 data: {
                   image_loader_target: "image",
                   action: %|


### PR DESCRIPTION
# [Issue #131] Enhance Drag and Drop UX with Window-Wide Drop Zone

This PR implements an improved drag and drop experience by:
- Making the entire browser window act as a drop target
- Adding clear visual feedback during drag operations
- Handling edge cases like canceled drag operations

## Implementation Details
The window now provides visual cues during drag interactions:
- Displays a thick dotted border around the inner window perimeter
- Dims the background color to indicate an active drag state
- Gracefully reverts visual state if drag is canceled

## Demo
[Video demonstration of the new drag and drop behavior](https://www.loom.com/share/7a5986f54ce6457da4e8b9ab02f7d365)

Note: Visual styling (border style, background opacity) can be adjusted based on feedback.