### PR TITLE
Add Brave as a new API service driver

### DIFF
--- a/app/helpers/settings/api_services_helper.rb
+++ b/app/helpers/settings/api_services_helper.rb
@@ -1,7 +1,7 @@
 module Settings
   module APIServicesHelper
     def official?(model)
-      openai?(model) || anthropic?(model) || groq?(model) || gemini?(model)
+      openai?(model) || anthropic?(model) || groq?(model) || gemini?(model) || brave?(model)
     end
 
     def openai?(api_service)
@@ -18,6 +18,10 @@ module Settings
 
     def gemini?(api_service)
       api_service.url == APIService::URL_GEMINI
+    end
+
+    def brave?(api_service)
+      api_service.url == APIService::URL_BRAVE
     end
   end
 end

--- a/app/models/api_service.rb
+++ b/app/models/api_service.rb
@@ -3,12 +3,13 @@ class APIService < ApplicationRecord
   URL_ANTHROPIC = "https://api.anthropic.com/"
   URL_GROQ = "https://api.groq.com/openai/v1/"
   URL_GEMINI = "https://generativelanguage.googleapis.com/v1beta/"
+  URL_BRAVE = "https://api.search.brave.com/res/v1/"
 
   belongs_to :user
 
   has_many :language_models, -> { not_deleted }
 
-  enum :driver, %w[openai anthropic gemini].index_by(&:to_sym)
+  enum :driver, %w[openai anthropic gemini brave].index_by(&:to_sym)
 
   validates :url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), if: -> { url.present? }
   validates :name, :url, presence: true
@@ -32,18 +33,24 @@ class APIService < ApplicationRecord
   end
 
   def requires_token?
-    [URL_OPEN_AI, URL_ANTHROPIC, URL_GEMINI].include?(url) # other services may require it but we don't always know
+    [URL_OPEN_AI, URL_ANTHROPIC, URL_GEMINI, URL_BRAVE].include?(url) # other services may require it but we don't always know
   end
 
   def effective_token
-    token.presence || default_llm_key
+    token.presence || default_token
   end
 
   def test_api_service(url = nil, token = nil)
+    return "Error: Testing is not supported for this API service." if ai_backend.nil?
     ai_backend.test_api_service(self, url, token)
   end
 
   private
+
+  def default_token
+    return Setting.default_brave_key if url == URL_BRAVE
+    default_llm_key
+  end
 
   def default_llm_key
     return nil unless Feature.default_llm_keys?

--- a/app/models/user/registerable.rb
+++ b/app/models/user/registerable.rb
@@ -12,6 +12,7 @@ module User::Registerable
     api_services.create!(url: APIService::URL_ANTHROPIC, driver: :anthropic, name: "Anthropic")
     api_services.create!(url: APIService::URL_GROQ, driver: :openai, name: "Groq")
     api_services.create!(url: APIService::URL_GEMINI, driver: :gemini, name: "Google Gemini")
+    api_services.create!(url: APIService::URL_BRAVE, driver: :brave, name: "Brave")
 
     LanguageModel.import_from_file(users: [self])
     Assistant.import_from_file(users: [self])

--- a/app/views/settings/api_services/_form.html.erb
+++ b/app/views/settings/api_services/_form.html.erb
@@ -38,7 +38,7 @@
   <div class="my-5 inline-block w-full">
   <%= form.label :url, t('app.settings.api_services.table.url') %>
      <span>
-      <% if api_service.persisted? %>
+      <% if api_service.persisted? && !brave?(api_service) %>
         <% link_url = settings_api_services_path + "/" + api_service.id.to_s + "/test" %>
   <%= link_to t('app.settings.api_services.test'), link_url,
           data: { testing_target: "test", turbo_stream: true, action: "click->testing#update_link_api_service" },
@@ -182,6 +182,29 @@
           target: "_blank"
         %>.
       </li>
+    </ol>
+    <ol id="brave-instructions"
+      data-transition-target="<%= brave?(api_service) && 'transitionable' %>"
+      class="
+        list-decimal
+        my-3 p-2 pl-8
+        border border-gray-200
+        bg-gray-50 dark:bg-transparent
+        hidden
+      "
+    >
+      <li>Sign up for the
+        <%= link_to "Brave Search API", "https://brave.com/search/api/",
+          class: "underline text-blue-600",
+          target: "_blank"
+        %> and choose a plan (a free tier is available).
+      </li>
+      <li>Go to
+        <%= link_to "API Keys", "https://api.search.brave.com/app/keys",
+          class: "underline text-blue-600",
+          target: "_blank"
+        %>.</li>
+      <li>Click "Add API key", name it something like "<%= Setting.product_name %>" and paste it below.</li>
     </ol>
     <%= form.text_field :token,
       class: %|

--- a/config/options.yml
+++ b/config/options.yml
@@ -55,6 +55,7 @@ shared:
     default_openai_key: <%= ENV["DEFAULT_OPENAI_KEY"] %>
     default_anthropic_key: <%= ENV["DEFAULT_ANTHROPIC_KEY"] %>
     default_groq_key: <%= ENV["DEFAULT_GROQ_KEY"] %>
+    default_brave_key: <%= ENV["BRAVE_API_KEY"] %>
     cloudflare_account_id: <%= ENV["CLOUDFLARE_ACCOUNT_ID"] || default_to(cloudflare: :account_id) %>
     cloudflare_access_key_id: <%= ENV["CLOUDFLARE_ACCESS_KEY_ID"] || default_to(cloudflare: :access_key_id) %>
     cloudflare_secret_access_key: <%= ENV["CLOUDFLARE_SECRET_ACCESS_KEY"] || default_to(cloudflare: :secret_access_key) %>

--- a/db/migrate/20260808000000_add_brave.rb
+++ b/db/migrate/20260808000000_add_brave.rb
@@ -1,0 +1,11 @@
+class AddBrave < ActiveRecord::Migration[8.1]
+  def up
+    User.all.find_each do |user|
+      user.api_services.create!(url: APIService::URL_BRAVE, driver: :brave, name: "Brave")
+    end
+  end
+
+  def down
+    APIService.where(url: APIService::URL_BRAVE, driver: :brave).destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_08_03_134328) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_08_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/test/controllers/settings/api_services_controller_test.rb
+++ b/test/controllers/settings/api_services_controller_test.rb
@@ -109,6 +109,16 @@ class Settings::APIServicesControllerTest < ActionDispatch::IntegrationTest
     assert_select "button#instructions.hidden"
   end
 
+  test "special instruction link is visible for brave url" do
+    get edit_settings_api_service_url(api_services(:keith_brave_service))
+    assert_select "button#instructions:not(.hidden)"
+  end
+
+  test "test link is NOT shown for brave since it has no ai_backend" do
+    get edit_settings_api_service_url(api_services(:keith_brave_service))
+    assert_select "a", text: "Test", count: 0
+  end
+
   test "test should return success and a message" do
     TestClient::OpenAI.stub :text, "Success." do
       get settings_api_service_test_url(format: :turbo_stream, api_service_id: api_services(:keith_openai_service).id, url: "https://api.openai.com/v1", token: "abc-secret123")

--- a/test/fixtures/api_services.yml
+++ b/test/fixtures/api_services.yml
@@ -69,3 +69,10 @@ taylor_openai_service:
   url: http://taylor.org/doit-open
   token: open-secret
   driver: openai
+
+keith_brave_service:
+  name: Brave
+  user: keith
+  url: https://api.search.brave.com/res/v1/
+  token: abc-secret
+  driver: brave

--- a/test/helpers/settings/api_services_helper_test.rb
+++ b/test/helpers/settings/api_services_helper_test.rb
@@ -15,4 +15,8 @@ class Settings::APIServicesHelperTest < ActiveSupport::TestCase
   test "anthropic is official" do
     assert official?(api_services(:rob_anthropic_service))
   end
+
+  test "brave is official" do
+    assert official?(api_services(:keith_brave_service))
+  end
 end

--- a/test/models/api_service_test.rb
+++ b/test/models/api_service_test.rb
@@ -100,6 +100,28 @@ class APIServiceTest < ActiveSupport::TestCase
     end
   end
 
+  test "brave key falls back to BRAVE_API_KEY-derived setting even when default_llm_keys is disabled" do
+    api_services(:keith_brave_service).update!(token: nil)
+
+    stub_features(default_llm_keys: false) do
+      stub_settings(default_brave_key: "brave-default-key") do
+        assert_equal "brave-default-key", api_services(:keith_brave_service).effective_token
+      end
+    end
+  end
+
+  test "brave key prefers the user's own token over the default" do
+    api_services(:keith_brave_service).update!(token: "user-brave-key")
+
+    stub_settings(default_brave_key: "brave-default-key") do
+      assert_equal "user-brave-key", api_services(:keith_brave_service).effective_token
+    end
+  end
+
+  test "test_api_service returns a friendly error for drivers without an ai_backend" do
+    assert_equal "Error: Testing is not supported for this API service.", api_services(:keith_brave_service).test_api_service
+  end
+
   private
 
   def create_params


### PR DESCRIPTION
## Summary
Adds a "brave" driver to `APIService` for the Brave Search API, following the same env-var-fallback pattern used by OpenAI/Anthropic/Groq: if `BRAVE_API_KEY` is set as an environment variable it's used as the default token; if a token is entered in the Settings form, that takes precedence.

- `APIService`: new `URL_BRAVE` constant, `brave` driver, `requires_token?`, and an `effective_token` fallback to `Setting.default_brave_key` (sourced from `BRAVE_API_KEY`) that applies unconditionally — unlike the LLM default keys, which are gated behind `Feature.default_llm_keys?`.
- Settings UI: Brave gets setup instructions like the other official providers, but no "Test" link since it has no `AIBackend`/chat backend (`test_api_service` now returns a friendly error instead of raising when `ai_backend` is nil).
- New users get a blank Brave `APIService` seeded on registration (`User::Registerable`), and a migration backfills one for existing users.

This is infrastructure only — no `Toolbox::BraveSearch` tool is added in this PR; a future search tool can consume the key via `api_service.effective_token`.

## Test plan
- `bin/rails test` — 679 runs, 0 failures
- `bundle exec rubocop` on touched files — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)