### PR TITLE
Remove the best column from the database with a migration and remove it from the UIs

### DIFF
--- a/app/controllers/settings/language_models_controller.rb
+++ b/app/controllers/settings/language_models_controller.rb
@@ -36,6 +36,8 @@ class Settings::LanguageModelsController < Settings::ApplicationController
 
   def test
     @language_model = Current.user.language_models.find_by(id: params[:language_model_id])
+    # TODO: The user may be changing the api-name and the ai-service at the same time.
+    # So also should use the api-service for the test
     @answer = @language_model.test(params[:model])
 
     respond_to do |format|

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -40,7 +40,7 @@ class LanguageModel < ApplicationRecord
   def effective_api_name
     if api_name =~ /-best\Z/
       begin
-        Current.user.language_models.best_for_api_service(api_service).first.api_name
+        api_service.language_models.best_for_api_service(api_service).first.api_name # there should be only one.
       rescue => e
         Rails.logger.info "Could not resolve best model for #{api_name} from API service #{api_service.name} : #{e}"
         raise "Could not resolve best model for #{api_name} from API service #{api_service.name}"

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -35,6 +35,21 @@ class LanguageModel < ApplicationRecord
     ai_backend.test_language_model(self, api_name)
   end
 
+  # Records can be labelled "best" for that API Service. When an api_name ends in "-best" we use the one
+  # labelled best for the service. Note the api_service's are scoped to the user.
+  def effective_api_name
+    if api_name =~ /-best\Z/
+      begin
+        Current.user.language_models.best_for_api_service(api_service).first.api_name
+      rescue => e
+        Rails.logger.info "Could not resolve best model for #{api_name} from API service #{api_service.name} : #{e}"
+        raise "Could not resolve best model for #{api_name} from API service #{api_service.name}"
+      end
+    else
+      api_name
+    end
+  end
+
   private
 
   def populate_position

--- a/app/models/run.rb
+++ b/app/models/run.rb
@@ -14,6 +14,6 @@ class Run < ApplicationRecord
   private
 
   def set_model
-    self.model = assistant&.language_model&.api_name
+    self.model = assistant&.language_model&.effective_api_name
   end
 end

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -49,7 +49,7 @@ class AIBackend
   end
 
   def self.test_language_model(language_model, api_name = nil)
-    api_name ||= language_model.api_name
+    api_name ||= language_model.effective_api_name
     url = language_model.api_service.url
     token = language_model.api_service.effective_token
     return "Error: API key (token) is blank" if language_model.api_service.requires_token? && token.blank?
@@ -61,7 +61,7 @@ class AIBackend
     url ||= api_service.url
     token ||= api_service.effective_token
     language_model = LanguageModel.where(best: true, api_service: api_service).first
-    api_name = language_model.api_name unless language_model.nil?
+    api_name = language_model.effective_api_name unless language_model.nil?
 
     return "Error: API key (token) is blank" if api_service.requires_token? && token.blank?
     return "Error: API name is blank. Define a best Language Model for this API service." if api_name.blank?

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -59,7 +59,7 @@ class AIBackend::Anthropic < AIBackend
     super(config)
 
     @client_config = {
-      model: @assistant.language_model.api_name,
+      model: @assistant.language_model.effective_api_name,
       system: config[:instructions],
       messages: config[:messages],
       parameters: {

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -48,7 +48,7 @@ class AIBackend::Gemini < AIBackend
           version: "v1beta"
         },
         options: {
-          model: assistant.language_model.api_name,
+          model: assistant.language_model.effective_api_name,
           server_sent_events: true
         }
       )

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -63,7 +63,7 @@ class AIBackend::OpenAI < AIBackend
 
     @client_config = {
       parameters: {
-        model: @assistant.language_model.api_name,
+        model: @assistant.language_model.effective_api_name,
         messages: system_message(config[:instructions]) + config[:messages],
         stream: config[:streaming] && @response_handler || nil,
         max_tokens: 2000, # we should really set this dynamically, based on the model, to the max

--- a/test/controllers/settings/language_models_controller_test.rb
+++ b/test/controllers/settings/language_models_controller_test.rb
@@ -207,4 +207,12 @@ class Settings::LanguageModelsControllerTest < ActionDispatch::IntegrationTest
       assert_contains_text "div#test_result", "Success."
     end
   end
+
+  test "test should return success and a message when ends in best" do
+    TestClient::OpenAI.stub :text, "Success." do
+      get settings_language_model_test_url(format: :turbo_stream, language_model_id: language_models(:gpt_best).id, model: "gpt-best")
+      assert_response :success
+      assert_contains_text "div#test_result", "Success."
+    end
+  end
 end

--- a/test/fixtures/language_models.yml
+++ b/test/fixtures/language_models.yml
@@ -148,7 +148,6 @@ gpt_best:
   position: 1
   user: keith
   name: Best OpenAI Model
-  best: true
   api_name: gpt-best
   api_service: keith_openai_service
   supports_images: true
@@ -175,6 +174,7 @@ gpt_4o:
   name: GPT-4o (latest)
   api_name: gpt-4o
   api_service: keith_openai_service
+  best: true
   supports_images: true
   supports_tools: true
   input_token_cost_cents: 0.0001

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -23,7 +23,8 @@ class LanguageModelTest < ActiveSupport::TestCase
     assert_equal "gpt-4o-2024-05-13", language_models(:gpt_4o_2024_05_13).effective_api_name
   end
 
-  test "effective_api_name needs current user when api_name ends in best" do
+  test "effective_api_name fails with message when api_name ends in best" do
+    language_models(:gpt_4o).update!(best: false)
     exc = assert_raises do 
       language_models(:gpt_best).effective_api_name
     end

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -18,6 +18,24 @@ class LanguageModelTest < ActiveSupport::TestCase
     refute language_models(:guanaco).supports_tools?
   end
 
+  test "has effective_api_name when not -best" do
+    assert_equal "gpt-4o", language_models(:gpt_4o).effective_api_name
+    assert_equal "gpt-4o-2024-05-13", language_models(:gpt_4o_2024_05_13).effective_api_name
+  end
+
+  test "effective_api_name needs current user when api_name ends in best" do
+    exc = assert_raises do 
+      language_models(:gpt_best).effective_api_name
+    end
+    assert_equal "Could not resolve best model for gpt-best from API service OpenAI", exc.to_s
+  end
+
+  test "has effective_api_name when api_name ends in best" do
+    Current.stub :user, users(:keith) do
+      assert_equal "gpt-4o", language_models(:gpt_best).effective_api_name
+    end
+  end
+
   test "ai_backend works as a delegated attribute" do
     assert_equal AIBackend::OpenAI, language_models(:gpt_best).ai_backend
   end

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -25,7 +25,7 @@ class LanguageModelTest < ActiveSupport::TestCase
 
   test "effective_api_name fails with message when api_name ends in best" do
     language_models(:gpt_4o).update!(best: false)
-    exc = assert_raises do 
+    exc = assert_raises do
       language_models(:gpt_best).effective_api_name
     end
     assert_equal "Could not resolve best model for gpt-best from API service OpenAI", exc.to_s

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -42,7 +42,7 @@ class RunTest < ActiveSupport::TestCase
 
   test "effective model populated from conversations language_model" do
     assistant = assistants(:keith_claude3)
-    assistant.language_model.stub :effective_api_name, 'test-effective' do
+    assistant.language_model.stub :effective_api_name, "test-effective" do
       r = Run.create!(
         assistant: assistant,
         conversation: conversations(:greeting),

--- a/test/models/run_test.rb
+++ b/test/models/run_test.rb
@@ -40,6 +40,20 @@ class RunTest < ActiveSupport::TestCase
       assert_equal "claude-3-opus-20240229", r.model
   end
 
+  test "effective model populated from conversations language_model" do
+    assistant = assistants(:keith_claude3)
+    assistant.language_model.stub :effective_api_name, 'test-effective' do
+      r = Run.create!(
+        assistant: assistant,
+        conversation: conversations(:greeting),
+        instructions: "Some instructions",
+        status: "queued",
+        expired_at: 1.minute.from_now
+      )
+      assert_equal "test-effective", r.model
+    end
+  end
+
   test "associations are deleted upon destroy" do
     assert_difference "Step.count", -1 do
       runs(:hear_me_response).destroy

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -19,7 +19,7 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
   end
 
   test "client uses effective api name for language model" do
-    @assistant.language_model.stub :effective_api_name, 'test-effective' do
+    @assistant.language_model.stub :effective_api_name, "test-effective" do
       @anthropic = AIBackend::Anthropic.new(
         users(:keith),
         @assistant,
@@ -27,7 +27,7 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
         @conversation.latest_message_for_version(:latest)
       )
       @anthropic.send(:set_client_config,{})
-      assert_equal 'test-effective', @anthropic.instance_eval('@client_config')[:model]
+      assert_equal "test-effective", @anthropic.instance_eval("@client_config")[:model]
     end
   end
 

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -18,6 +18,19 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
     assert @anthropic.client.present?
   end
 
+  test "client uses effective api name for language model" do
+    @assistant.language_model.stub :effective_api_name, 'test-effective' do
+      @anthropic = AIBackend::Anthropic.new(
+        users(:keith),
+        @assistant,
+        @conversation,
+        @conversation.latest_message_for_version(:latest)
+      )
+      @anthropic.send(:set_client_config,{})
+      assert_equal 'test-effective', @anthropic.instance_eval('@client_config')[:model]
+    end
+  end
+
   test "stream_next_conversation_message works to stream text and uses model from assistant" do
     assert_not_equal @assistant, @conversation.assistant, "Should force this next message to use a different assistant so these don't match"
 

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -17,14 +17,14 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
   end
 
   test "client uses effective api name for language model" do
-    @assistant.language_model.stub :effective_api_name, 'test-effective' do
+    @assistant.language_model.stub :effective_api_name, "test-effective" do
       @gemini = AIBackend::Gemini.new(
         users(:keith),
         @assistant,
         @conversation,
         @conversation.latest_message_for_version(:latest)
       )
-      assert_equal 'test-effective', @gemini.client.init_args[:options][:model]
+      assert_equal "test-effective", @gemini.client.init_args[:options][:model]
     end
   end
 end

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class AIBackend::GeminiTest < ActiveSupport::TestCase
+  setup do
+    @conversation = conversations(:gemini_conversation)
+    @assistant = assistants(:keith_gemini)
+    @gemini = AIBackend::Gemini.new(
+      users(:keith),
+      @assistant,
+      @conversation,
+      @conversation.latest_message_for_version(:latest)
+    )
+  end
+
+  test "initializing client works" do
+    assert @gemini.client.present?
+  end
+
+  test "client uses effective api name for language model" do
+    @assistant.language_model.stub :effective_api_name, 'test-effective' do
+      @gemini = AIBackend::Gemini.new(
+        users(:keith),
+        @assistant,
+        @conversation,
+        @conversation.latest_message_for_version(:latest)
+      )
+      assert_equal 'test-effective', @gemini.client.init_args[:options][:model]
+    end
+  end
+end

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -19,10 +19,10 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
   end
 
   test "client uses effective api name for language model" do
-    @openai.stub :system_message, 'test-system-message' do # Not sure how not to stub this one
-      @assistant.language_model.stub :effective_api_name, 'test-effective' do
-        @openai.send(:set_client_config,{messages: 'test-msg'})
-        assert_equal 'test-effective', @openai.instance_eval('@client_config')[:parameters][:model]
+    @openai.stub :system_message, "test-system-message" do # Not sure how not to stub this one
+      @assistant.language_model.stub :effective_api_name, "test-effective" do
+        @openai.send(:set_client_config, {messages: "test-msg"})
+        assert_equal "test-effective", @openai.instance_eval("@client_config")[:parameters][:model]
       end
     end
   end

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -18,6 +18,14 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
     assert @openai.client.present?
   end
 
+  test "client uses effective api name for language model" do
+    @openai.stub :system_message, 'test-system-message' do # Not sure how not to stub this one
+      @assistant.language_model.stub :effective_api_name, 'test-effective' do
+        @openai.send(:set_client_config,{messages: 'test-msg'})
+        assert_equal 'test-effective', @openai.instance_eval('@client_config')[:parameters][:model]
+      end
+    end
+  end
   test "openai url is properly set" do
     assert_equal "https://api.openai.com/v1/", @openai.client.uri_base
   end

--- a/test/support/test_client/gemini.rb
+++ b/test/support/test_client/gemini.rb
@@ -1,6 +1,8 @@
 module TestClient
   class Gemini
+    attr_reader :init_args
     def initialize(args)
+      @init_args = args.dup
     end
 
     def self.text


### PR DESCRIPTION
Added new method `LanguageModel#effective_api_name`. When the `api_name` of a `LanguageModel` ends in `-best` this method looks up the language model of its `APIService` that has the `best` flag set.

1. I don't think the Export class needs to resolve the (new) effective_api_name.
2. The Export functionality seems the only where the Assistant code references api_name. So no need to change the Assistant model code.
3. Added comment about the language model Test link (such a nice feature) that it should also take into account the API Service (File `app/controllers/settings/language_models_controller.rb`)

Fixes issue #592 