### PR TITLE
Move image generation to aibackend

### DIFF
--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -75,6 +75,12 @@ class AIBackend
     result
   end
 
+  # New backends: override this or accept OpenAI delegation — until a provider
+  # ships native image generation, OpenAI covers the capability for everyone.
+  def self.generate_image(prompt:, user:)
+    AIBackend::OpenAI.generate_image(prompt:, user:)
+  end
+
   private
 
   def client_method_name

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -1,6 +1,8 @@
 class AIBackend::OpenAI < AIBackend
   include Tools
 
+  IMAGE_MODEL = "gpt-image-1"
+
   # Rails system tests don't seem to allow mocking because the server and the
   # test are in separate processes.
   #
@@ -35,6 +37,28 @@ class AIBackend::OpenAI < AIBackend
     response.dig("choices", 0, "message", "content")
   rescue ::Faraday::Error => e
     "Error: #{e.message}"
+  end
+
+  def self.generate_image(prompt:, user:)
+    openai_service = user.api_services.find_by(driver: :openai)
+
+    if openai_service.nil? || openai_service.effective_token.blank?
+      current_backend = Current.message&.assistant&.language_model&.api_service&.name || "current AI backend"
+      raise "OpenAI API key not found. Image generation requires an OpenAI API key. Please configure your OpenAI API key in Settings > API Services to use image generation with #{current_backend}."
+    end
+
+    response = client.new(access_token: openai_service.effective_token).images.generate(
+      parameters: {
+        prompt: prompt,
+        model: IMAGE_MODEL,
+        n: 1,
+        size: "1024x1024",
+        quality: "auto"
+      }
+    )
+
+    b64_json = response.dig("data", 0, "b64_json") || response.dig(:data, 0, :b64_json)
+    { b64_json: b64_json, model: IMAGE_MODEL }
   end
 
   def initialize(user, assistant, conversation = nil, message = nil)

--- a/app/services/toolbox/image.rb
+++ b/app/services/toolbox/image.rb
@@ -5,46 +5,14 @@ class Toolbox::Image < Toolbox
   S
 
   def generate_an_image(image_generation_prompt_s:)
-    # For all backends, use OpenAI client for image generation
-    # since most don't have native image generation
-    generate_with_openai_client(image_generation_prompt_s)
-  end
-
-  private
-
-  def generate_with_openai_client(image_generation_prompt_s)
-    model = "gpt-image-1"
-    response = openai_client.images.generate(
-      parameters: {
-        prompt: image_generation_prompt_s,
-        model: model,
-        n: 1,
-        size: "1024x1024",
-        quality: "auto"
-      }
-    )
-
-    json = response.dig("data", 0, "b64_json") ||
-           response.dig(:data, 0, :b64_json)
+    backend = Current.message&.assistant&.language_model&.api_service&.ai_backend || AIBackend
+    result = backend.generate_image(prompt: image_generation_prompt_s, user: Current.user)
 
     {
       prompt_given: image_generation_prompt_s,
-      json_of_generated_image: json,
+      json_of_generated_image: result[:b64_json],
       note_to_assistant: "The image is already being shown on screen so reply with a nice message confirming the image has been generated, maybe re-describing it.",
-      message_to_user: "Image created by tool using OpenAI model #{model}"
+      message_to_user: "Image created by tool using OpenAI model #{result[:model]}"
     }
-  end
-
-  def openai_client
-    openai_service = Current.user.api_services.find_by(driver: :openai)
-
-    if openai_service.nil? || openai_service.effective_token.blank?
-      current_backend = Current.message&.assistant&.language_model&.api_service&.name || "current AI backend"
-      raise "OpenAI API key not found. Image generation requires an OpenAI API key. Please configure your OpenAI API key in Settings > API Services to use image generation with #{current_backend}."
-    end
-
-    OpenAI::Client.new(
-      access_token: openai_service.effective_token
-    )
   end
 end

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -199,3 +199,36 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
     assert_equal m3, messages.third
   end
 end
+
+class AIBackend::OpenAIImageTest < ActiveSupport::TestCase
+  test "generate_image calls the images API with expected parameters and returns the payload" do
+    response = AIBackend::OpenAI.generate_image(prompt: "A cartoon cat", user: users(:keith))
+
+    assert_equal "TEST_BASE64_IMAGE_DATA", response[:b64_json]
+    assert_equal "gpt-image-1", response[:model]
+
+    params = TestClient::OpenAI.images.parameters
+    assert_equal "A cartoon cat", params[:prompt]
+    assert_equal "gpt-image-1", params[:model]
+    assert_equal 1, params[:n]
+    assert_equal "1024x1024", params[:size]
+    assert_equal "auto", params[:quality]
+  end
+
+  test "generate_image raises the preserved message when the user has no OpenAI service" do
+    users(:keith).api_services.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+
+    Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
+      error = assert_raises(RuntimeError) { AIBackend::OpenAI.generate_image(prompt: "A cartoon cat", user: users(:keith)) }
+      expected_backend = messages(:image_generation_tool_call).assistant.language_model.api_service.name
+      assert_equal "OpenAI API key not found. Image generation requires an OpenAI API key. Please configure your OpenAI API key in Settings > API Services to use image generation with #{expected_backend}.", error.message
+    end
+  end
+
+  test "backends without native image generation delegate to OpenAI" do
+    AIBackend::OpenAI.stub :generate_image, { b64_json: "DELEGATED", model: "gpt-image-1" } do
+      result = AIBackend::Anthropic.generate_image(prompt: "A cartoon cat", user: users(:keith))
+      assert_equal "DELEGATED", result[:b64_json]
+    end
+  end
+end

--- a/test/services/toolbox/image_test.rb
+++ b/test/services/toolbox/image_test.rb
@@ -6,90 +6,44 @@ class Toolbox::ImageTest < ActiveSupport::TestCase
     @prompt = "A cartoon image of a cat"
   end
 
-  test "generate_an_image calls api with expected params and returns payload" do
-    response_payload = {
-      "data" => [
-        {
-          "b64_json" => "BASE64_IMAGE_DATA"
-        }
-      ]
-    }
-
-    images_double = Class.new do
-      attr_reader :last_parameters
-
-      def initialize(response)
-        @response = response
-      end
-
-      def generate(parameters:)
-        @last_parameters = parameters
-        @response
-      end
-    end.new(response_payload)
-
-    client_double = Struct.new(:images).new(images_double)
-
+  test "generate_an_image asks the current backend and composes the payload" do
     Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
-      # Mock the openai_client method to return our test client
-      @tool.stub :openai_client, client_double do
+      AIBackend::OpenAI.stub :generate_image, { b64_json: "BASE64_IMAGE_DATA", model: "gpt-image-1" } do
         result = @tool.generate_an_image(image_generation_prompt_s: @prompt)
 
-        params = images_double.last_parameters
-        assert_equal @prompt, params[:prompt]
-        assert_equal "1024x1024", params[:size]
-        assert_equal "auto", params[:quality] # dalle-e is "standard"
-
         assert_equal @prompt, result[:prompt_given]
+        assert_equal "BASE64_IMAGE_DATA", result[:json_of_generated_image]
         assert_includes result[:note_to_assistant], "image"
+        assert_equal "Image created by tool using OpenAI model gpt-image-1", result[:message_to_user]
       end
     end
   end
 
-  test "generate_an_image works with Anthropic backend by using OpenAI client" do
-    response_payload = {
-      "data" => [
-        {
-          "b64_json" => "BASE64_IMAGE_DATA_ANTHROPIC"
-        }
-      ]
-    }
-
-    images_double = Class.new do
-      attr_reader :last_parameters
-
-      def initialize(response)
-        @response = response
-      end
-
-      def generate(parameters:)
-        @last_parameters = parameters
-        @response
-      end
-    end.new(response_payload)
-
-    client_double = Struct.new(:images).new(images_double)
-
-    # Create a message with an Anthropic assistant
+  test "generate_an_image works with an Anthropic assistant by delegating through its backend to OpenAI" do
     anthropic_message = messages(:image_generation_tool_call).dup
     anthropic_message.assistant = assistants(:keith_claude3)
 
     Current.set(user: users(:keith), message: anthropic_message) do
-      # Mock the openai_client method to return our test client
-      @tool.stub :openai_client, client_double do
+      openai_received = nil
+      AIBackend::OpenAI.stub :generate_image, ->(prompt:, user:) {
+        openai_received = { prompt: prompt, user: user }
+        { b64_json: "BASE64_IMAGE_DATA_ANTHROPIC", model: "gpt-image-1" }
+      } do
         result = @tool.generate_an_image(image_generation_prompt_s: @prompt)
 
-        params = images_double.last_parameters
-        assert_equal @prompt, params[:prompt]
-        assert_equal "1024x1024", params[:size]
-        assert_equal "auto", params[:quality]
-
-        assert_equal @prompt, result[:prompt_given]
-        assert_includes result[:note_to_assistant], "image"
+        assert_equal @prompt, openai_received[:prompt]
+        assert_equal users(:keith), openai_received[:user]
         assert_equal "BASE64_IMAGE_DATA_ANTHROPIC", result[:json_of_generated_image]
       end
     end
   end
+
+  test "generate_an_image surfaces the backend error when no OpenAI service is configured" do
+    users(:keith).api_services.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+
+    Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
+      error = assert_raises(RuntimeError) { @tool.generate_an_image(image_generation_prompt_s: @prompt) }
+      assert_includes error.message, "OpenAI API key not found"
+    end
+  end
 end
-
-

--- a/test/support/test_client/open_ai.rb
+++ b/test/support/test_client/open_ai.rb
@@ -116,5 +116,36 @@ module TestClient
         self.class.api_oneoff_response
       end
     end
+
+    def self.images
+      @images ||= Images.new
+    end
+
+    def images
+      self.class.images
+    end
+
+    class Images
+      class << self
+        attr_accessor :parameters
+      end
+
+      def parameters
+        self.class.parameters
+      end
+
+      def self.api_images_response
+        {
+          "data" => [
+            { "b64_json" => "TEST_BASE64_IMAGE_DATA" }
+          ]
+        }
+      end
+
+      def generate(parameters:)
+        self.class.parameters = parameters
+        self.class.api_images_response
+      end
+    end
   end
 end


### PR DESCRIPTION
## Move image generation into the AI backend layer

Groundwork for [#740](https://github.com/AllYourBot/hostedgpt/issues/740) so it gives the RubyLLM migration a clean seam for images ([#775](https://github.com/AllYourBot/hostedgpt/pull/775) Phase 4).

## Summary

`Toolbox::Image` built its own `OpenAI::Client`, resolved the OpenAI `APIService` itself, and carried the comment *"For all backends, use OpenAI client for image generation"* - provider policy living as prose inside a tool. The provider call now lives in the backend layer:

- `AIBackend::OpenAI.generate_image` owns the call: service lookup, key validation, request parameters, and a raw `{ b64_json:, model: }` result. The tool payload strings stay in the toolbox.
- `AIBackend` defines a delegation default so **every backend answers the image question** - today's "always OpenAI" policy stated once as executable code. Backends with native capability override it: when Anthropic or Gemini ships image generation, or RubyLLM's `.paint` arrives, the swap is one method override in one file, and the toolbox never notices.
- `Toolbox::Image` now asks the current assistant's backend and names no provider. Behavior is preserved: images still always use OpenAI (`gpt-image-1`, same parameters, same payload, same error text).
- `TestClient::OpenAI` gains `images.generate` following its existing class-level-stubbable pattern, and the "OpenAI API key not found" error message is asserted for the first time.

## Follow-ups

- Routing images by per-user backend choices and the `RubyLLM.paint` implementation arrive with #775 Phase 4 - this PR builds the slot they plug into. Until then, images remain OpenAI-only.