### PR TITLE
Use YAML DEFAULTS in fixtures

### DIFF
--- a/test/fixtures/documents.yml
+++ b/test/fixtures/documents.yml
@@ -1,39 +1,38 @@
-background:
+DEFAULTS: &DEFAULTS
   user: keith
+  purpose: assistants
+
+background:
+  <<: *DEFAULTS
   assistant: samantha
   message:
   filename: background.docx
-  purpose: assistants
   bytes: 100
 
 cat_photo:
-  user: keith
+  <<: *DEFAULTS
   assistant:
   message: examine_this
   filename: cat.png
-  purpose: assistants
   bytes: 51452
 
 cute_cat_photo:
-  user: keith
+  <<: *DEFAULTS
   assistant:
   message: one_attachment
   filename: cute_cat_photo.png
-  purpose: assistants
   bytes: 200
 
 single_cat_photo:
-  user: keith
+  <<: *DEFAULTS
   assistant:
   message: two_attachments
   filename: single_cat_photo.png
-  purpose: assistants
   bytes: 300
 
 single_dog_photo:
-  user: keith
+  <<: *DEFAULTS
   assistant:
   message: two_attachments
   filename: single_dog_photo.png
-  purpose: assistants
   bytes: 400

--- a/test/fixtures/runs.yml
+++ b/test/fixtures/runs.yml
@@ -1,12 +1,7 @@
-hear_me_response:
-  assistant: samantha
-  conversation: greeting
+DEFAULTS: &DEFAULTS
   status: completed
   required_action:
   last_error:
-  started_at: 2023-12-25 15:03:41
-  completed_at: 2023-12-25 15:04:41
-  expired_at: 2023-12-25 15:05:41
   cancelled_at:
   failed_at:
   model: gpt-4
@@ -14,326 +9,177 @@ hear_me_response:
   additional_instructions:
   tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
-identify_photo_response:
+hear_me_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: greeting
-  status: completed
-  required_action:
-  last_error:
+  started_at: 2023-12-25 15:03:41
+  completed_at: 2023-12-25 15:04:41
+  expired_at: 2023-12-25 15:05:41
+
+identify_photo_response:
+  <<: *DEFAULTS
+  assistant: samantha
+  conversation: greeting
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
   file_ids: ["file-abc123"]
 
 what_day_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: greeting
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 alive_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: greeting
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 your_name_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachment
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:03:41
   completed_at: 2023-12-25 15:04:41
   expired_at: 2023-12-25 15:05:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 examine_this_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachment
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
   file_ids: ["file-abc123"]
 
 what_month_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachment
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 human_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachment
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 can_you_hear_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachments
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:03:41
   completed_at: 2023-12-25 15:04:41
   expired_at: 2023-12-25 15:05:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 one_attachment_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachments
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
   file_ids: ["file-def123"]
 
 two_attachments_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: attachments
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
   file_ids: ["file-xyz123", "file-xyz987"]
 
 popstate_response:
+  <<: *DEFAULTS
   assistant: keith_gpt4
   conversation: javascript
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
   instructions:
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 ruby_version_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: ruby_version
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-25 15:06:41
   completed_at: 2023-12-25 15:07:41
   expired_at: 2023-12-25 15:08:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
   instructions:
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 filter_map_response:
+  <<: *DEFAULTS
   assistant: rob_gpt4
   conversation: debugging
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-12-27 15:03:41
   completed_at: 2023-12-27 15:04:41
   expired_at: 2023-12-27 15:05:41
-  cancelled_at:
-  failed_at:
-  model: gpt-4
   instructions:
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 message0_v1_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:01:00
   completed_at: 2023-1-1 1:01:00
   expired_at: 2023-1-1 1:01:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 message2_v1_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:03:00
   completed_at: 2023-1-1 1:03:00
   expired_at: 2023-1-1 1:03:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 message2_v2_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:05:00
   completed_at: 2023-1-1 1:05:00
   expired_at: 2023-1-1 1:05:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 message4_v2_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:07:00
   completed_at: 2023-1-1 1:07:00
   expired_at: 2023-1-1 1:07:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 msg0_v1_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned2
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:07:00
   completed_at: 2023-1-1 1:07:00
   expired_at: 2023-1-1 1:07:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 msg2_v1_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned2
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:07:00
   completed_at: 2023-1-1 1:07:00
   expired_at: 2023-1-1 1:07:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]
 
 msg3_v2_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: versioned2
-  status: completed
-  required_action:
-  last_error:
   started_at: 2023-1-1 1:07:00
   completed_at: 2023-1-1 1:07:00
   expired_at: 2023-1-1 1:07:00
-  cancelled_at:
-  failed_at:
-  model: gpt-4
-  instructions: You are a helpful assistant
-  additional_instructions:
-  tools: [{"type": "code_interpreter"}, {"type": "retrieval"}, {"type": "function"}]

--- a/test/fixtures/steps.yml
+++ b/test/fixtures/steps.yml
@@ -1,64 +1,43 @@
+DEFAULTS: &DEFAULTS
+  kind: message_creation
+  status: completed
+  last_error:
+  expired_at: 2023-12-25 15:07:10
+  cancelled_at: 2023-12-25 15:07:10
+  failed_at: 2023-12-25 15:07:10
+  completed_at: 2023-12-25 15:07:10
+
 hear_me_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: greeting
   run: hear_me_response
-  kind: message_creation
-  status: completed
   details: {"type": "message_creation", "message_id": "<%= ActiveRecord::FixtureSet.identify(:yes_i_do) %>"}
-  last_error:
-  expired_at: 2023-12-25 15:07:10
-  cancelled_at: 2023-12-25 15:07:10
-  failed_at: 2023-12-25 15:07:10
-  completed_at: 2023-12-25 15:07:10
 
 identify_photo_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: greeting
   run: identify_photo_response
-  kind: message_creation
-  status: completed
   details: {"type": "message_creation", "message_id": "<%= ActiveRecord::FixtureSet.identify(:yes_i_do) %>"}
-  last_error:
-  expired_at: 2023-12-25 15:07:10
-  cancelled_at: 2023-12-25 15:07:10
-  failed_at: 2023-12-25 15:07:10
-  completed_at: 2023-12-25 15:07:10
 
 popstate_response:
+  <<: *DEFAULTS
   assistant: keith_gpt4
   conversation: javascript
   run: popstate_response
-  kind: message_creation
-  status: completed
   details: {"type": "message_creation", "message_id": "<%= ActiveRecord::FixtureSet.identify(:popstate_event) %>"}
-  last_error:
-  expired_at: 2023-12-25 15:07:10
-  cancelled_at: 2023-12-25 15:07:10
-  failed_at: 2023-12-25 15:07:10
-  completed_at: 2023-12-25 15:07:10
 
 ruby_version_response:
+  <<: *DEFAULTS
   assistant: samantha
   conversation: ruby_version
   run: ruby_version_response
-  kind: message_creation
-  status: completed
   details: {"type": "message_creation", "message_id": "<%= ActiveRecord::FixtureSet.identify(:latest_ruby_version) %>"}
-  last_error:
-  expired_at: 2023-12-25 15:07:10
-  cancelled_at: 2023-12-25 15:07:10
-  failed_at: 2023-12-25 15:07:10
-  completed_at: 2023-12-25 15:07:10
 
 filter_map_response:
+  <<: *DEFAULTS
   assistant: rob_gpt4
   conversation: debugging
   run: filter_map_response
-  kind: message_creation
-  status: completed
   details: {"type": "message_creation", "message_id": "<%= ActiveRecord::FixtureSet.identify(:filter_map_example) %>"}
-  last_error:
-  expired_at: 2023-12-25 15:07:10
-  cancelled_at: 2023-12-25 15:07:10
-  failed_at: 2023-12-25 15:07:10
-  completed_at: 2023-12-25 15:07:10

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,16 +1,19 @@
+DEFAULTS: &DEFAULTS
+  preferences: {}
+
 keith:
+  <<: *DEFAULTS
   first_name: Keith
   last_name: Schacht
   registered_at: 2023-12-19 08:40:05
   last_cancelled_message: dont_know_day
-  preferences: {}
 
 rob:
+  <<: *DEFAULTS
   first_name: Rob
   registered_at: 2023-12-26 08:40:05
-  preferences: {}
 
 taylor:
+  <<: *DEFAULTS
   first_name: Taylor
   registered_at: 2024-05-31 08:40:05
-  preferences: {}


### PR DESCRIPTION
Applies the DEFAULTS: &DEFAULTS / <<: *DEFAULTS merge-key pattern (https://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html) to fixture files with heavily duplicated attributes: runs.yml, steps.yml, documents.yml, and users.yml. Rows now only spell out what differs from the shared default, and Rails' fixture loader automatically skips any row named DEFAULTS when inserting records.

Closes #504