### PR TITLE
Better handling of assistant import

### DIFF
--- a/app/models/assistant/export.rb
+++ b/app/models/assistant/export.rb
@@ -42,9 +42,17 @@ module Assistant::Export
       assistants.each do |assistant|
         assistant = assistant.with_indifferent_access
         users.each do |user|
-          asst = user.assistants.find_or_create_by(slug: assistant["slug"])
-          asst.assign_attributes(assistant.except("slug"))
-          asst.save!
+          existing = user.assistants.not_deleted.find_by(slug: assistant["slug"])
+          if existing
+            existing.assign_attributes(assistant.except("slug", "language_model_api_name"))
+            existing.language_model_api_name = assistant["language_model_api_name"]
+            existing.save!
+          elsif !user.assistants.where(slug: assistant["slug"]).where.not(deleted_at: nil).exists?
+            attrs = assistant.except("language_model_api_name")
+            new_assistant = user.assistants.new(attrs)
+            new_assistant.language_model_api_name = assistant["language_model_api_name"]
+            new_assistant.save!
+          end
         end
       end
     end

--- a/app/models/assistant/slug.rb
+++ b/app/models/assistant/slug.rb
@@ -4,6 +4,7 @@ module Assistant::Slug
   included do
     before_validation :set_default_slug
     before_validation :clear_conflicting_deleted_assistant_slug
+    validates :slug, uniqueness: { scope: :user_id, message: "has already been taken" }
   end
 
   private

--- a/test/controllers/settings/assistants_controller_test.rb
+++ b/test/controllers/settings/assistants_controller_test.rb
@@ -24,6 +24,24 @@ class Settings::AssistantsControllerTest < ActionDispatch::IntegrationTest
     assert_equal params, Assistant.last.slice(:name, :description, :instructions, :language_model_id)
   end
 
+  test "should show error when creating assistant with duplicate slug" do
+    existing_assistant = assistants(:samantha)
+    params = {
+      name: "New Assistant",
+      slug: existing_assistant.slug,
+      description: "A new description",
+      instructions: "New instructions",
+      language_model_id: language_models(:gpt_4o).id
+    }
+
+    assert_no_difference("Assistant.count") do
+      post settings_assistants_url, params: { assistant: params }
+    end
+
+    assert_response :unprocessable_entity
+    assert_contains_text "main", "Slug has already been taken"
+  end
+
   test "should get edit" do
     get edit_settings_assistant_url(@assistant)
     assert_response :success


### PR DESCRIPTION
This PR ensures a few key cases work correctly:

1) When you delete an assistant, it will not be imported again from assistants.yml
2) When you delete an assistant, you can create a new assistant with that old slug
3) Slugs for non-deleted assistants are still enforced to be unique