### PR TITLE
Support attaching multiple images to a single chat message

### DIFF
--- a/app/javascript/stimulus/image_upload_controller.js
+++ b/app/javascript/stimulus/image_upload_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = [ "file", "content", "preview" ]
+  static targets = [ "file", "picker", "content", "previewList", "previewTemplate", "fileInputs" ]
 
   connect() {
     if (!this.hasFileTarget || !this.hasContentTarget) {
@@ -9,8 +9,13 @@ export default class extends Controller {
       return
     }
 
+    this.entries = []
+    this.nextEntryId = 0
+    this.nextCloneIndex = 1
+
     this.dragCounter = 0
-    this.fileTarget.addEventListener("change", this.boundPreviewUpdate)
+    this.fileTarget.addEventListener("change", this.boundPickerChanged)
+    this.pickerTarget.addEventListener("change", this.boundPickerChanged)
     this.element.addEventListener("drop", this.boundDropped)
     this.contentTarget.addEventListener("paste", this.boundPasted)
     this.element.addEventListener("dragenter", this.boundDragEnter)
@@ -21,7 +26,8 @@ export default class extends Controller {
   disconnect() {
     if (!this.hasFileTarget || !this.hasContentTarget) return
 
-    this.fileTarget.removeEventListener("change", this.boundPreviewUpdate)
+    this.fileTarget.removeEventListener("change", this.boundPickerChanged)
+    this.pickerTarget.removeEventListener("change", this.boundPickerChanged)
     this.element.removeEventListener("drop", this.boundDropped)
     this.contentTarget.removeEventListener("paste", this.boundPasted)
     this.element.removeEventListener("dragenter", this.boundDragEnter)
@@ -29,62 +35,99 @@ export default class extends Controller {
     this.element.removeEventListener("dragleave", this.boundDragLeave)
   }
 
-  boundPreviewUpdate = () => { this.previewUpdate() }
-  previewUpdate() {
-    if (!this.hasFileTarget || !this.hasPreviewTarget) return
-
-    const input = this.fileTarget
-    if (input.files && input.files[0]) {
-      const file = input.files[0]
-      const reader = new FileReader()
-      reader.onload = (e) => {
-        const previewContainer = this.previewTarget.querySelector("[data-role='preview']")
-        const img = previewContainer.querySelector("img")
-        const fileIcon = previewContainer.querySelector("[data-role='file-icon']")
-
-        if (file.type.startsWith('image/')) {
-          // Handle image files
-          img.src = e.target.result
-          img.style.display = 'block'
-          if (fileIcon) fileIcon.style.display = 'none'
-        } else if (file.type === 'application/pdf') {
-          // Handle PDF files
-          img.style.display = 'none'
-          if (fileIcon) {
-            fileIcon.style.display = 'flex'
-          } else {
-            // Create PDF icon if it doesn't exist
-            const pdfIcon = document.createElement('div')
-            pdfIcon.setAttribute('data-role', 'file-icon')
-            pdfIcon.className = 'w-full h-full flex items-center justify-center bg-red-100 dark:bg-red-900'
-            pdfIcon.innerHTML = `
-              <svg class="w-8 h-8 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"></path>
-              </svg>
-            `
-            previewContainer.appendChild(pdfIcon)
-          }
-        }
-
-        this.element.classList.add("show-previews")
-        this.contentTarget.focus()
-        window.dispatchEvent(new CustomEvent('main-column-changed'))
-      }
-      reader.readAsDataURL(file)
-    }
+  // The picker is a plain, unnamed <input multiple> used only to trigger the OS file dialog —
+  // it's never part of the submitted form. Each file it returns is handed off to its own
+  // single-file submission input (fileTarget for the first, a clone for each additional one),
+  // so a real Rails-nested-attributes input is never left both "multiple" and empty, which
+  // browsers submit as a blank value instead of omitting entirely. fileTarget itself is also
+  // watched directly so attaching a file straight to it (e.g. via Capybara) still works.
+  boundPickerChanged = (event) => { this.pickerChanged(event) }
+  pickerChanged(event) {
+    const input = event.target
+    const files = Array.from(input.files || [])
+    if (input === this.pickerTarget) input.value = ''
+    files.forEach((file) => this.addFile(file))
   }
 
-  previewRemove() {
-    if (!this.hasPreviewTarget) return
+  addFile(file) {
+    const entryId = this.nextEntryId++
+    const usingFileTarget = !this.entries.some((entry) => entry.input === this.fileTarget)
 
-    const previewContainer = this.previewTarget.querySelector("[data-role='preview']")
-    const img = previewContainer.querySelector("img")
-    const fileIcon = previewContainer.querySelector("[data-role='file-icon']")
+    let input
+    if (usingFileTarget) {
+      input = this.fileTarget
+    } else {
+      const cloneIndex = this.nextCloneIndex++
+      input = this.fileTarget.cloneNode(false)
+      input.removeAttribute("id")
+      input.name = this.fileTarget.name.replace(/\[documents_attributes\]\[\d+\]/, `[documents_attributes][${cloneIndex}]`)
+      this.fileInputsTarget.appendChild(input)
+    }
 
-    if (img) img.src = ''
-    if (fileIcon) fileIcon.style.display = 'none'
+    const dataTransfer = new DataTransfer()
+    dataTransfer.items.add(file)
+    input.files = dataTransfer.files
 
-    this.element.classList.remove("show-previews")
+    const preview = this.buildPreview(file, entryId)
+    this.entries.push({ entryId, file, input, preview })
+  }
+
+  buildPreview(file, entryId) {
+    const clone = this.previewTemplateTarget.content.firstElementChild.cloneNode(true)
+    clone.dataset.entryId = entryId
+
+    const removeBtn = clone.querySelector("[data-role='preview-remove']")
+    if (removeBtn) removeBtn.dataset.imageUploadIndexParam = entryId
+
+    const img = clone.querySelector("img")
+    const fileIcon = clone.querySelector("[data-role='file-icon']")
+
+    if (file.type.startsWith('image/')) {
+      const reader = new FileReader()
+      reader.onload = (e) => { img.src = e.target.result }
+      reader.readAsDataURL(file)
+    } else if (file.type === 'application/pdf') {
+      img.style.display = 'none'
+      if (fileIcon) {
+        fileIcon.style.display = 'flex'
+      } else {
+        const pdfIcon = document.createElement('div')
+        pdfIcon.setAttribute('data-role', 'file-icon')
+        pdfIcon.className = 'w-full h-full flex items-center justify-center bg-red-100 dark:bg-red-900'
+        pdfIcon.innerHTML = `
+          <svg class="w-8 h-8 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"></path>
+          </svg>
+        `
+        clone.appendChild(pdfIcon)
+      }
+    }
+
+    this.previewListTarget.appendChild(clone)
+    this.element.classList.add("show-previews")
+    this.contentTarget.focus()
+    window.dispatchEvent(new CustomEvent('main-column-changed'))
+
+    return clone
+  }
+
+  removeFile(event) {
+    const entryId = parseInt(event.params.index, 10)
+    const index = this.entries.findIndex((entry) => entry.entryId === entryId)
+    if (index === -1) return
+
+    const entry = this.entries[index]
+    entry.preview.remove()
+
+    if (entry.input === this.fileTarget) {
+      this.fileTarget.value = ''
+    } else {
+      entry.input.remove()
+    }
+
+    this.entries.splice(index, 1)
+
+    if (this.entries.length === 0) this.element.classList.remove("show-previews")
     if (this.hasContentTarget) this.contentTarget.focus()
     window.dispatchEvent(new CustomEvent('main-column-changed'))
   }
@@ -98,9 +141,8 @@ export default class extends Controller {
     const shade = this.element.querySelector("#drag-n-drop-shade")
     if (shade) shade.remove()
 
-    let files = event.dataTransfer.files
-    this.fileTarget.files = files
-    this.previewUpdate()
+    const files = Array.from(event.dataTransfer.files || []).filter((file) => this.isAllowedType(file))
+    files.forEach((file) => this.addFile(file))
   }
 
   boundDragOver = (event) => this.dragOver(event)
@@ -137,29 +179,21 @@ export default class extends Controller {
     for (const item of clipboardData.items) {
       if (item.kind === "file") {
         const blob = item.getAsFile()
-        if (!blob) return
+        if (!blob) continue
+        if (!this.isAllowedType(blob)) continue
 
-        // Only handle images and PDFs
-        if (blob.type.startsWith('image/') || blob.type === 'application/pdf') {
-          const dataURL = await this.readPastedBlobAsDataURL(blob)
-          this.addFileToFileInput(dataURL, blob.type, blob.name || "pasted-file")
-        }
+        const file = new File([blob], blob.name || this.defaultFileName(blob.type), { type: blob.type })
+        this.addFile(file)
       }
     }
-    this.previewUpdate()
   }
 
-  async readPastedBlobAsDataURL(blob) {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = (event) => {
-        resolve(event.target.result)
-      }
-      reader.onerror = (error) => {
-        reject(error)
-      }
-      reader.readAsDataURL(blob)
-    })
+  isAllowedType(file) {
+    return file.type.startsWith('image/') || file.type === 'application/pdf'
+  }
+
+  defaultFileName(fileType) {
+    return fileType === 'application/pdf' ? 'pasted-document.pdf' : 'pasted-image.png'
   }
 
   displayDragnDropShade() {
@@ -172,44 +206,8 @@ export default class extends Controller {
     );
   }
 
-  addFileToFileInput(dataURL, fileType, fileName) {
-    if (!this.hasFileTarget) return
-
-    const fileList = new DataTransfer()
-    const blob = this.dataURLtoBlob(dataURL, fileType)
-
-    // Generate appropriate filename based on file type
-    let defaultFileName = "pasted-file"
-    if (fileType.startsWith('image/')) {
-      defaultFileName = "pasted-image.png"
-    } else if (fileType === 'application/pdf') {
-      defaultFileName = "pasted-document.pdf"
-    }
-
-    fileList.items.add(
-      new File([blob], fileName || defaultFileName, { type: fileType }),
-    )
-    this.fileTarget.files = fileList.files
-  }
-
-  dataURLtoBlob(dataURL, fileType) {
-    const binaryString = atob(dataURL.split(",")[1])
-    const arrayBuffer = new ArrayBuffer(binaryString.length)
-    const uint8Array = new Uint8Array(arrayBuffer)
-    for (let i = 0; i < binaryString.length; i++) {
-      uint8Array[i] = binaryString.charCodeAt(i)
-    }
-    return new Blob([uint8Array], { type: fileType })
-  }
-
   choose() {
-    if (!this.hasFileTarget) return
-    this.fileTarget.click()
-  }
-
-  remove() {
-    if (!this.hasFileTarget) return
-    this.fileTarget.value = ''
-    this.previewRemove()
+    if (!this.hasPickerTarget) return
+    this.pickerTarget.click()
   }
 }

--- a/app/models/message/document_image.rb
+++ b/app/models/message/document_image.rb
@@ -8,38 +8,14 @@ module Message::DocumentImage
   end
 
   def has_document_image?(variant = nil)
-    documents.present? && documents.first.has_image?(variant)
+    documents.any? { |document| document.has_image?(variant) }
   end
 
   def has_document_pdf?
-    documents.present? && documents.first.file.attached? && documents.first.file.content_type == "application/pdf"
+    documents.any?(&:has_document_pdf?)
   end
 
   def has_documents?
-    documents.present? && documents.first.file.attached?
-  end
-
-  def document_image_url(variant, fallback: nil)
-    return nil unless has_document_image?
-
-    documents.last.image_url(variant, fallback: fallback)
-  end
-
-  def document_pdf_url
-    return nil unless has_document_pdf?
-
-    documents.last.file.url
-  end
-
-  def document_filename
-    return nil unless has_documents?
-
-    documents.last.filename
-  end
-
-  def document_content_type
-    return nil unless has_documents?
-
-    documents.last.file.content_type
+    documents.any? { |document| document.file.attached? }
   end
 end

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -178,42 +178,45 @@
           %>
         <% end %>
 
-        <div id="document-previews" class="absolute hidden space-x-3 left-9 top-3 show-previews:preview-container" data-image-upload-target="preview">
-          <div class="
-              flex flex-col
-              items-stretch
-              w-16 h-16
-              overflow-hidden
-              border-2 border-gray-100
-              rounded-xl
-              group
-            "
-            data-role="preview"
-          >
-            <%= button_tag type: "button",
-              class: "rounded-full absolute -top-2 -right-2 border border-gray-300 bg-gray-200 dark:bg-gray-800 hidden group-hover:block",
-              data: {
-                action: "image-upload#remove",
-                role: "preview-remove"
-              } do
-            %>
-              <%= icon "x-mark",
-                variant: :mini,
-                class: %|
-                  text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white
-                  cursor-pointer stroke-2
-                |,
-                title: t('app.conversations.ui.remove_file'),
-                tooltip: :top
+        <div id="document-previews" class="absolute hidden flex-wrap gap-3 max-w-[280px] left-9 top-3 show-previews:preview-container" data-image-upload-target="previewList">
+          <template data-image-upload-target="previewTemplate">
+            <div class="
+                flex flex-col
+                items-stretch
+                w-16 h-16
+                overflow-hidden
+                border-2 border-gray-100
+                rounded-xl
+                group
+                relative
+              "
+              data-role="preview"
+            >
+              <%= button_tag type: "button",
+                class: "rounded-full absolute -top-2 -right-2 border border-gray-300 bg-gray-200 dark:bg-gray-800 hidden group-hover:block",
+                data: {
+                  action: "image-upload#removeFile",
+                  role: "preview-remove"
+                } do
               %>
-            <% end %>
+                <%= icon "x-mark",
+                  variant: :mini,
+                  class: %|
+                    text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white
+                    cursor-pointer stroke-2
+                  |,
+                  title: t('app.conversations.ui.remove_file'),
+                  tooltip: :top
+                %>
+              <% end %>
 
-            <%= button_tag type: "button",
-              class: "w-full h-full flex-1 p-0" do
-            %>
-              <%= image_tag "", class: "w-full h-full object-cover" %>
-            <% end %>
-          </div>
+              <%= button_tag type: "button",
+                class: "w-full h-full flex-1 p-0" do
+              %>
+                <%= image_tag "", class: "w-full h-full object-cover" %>
+              <% end %>
+            </div>
+          </template>
         </div>
 
         <% if @streaming_message %>
@@ -268,6 +271,13 @@
           <%= form.fields_for :documents, @new_message.documents.build do |document_form| %>
             <%= document_form.file_field :file, accept: "image/*,.pdf", class: "hidden", data: { image_upload_target: "file" } %>
           <% end %>
+          <div class="hidden" data-image-upload-target="fileInputs"></div>
+
+          <%= file_field_tag :attachment_picker,
+            multiple: true,
+            accept: "image/*,.pdf",
+            class: "hidden",
+            data: { image_upload_target: "picker" } %>
 
           <%= form.text_area :content_text,
             id: "composer-input",

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -51,7 +51,6 @@ end %>
       data-controller="
         clipboard
         transition
-        <%= message.has_document_image? && "modal" %>
       "
       data-transition-toggle-class="hidden"
     >
@@ -74,61 +73,96 @@ end %>
           data-role="content-text"
           class="prose break-words leading-normal dark:[&_*]:text-gray-100 dark:marker:text-gray-100"
         >
-          <% if message.has_document_image? %>
-            <%= button_tag type: "button",
-              class: "w-full h-auto flex focus:outline-none",
-              data: {
-                role: "image-preview",
-                controller: "image-loader",
-                image_loader_message_scroller_outlet: "[data-role='inner-message']",
-                image_loader_url_value: message.document_image_url(:small),
-                action: "modal#open",
-            } do %>
-              <%= image_tag message.document_image_url(:small, fallback: ""),
-                class: %|
-                  my-0
-                  mx-auto
-                  max-w-full
-                  border-2 border-gray-100 dark:border-gray-400
-                  rounded-md
-                |,
-                data: {
-                  image_loader_target: "image",
-                  action: %|
-                    error->image-loader#retryAfterDelay
-                    load->image-loader#show
-                  |
-              } %>
-              <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
-                <%= spinner size: 6, class: "text-black dark:text-white" %>
-              </div>
-            <% end %>
-          <% elsif message.has_document_pdf? %>
-            <%= link_to message.document_pdf_url,
-              class: "w-full my-2 p-4 border-2 border-gray-200 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 block",
-              target: "_blank",
-              rel: "noopener noreferrer" do %>
-              <div class="flex items-center space-x-3">
-                <div class="flex-shrink-0">
-                  <svg class="w-8 h-8 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20">
-                    <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"></path>
-                  </svg>
-                </div>
-                <div class="flex-1 min-w-0">
-                  <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
-                    <%= message.document_filename %>
-                  </p>
-                  <p class="text-sm text-gray-500 dark:text-gray-400">
-                    PDF Document - Click to open
-                  </p>
-                </div>
-                <div class="flex-shrink-0">
-                  <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
-                  </svg>
-                </div>
-              </div>
-            <% end %>
+          <% if message.documents.present? %>
+            <div class="flex flex-wrap gap-2 my-1" data-role="document-attachments">
+              <% message.documents.each do |document| %>
+                <% if document.has_image? %>
+                  <div data-controller="modal">
+                    <%= button_tag type: "button",
+                      class: "w-full h-auto flex focus:outline-none",
+                      data: {
+                        role: "image-preview",
+                        controller: "image-loader",
+                        image_loader_message_scroller_outlet: "[data-role='inner-message']",
+                        image_loader_url_value: document.image_url(:small),
+                        action: "modal#open",
+                    } do %>
+                      <%= image_tag document.image_url(:small, fallback: ""),
+                        class: %|
+                          my-0
+                          mx-auto
+                          max-w-full
+                          border-2 border-gray-100 dark:border-gray-400
+                          rounded-md
+                        |,
+                        data: {
+                          image_loader_target: "image",
+                          action: %|
+                            error->image-loader#retryAfterDelay
+                            load->image-loader#show
+                          |
+                      } %>
+                      <div data-role="image-loader" class="mx-auto hidden" data-image-loader-target="loader">
+                        <%= spinner size: 6, class: "text-black dark:text-white" %>
+                      </div>
+                    <% end %>
+
+                    <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
+                      <main class="modal-box max-w-5xl p-0 rounded-none">
+                        <article
+                          class="flex flex-col md:flex-row justify-center"
+                          data-controller="image-loader"
+                          data-image-loader-message-scroller-outlet="[data-role='inner-message']"
+                          data-image-loader-url-value="<%= document.image_url(:large) %>"
+                          data-turbo-permanent
+                        >
+                          <%= image_tag document.image_url(:large, fallback: ""),
+                            class: "w-full h-auto",
+                            data: {
+                              image_loader_target: "image",
+                              action: %|
+                                error->image-loader#retryAfterDelay
+                                load->image-loader#show
+                          | } %>
+                          <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
+                            <%= spinner size: 6, class: "text-black dark:text-white" %>
+                          </div>
+                        </article>
+                      </main>
+                      <form method="dialog" class="modal-backdrop no-focus-outline">
+                        <button id="modal-backdrop">close</button>
+                      </form>
+                    </dialog>
+                  </div>
+                <% elsif document.has_document_pdf? %>
+                  <%= link_to document.file.url,
+                    class: "w-full my-2 p-4 border-2 border-gray-200 dark:border-gray-600 rounded-lg bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 block",
+                    target: "_blank",
+                    rel: "noopener noreferrer" do %>
+                    <div class="flex items-center space-x-3">
+                      <div class="flex-shrink-0">
+                        <svg class="w-8 h-8 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                          <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clip-rule="evenodd"></path>
+                        </svg>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <p class="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                          <%= document.filename %>
+                        </p>
+                        <p class="text-sm text-gray-500 dark:text-gray-400">
+                          PDF Document - Click to open
+                        </p>
+                      </div>
+                      <div class="flex-shrink-0">
+                        <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                        </svg>
+                      </div>
+                    </div>
+                  <% end %>
+                <% end %>
+              <% end %>
+            </div>
           <% end %>
           <%= formatted_text = format_for_display message, append_inside_tag: thinking_html(message, thinking) %>
         </div>
@@ -270,35 +304,6 @@ end %>
           <% end %>
         </div>
       </turbo-frame>
-
-      <% if message.has_document_image? %>
-        <dialog class="modal no-focus-outline" data-modal-target="dialog" data-role="image-modal">
-          <main class="modal-box max-w-5xl p-0 rounded-none">
-            <article
-              class="flex flex-col md:flex-row justify-center"
-              data-controller="image-loader"
-              data-image-loader-message-scroller-outlet="[data-role='inner-message']"
-              data-image-loader-url-value="<%= message.document_image_url(:large) %>"
-              data-turbo-permanent
-            >
-              <%= image_tag message.document_image_url(:large, fallback: ""),
-                class: "w-full h-auto",
-                data: {
-                  image_loader_target: "image",
-                  action: %|
-                    error->image-loader#retryAfterDelay
-                    load->image-loader#show
-              | } %>
-              <div data-role="image-loader" class="hidden p-5" data-image-loader-target="loader">
-                <%= spinner size: 6, class: "text-black dark:text-white" %>
-              </div>
-            </article>
-          </main>
-          <form method="dialog" class="modal-backdrop no-focus-outline">
-            <button id="modal-backdrop">close</button>
-          </form>
-        </dialog>
-      <% end %>
     </div>
   </div>
 </div>

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -114,6 +114,26 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal Document.last, user_msg.documents.first
   end
 
+  test "should create message with multiple image attachments" do
+    cat_file = fixture_file_upload("cat.png", "image/png")
+    dog_file = fixture_file_upload("cat.png", "image/png")
+
+    assert_difference "Conversation.count", 1 do
+      assert_difference "Document.count", 2 do
+        assert_difference "Message.count", 2 do
+          post assistant_messages_url(@assistant), params: { message: {
+            documents_attributes: { "0": { file: cat_file }, "1": { file: dog_file } },
+            content_text: @message.content_text
+          } }
+        end
+      end
+    end
+
+    (user_msg, _asst_msg) = Message.last(2)
+    assert_equal 2, user_msg.documents.count
+    assert_equal Document.last(2).to_set, user_msg.documents.to_set
+  end
+
   test "should create message with PDF attachment" do
     # Create a simple PDF file for testing
     pdf_content = "%PDF-1.4\n1 0 obj\n<<\n/Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n2 0 obj\n<<\n/Type /Pages\n/Kids [3 0 R]\n/Count 1\n>>\nendobj\n3 0 obj\n<<\n/Type /Page\n/Parent 2 0 R\n/MediaBox [0 0 612 792]\n>>\nendobj\nxref\n0 4\n0000000000 65535 f \n0000000009 00000 n \n0000000058 00000 n \n0000000115 00000 n \ntrailer\n<<\n/Size 4\n/Root 1 0 R\n>>\nstartxref\n174\n%%EOF"

--- a/test/models/message/document_image_test.rb
+++ b/test/models/message/document_image_test.rb
@@ -18,9 +18,22 @@ class Message::DocumentImageTest < ActiveSupport::TestCase
 
   test "document_image_url with data url" do
     stub_custom_config_value(:app_url, "") do
-      url = messages(:examine_this).document_image_url(:small)
+      url = messages(:examine_this).documents.first.image_url(:small)
       assert url.is_a?(String)
       assert url.starts_with?("data:image/png;base64,")
+    end
+  end
+
+  test "has_document_image? is true when a message has multiple image attachments" do
+    message = messages(:two_attachments)
+
+    assert_equal 2, message.documents.count
+    assert message.has_document_image?
+
+    stub_custom_config_value(:app_url, "") do
+      urls = message.documents.map { |document| document.image_url(:small) }
+      assert_equal 2, urls.length
+      urls.each { |url| assert url.starts_with?("data:image/png;base64,") }
     end
   end
 end

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -19,6 +19,33 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
     assert @gemini.client.present?
   end
 
+  test "preceding_conversation_messages constructs a proper response and pivots on images" do
+    conversation = conversations(:attachments)
+    assistant = assistants(:keith_claude35)
+    assistant.language_model.update!(supports_tools: false, supports_images: true)
+    gemini = AIBackend::Gemini.new(
+      users(:keith),
+      assistant,
+      conversation,
+      conversation.latest_message_for_version(:latest)
+    )
+
+    preceding_conversation_messages = gemini.send(:preceding_conversation_messages)
+
+    assert_equal conversation.messages.length - 1, preceding_conversation_messages.length
+
+    conversation.messages.ordered.each_with_index do |message, i|
+      next if conversation.messages.length == i + 1
+
+      if message.documents.present?
+        assert_instance_of Array, preceding_conversation_messages[i][:parts]
+        assert_equal message.documents.length + 1, preceding_conversation_messages[i][:parts].length
+      else
+        assert_equal message.content_text || "", preceding_conversation_messages[i][:parts][:text]
+      end
+    end
+  end
+
   test "preceding_conversation_messages processes PDF documents" do
     # Create a new conversation with a message that has a PDF document
     assistant = assistants(:keith_claude35)

--- a/test/system/conversations/messages/images_test.rb
+++ b/test/system/conversations/messages/images_test.rb
@@ -44,6 +44,35 @@ class ConversationMessagesImagesTest < ApplicationSystemTestCase
     end
   end
 
+  test "a message with multiple images renders one preview per image, each with its own independent modal" do
+    visit_and_scroll_wait conversation_messages_path(@conversation)
+
+    multi_image_msg = find_messages.fifth
+    previews = multi_image_msg.all("[data-role='image-preview']", visible: :all).to_a
+    modals = multi_image_msg.all("[data-role='image-modal']", visible: :all).to_a
+
+    assert_equal 2, previews.length
+    assert_equal 2, modals.length
+    modals.each { |modal| refute modal.visible? }
+
+    previews.first.click
+    assert_true "first modal should be visible" do
+      modals.first.visible?
+    end
+    refute modals.second.visible?
+
+    send_keys "esc"
+    assert_false "first modal should have closed" do
+      modals.first.visible?
+    end
+
+    previews.second.click
+    assert_true "second modal should be visible" do
+      modals.second.visible?
+    end
+    refute modals.first.visible?
+  end
+
   test "images eventually render in messages WHEN NOT pre-processed, clicking opens modal" do
     simulate_image_variant_processing do
       visit_and_scroll_wait conversation_messages_path(@conversation)

--- a/test/system/messages/composer/attachment_test.rb
+++ b/test/system/messages/composer/attachment_test.rb
@@ -35,8 +35,36 @@ class MessagesComposerAttachmentTest < ApplicationSystemTestCase
     assert_active @input_selector
   end
 
+  test "attaching multiple images to the composer shows a preview for each" do
+    attach_file "attachment_picker", [
+      Rails.root.join("test", "assets", "cat-image-for-attaching.png"),
+      Rails.root.join("test", "assets", "cat-image-for-attaching.png"),
+    ], make_visible: true
+
+    assert_equal 2, find_previews.length
+    find_previews.each { |preview| assert preview.visible? }
+    refute @submit.visible?
+    assert_active @input_selector
+  end
+
+  test "attaching multiple images and removing one keeps the other" do
+    attach_file "attachment_picker", [
+      Rails.root.join("test", "assets", "cat-image-for-attaching.png"),
+      Rails.root.join("test", "assets", "cat-image-for-attaching.png"),
+    ], make_visible: true
+
+    assert_equal 2, find_previews.length
+
+    find_previews.first.hover
+    find_previews.first.find("[data-role='preview-remove']").click
+
+    assert_equal 1, find_previews.length
+    assert find("#document-previews").visible?
+    refute @submit.visible?
+    assert_active @input_selector
+  end
+
   # TODO: Add a test for submitting this and ensuring it gets attached to the message
-  # TODO: Add tests for attaching multiple images
 
   private
 


### PR DESCRIPTION
The message/document data layer already supported multiple documents per message (has_many :documents, all three AIBackend providers already looped over them), but the composer UI, upload controller, and message display only ever handled one.

- Message::DocumentImage: replace .first/.last helpers with aggregate has_document_image?/has_document_pdf?/has_documents? checks; the view now reads per-document data straight off Document.
- Composer: file picker accepts multiple files, preview box becomes a cloneable template instead of one static slot.
- image_upload_controller.js: track an ordered list of attached files. Uses a separate, unnamed <input multiple> purely to trigger the OS file dialog, keeping the real Rails-nested-attributes inputs single-file always — a multiple file input left empty submits a blank value instead of being omitted, which would 422 every send.
- Message display: loop over documents, giving each image its own modal controller/dialog instead of sharing one per message.
- Add Gemini multi-image payload test to match existing OpenAI/ Anthropic coverage.

Closes #78