### PR TITLE
Update Groq Models

### DIFF
--- a/assistants.yml
+++ b/assistants.yml
@@ -8,7 +8,10 @@ assistants:
   language_model_api_name: claude-3-5-sonnet-20241022
 - name: Meta Llama
   slug: llama-3-70b
-  language_model_api_name: llama-3.1-70b-versatile
+  language_model_api_name: llama-3.3-70b-versatile
+- name: DeepSeek R1
+  slug: deepseek-r1
+  language_model_api_name: deepseek-r1-distill-llama-70B
 - name: Gemini Pro 1.5
   slug: gemini-1-5-pro
   language_model_api_name: gemini-1.5-pro-002

--- a/models.yml
+++ b/models.yml
@@ -18,10 +18,19 @@ models:
   best: true
   supports_system_message: true
   api_service_name: Anthropic
-- api_name: llama-3.1-70b-versatile
-  name: Meta Llama 3.1 70b Versatile
+- api_name: deepseek-r1-distill-llama-70B
+  name: DeepSeek R1 Distill Llama 70B
   supports_images: false
-  supports_tools: true
+  supports_tools: false
+  input_token_cost_cents: '0.000075'
+  output_token_cost_cents: '0.000099'
+  best: true
+  supports_system_message: true
+  api_service_name: Groq
+- api_name: llama-3.3-70b-versatile
+  name: Llama 3.3 70B Versatile 128k
+  supports_images: false
+  supports_tools: false
   input_token_cost_cents: '0.000059'
   output_token_cost_cents: '0.000079'
   best: true

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -58,7 +58,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     user = Person.find_by(email: email).user
     assert_equal "John", user.first_name
     assert_equal "Doe", user.last_name
-    assert_equal 4, user.assistants.count, "This new user did not get the expected number of assistants"
+    assert_equal 5, user.assistants.count, "This new user did not get the expected number of assistants"
 
     assistant = user.assistants.ordered.first
 


### PR DESCRIPTION
The `llama-3.1-70b-versatile` model has been removed from the Groq API. With deepseek-r1's rising popularity, testing distilled versions on Groq's infrastructure could be worthwhile.

- add deepseek-r1-distill-llama-70B
- replace llama-3.1-70b-versatile with llama-3.3-70b-versatile

Note that Groq doesn't support the max. context lengths of 128K on the free tier. At least I get an API error if I exceed ~6000 tokens:

```
 Request too large for model deepseek-r1-distill-llama-70b in organization XYZ service tier on_demand
 on tokens per minute (TPM): Limit 6000, Requested 16955, please reduce your message size and try again.
 Visit https://console.groq.com/docs/rate-limits for more information.
```