### PR TITLE
Localize Share Conversation dialog

### DIFF
--- a/app/views/conversations/_share_modal.html.erb
+++ b/app/views/conversations/_share_modal.html.erb
@@ -6,17 +6,17 @@
 >
   <div class="modal-box max-w-2xl dark:bg-black">
     <header class="font-bold text-lg mb-5">
-      Share this conversation
+      <%= t('app.share.title') %>
     </header>
 
     <div class="space-y-4">
       <p class="text-gray-600 dark:text-gray-400">
-        Share a publicly accessible link to this conversation. Anyone with the link will be able to view the conversation.
+        <%= t('app.share.description') %>
       </p>
 
       <div class="form-control">
         <label class="label">
-          <span class="label-text">Shareable URL</span>
+          <span class="label-text"><%= t('app.share.url') %></span>
         </label>
         <div class="flex gap-2">
           <input
@@ -32,24 +32,24 @@
             class="btn btn-primary"
           >
             <%= icon "clipboard", variant: :outline, size: 20 %>
-            Copy
+            <%= t('app.share.copy') %>
           </button>
         </div>
         <div
           data-share-target="copiedMessage"
           class="hidden text-sm text-green-600 dark:text-green-400 mt-2"
         >
-          Copied to clipboard!
+          <%= t('app.share.copied') %>
         </div>
       </div>
 
       <div class="alert alert-warning">
         <%= icon "exclamation-triangle", variant: :outline, size: 20 %>
-        <span>Anyone with this link can view this conversation. Be careful not to share sensitive information.</span>
+        <span><%= t('app.share.warning') %></span>
       </div>
     </div>
   </div>
   <form method="dialog" class="modal-backdrop no-focus-outline">
-    <button>close</button>
+    <button><%= t('app.share.close') %></button>
   </form>
 </dialog>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -251,6 +251,14 @@ de:
         created: "Dokument wurde erfolgreich erstellt."
         updated: "Dokument wurde erfolgreich aktualisiert."
         destroyed: "Dokument wurde erfolgreich gelöscht."
+    share:
+      title: "Diese Unterhaltung teilen"
+      description: "Teilen Sie einen öffentlich zugänglichen Link zu dieser Konversation. Jeder mit diesem Link kann die Konversation ansehen."
+      url: "Teilbare Link"
+      copy: "Kopieren"
+      copied: "In die Zwischenablage kopiert!"
+      warning: "Jeder mit diesem Link kann diese Konversation ansehen. Achten Sie darauf, keine sensiblen Informationen zu teilen."
+      close: "Schließen"
     helpers:
       messages:
         from_user: "Du"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -280,6 +280,14 @@ en:
         created: "Document was successfully created."
         updated: "Document was successfully updated."
         destroyed: "Document was successfully destroyed."
+    share:
+      title: "Share this conversation"
+      description: "Share a publicly accessible link to this conversation. Anyone with the link will be able to view the conversation."
+      url: "Shareable URL"
+      copy: "Copy"
+      copied: "Copied to clipboard!"
+      warning: "Anyone with this link can view this conversation. Be careful not to share sensitive information."
+      close: "Close"
     helpers:
       messages:
         from_user: "You"


### PR DESCRIPTION
## Summary
Localizes the Share Conversation dialog by replacing hard-coded strings with I18n translation keys.

## Changes
- Added translation keys under `app.conversations.share`
- Added German translations in `de.yml`
- Updated the share dialog to use `t(...)` for all user-facing text

## Related Issue
Closes #720