### PR TITLE
Remove `ruby-lsp` from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ group :development do
 
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "standard"
-  gem "ruby-lsp"
   gem "rubocop-rails"
   gem "rubocop-capybara"
   gem "rubocop-minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,8 +346,6 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     rb_sys (0.9.106)
-    rbs (3.9.4)
-      logger
     rdoc (6.13.1)
       psych (>= 4.0.0)
     redcarpet (3.6.1)
@@ -394,11 +392,6 @@ GEM
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
-    ruby-lsp (0.23.20)
-      language_server-protocol (~> 3.17.0)
-      prism (>= 1.2, < 2.0)
-      rbs (>= 3, < 4)
-      sorbet-runtime (>= 0.5.10782)
     ruby-openai (7.0.1)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
@@ -430,7 +423,6 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (~> 1.3.1)
-    sorbet-runtime (0.5.12104)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -551,7 +543,6 @@ DEPENDENCIES
   rubocop-minitest
   rubocop-rails
   ruby-anthropic (~> 0.4.0)
-  ruby-lsp
   ruby-openai (~> 7.0.1)
   selenium-webdriver
   solid_queue (~> 1.0.0)


### PR DESCRIPTION
As per the ruby-lsp docs, it is not necessary to add Ruby LSP to the Gemfile:

https://shopify.github.io/ruby-lsp/#composed-ruby-lsp-bundle