### PR TITLE
Autotitle json intent refactor

### DIFF
--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -37,22 +37,27 @@ class AutotitleConversationJob < ApplicationJob
   end
 
   def usable_topic(response)
-    return nil if response.blank?
+    if response.blank?
+      Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}")
+      return nil
+    end
 
-    topic = JSON.parse(response)["topic"]
+    document = JSON.parse(response)
+    topic = document.is_a?(Hash) ? document["topic"] : nil
+
     if topic.is_a?(String) && topic.present?
       topic
     else
       Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}")
       nil
     end
-  rescue JSON::ParserError, TypeError => e
+  rescue JSON::ParserError, TypeError, NoMethodError => e
     Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}: #{e.class}")
     nil
   end
 
   def system_message
-    base_message = <<~END
+    <<~END
       You extract a 2-4 word topic from text. I will give the text of a chat. You reply with the topic of this chat,
       but summarize the topic in 2-4 words. Even though it's not a complete sentence, capitalize the first letter of
       the first word unless it's some odd anomaly like "iPhone". Make sure that your answer matches the language of
@@ -72,7 +77,5 @@ class AutotitleConversationJob < ApplicationJob
       { "topic": "Rails collection counter" }
       ```
     END
-
-    base_message
   end
 end

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -17,17 +17,11 @@ class AutotitleConversationJob < ApplicationJob
     response = Current.set(user: @conversation.user) do
       fetch_reply_for(messages.map(&:content_text).join("\n"))
     end
-    topic = usable_topic(response)
 
-    if topic.blank?
-      Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}")
-      return true
-    end
+    topic = usable_topic(response)
+    return true if topic.nil?
 
     @conversation.update!(title: topic)
-  rescue JSON::ParserError, TypeError => e
-    Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}: #{e.class}")
-    true
   end
 
   private
@@ -43,8 +37,18 @@ class AutotitleConversationJob < ApplicationJob
   end
 
   def usable_topic(response)
+    return nil if response.blank?
+
     topic = JSON.parse(response)["topic"]
-    topic if topic.is_a?(String)
+    if topic.is_a?(String) && topic.present?
+      topic
+    else
+      Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}")
+      nil
+    end
+  rescue JSON::ParserError, TypeError => e
+    Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}: #{e.class}")
+    nil
   end
 
   def system_message

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -37,7 +37,7 @@ class AutotitleConversationJob < ApplicationJob
       response = ai_backend.get_oneoff_message(
         system_message,
         [text],
-        generation_config: { response_mime_type: "application/json" }
+        { generation_config: { response_mime_type: "application/json" } }
       )
       return JSON.parse(response)["topic"]
     else

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -25,6 +25,12 @@ class AutotitleConversationJob < ApplicationJob
     return true if @conversation.title.present?
 
     @conversation.update!(title: topic)
+  rescue Faraday::Error,
+         ::OpenAI::ConfigurationError,
+         ::Anthropic::ConfigurationError,
+         ::Gemini::Errors::ConfigurationError => e
+    Rails.logger.warn("[AutotitleConversationJob] Provider failure for conversation #{@conversation.id}: #{e.class}")
+    true
   end
 
   private

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -26,6 +26,7 @@ class AutotitleConversationJob < ApplicationJob
 
     @conversation.update!(title: topic)
   rescue Faraday::Error,
+         ::Timeout::Error,
          ::OpenAI::ConfigurationError,
          ::Anthropic::ConfigurationError,
          ::Gemini::Errors::ConfigurationError => e

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -7,6 +7,8 @@ class AutotitleConversationJob < ApplicationJob
 
   def perform(conversation_id)
     @conversation = Conversation.find(conversation_id)
+    return true if @conversation.title.present?
+
     return false if @conversation.assistant.api_service.requires_token? && @conversation.assistant.api_service.effective_token.blank?
 
     messages = @conversation.messages.ordered.limit(4)

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -21,6 +21,9 @@ class AutotitleConversationJob < ApplicationJob
     topic = usable_topic(response)
     return true if topic.nil?
 
+    @conversation.reload
+    return true if @conversation.title.present?
+
     @conversation.update!(title: topic)
   end
 

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -21,32 +21,14 @@ class AutotitleConversationJob < ApplicationJob
   private
 
   def generate_title_for(text)
-
     ai_backend = @conversation.assistant.api_service.ai_backend.new(@conversation.user, @conversation.assistant)
 
-    if ai_backend.class == AIBackend::OpenAI || ai_backend.class == AIBackend::Anthropic
-      params = ai_backend.class == AIBackend::OpenAI ? { response_format: { type: "json_object" } } : {}
-
-      response = ai_backend.get_oneoff_message(
-        system_message,
-        [text],
-        params
-      )
-      return JSON.parse(response)["topic"]
-    elsif ai_backend.class == AIBackend::Gemini
-      response = ai_backend.get_oneoff_message(
-        system_message,
-        [text],
-        { generation_config: { response_mime_type: "application/json" } }
-      )
-      return JSON.parse(response)["topic"]
-    else
-      response = ai_backend.get_oneoff_message(
-        system_message,
-        [text]
-      )
-      return response.scan(/(?<=:)"(.+?)"/)&.flatten&.first&.strip
-    end
+    response = ai_backend.get_oneoff_message(
+      system_message,
+      [text],
+      json: true
+    )
+    JSON.parse(response)["topic"]
   end
 
   def system_message
@@ -71,10 +53,6 @@ class AutotitleConversationJob < ApplicationJob
       ```
     END
 
-    if @conversation.assistant.api_service.driver == "anthropic"
-      base_message + "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content. Your entire response should be exactly: {\"topic\": \"Your 2-4 word summary here\"}"
-    else
-      base_message
-    end
+    base_message
   end
 end

--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -14,23 +14,37 @@ class AutotitleConversationJob < ApplicationJob
     messages = @conversation.messages.ordered.limit(4)
     raise ConversationNotReady  if messages.empty?
 
-    new_title = Current.set(user: @conversation.user) do
-      generate_title_for(messages.map(&:content_text).join("\n"))
+    response = Current.set(user: @conversation.user) do
+      fetch_reply_for(messages.map(&:content_text).join("\n"))
     end
-    @conversation.update!(title: new_title)
+    topic = usable_topic(response)
+
+    if topic.blank?
+      Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}")
+      return true
+    end
+
+    @conversation.update!(title: topic)
+  rescue JSON::ParserError, TypeError => e
+    Rails.logger.warn("[AutotitleConversationJob] Unusable reply for conversation #{@conversation.id}: #{e.class}")
+    true
   end
 
   private
 
-  def generate_title_for(text)
+  def fetch_reply_for(text)
     ai_backend = @conversation.assistant.api_service.ai_backend.new(@conversation.user, @conversation.assistant)
 
-    response = ai_backend.get_oneoff_message(
+    ai_backend.get_oneoff_message(
       system_message,
       [text],
       json: true
     )
-    JSON.parse(response)["topic"]
+  end
+
+  def usable_topic(response)
+    topic = JSON.parse(response)["topic"]
+    topic if topic.is_a?(String)
   end
 
   def system_message

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -12,11 +12,12 @@ class AIBackend
     @response_handler = nil
   end
 
-  def get_oneoff_message(instructions, messages, params = {})
+  def get_oneoff_message(instructions, messages, params = {}, json: false)
     set_client_config(
       instructions:,
       messages: preceding_messages(messages),
       params:,
+      json:,
     )
     response = @client.send(client_method_name, ** @client_config)
 

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -1,7 +1,13 @@
+require "timeout"
+
 class AIBackend
   include Utilities, Tools
 
   attr :client
+
+  def self.oneoff_timeout_seconds
+    30
+  end
 
   def initialize(user, assistant, conversation = nil, message = nil)
     @user = user
@@ -19,7 +25,9 @@ class AIBackend
       params:,
       json:,
     )
-    response = @client.send(client_method_name, ** @client_config)
+    response = Timeout.timeout(self.class.oneoff_timeout_seconds) do
+      @client.send(client_method_name, ** @client_config)
+    end
 
     response.dig("content", 0, "text") ||
       response.dig("choices", 0, "message", "content")

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -127,9 +127,10 @@ class AIBackend::Anthropic < AIBackend
 
     instructions = config[:instructions]
     if config[:json]
-      # The example schema matches the historical autotitle prompt byte-for-byte;
-      # json intent is not yet exercised by any other caller.
-      instructions += "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content. Your entire response should be exactly: {\"topic\": \"Your 2-4 word summary here\"}"
+      # Mechanism-only coercion: the reply schema is the caller's job (the title
+      # prompt already demonstrates it), so any future json-intent caller is not
+      # handed autotitle vocabulary.
+      instructions += "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content."
     end
 
     formatted_tools = @assistant.language_model.supports_tools? && anthropic_format_tools(Toolbox.tools) || nil

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -127,21 +127,25 @@ class AIBackend::Anthropic < AIBackend
 
     instructions = config[:instructions]
     if config[:json]
+      # The example schema matches the historical autotitle prompt byte-for-byte;
+      # json intent is not yet exercised by any other caller.
       instructions += "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content. Your entire response should be exactly: {\"topic\": \"Your 2-4 word summary here\"}"
     end
+
+    formatted_tools = @assistant.language_model.supports_tools? && anthropic_format_tools(Toolbox.tools) || nil
 
     @client_config = {
       model: @assistant.language_model.api_name,
       system: instructions,
       messages: config[:messages],
-      tools: @assistant.language_model.supports_tools? && anthropic_format_tools(Toolbox.tools) || nil,
+      tools: formatted_tools,
       parameters: {
         model: @assistant.language_model.api_name,
         system: instructions,
         messages: config[:messages],
         max_tokens: 2000, # we should really set this dynamically, based on the model, to the max
         stream: config[:streaming] && @response_handler || nil,
-        tools: @assistant.language_model.supports_tools? && anthropic_format_tools(Toolbox.tools) || nil,
+        tools: formatted_tools,
       }.compact.merge(config[:params]&.except(:response_format) || {})
     }.compact
   end

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -125,14 +125,19 @@ class AIBackend::Anthropic < AIBackend
   def set_client_config(config)
     super(config)
 
+    instructions = config[:instructions]
+    if config[:json]
+      instructions += "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content. Your entire response should be exactly: {\"topic\": \"Your 2-4 word summary here\"}"
+    end
+
     @client_config = {
       model: @assistant.language_model.api_name,
-      system: config[:instructions],
+      system: instructions,
       messages: config[:messages],
       tools: @assistant.language_model.supports_tools? && anthropic_format_tools(Toolbox.tools) || nil,
       parameters: {
         model: @assistant.language_model.api_name,
-        system: config[:instructions],
+        system: instructions,
         messages: config[:messages],
         max_tokens: 2000, # we should really set this dynamically, based on the model, to the max
         stream: config[:streaming] && @response_handler || nil,

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -79,8 +79,8 @@ class AIBackend::Gemini < AIBackend
     response = @client.generate_content({
       system_instruction: system_message(instructions),
       contents: { role: "user", parts: { text: messages.first }}, # TODO: could implement preceding_conversation_messages and call it here
-      **params,
-      **(json ? { generation_config: { response_mime_type: "application/json" } } : {})
+      **(json ? { generation_config: { response_mime_type: "application/json" } } : {}),
+      **params
     })
     response.dig("candidates", 0, "content", "parts", 0, "text")
   end

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -75,11 +75,12 @@ class AIBackend::Gemini < AIBackend
     }.compact
   end
 
-  def get_oneoff_message(instructions, messages, params = {})
+  def get_oneoff_message(instructions, messages, params = {}, json: false)
     response = @client.generate_content({
       system_instruction: system_message(instructions),
       contents: { role: "user", parts: { text: messages.first }}, # TODO: could implement preceding_conversation_messages and call it here
-      ** params
+      **params,
+      **(json ? { generation_config: { response_mime_type: "application/json" } } : {})
     })
     response.dig("candidates", 0, "content", "parts", 0, "text")
   end

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -92,7 +92,7 @@ class AIBackend::OpenAI < AIBackend
         stream: config[:streaming] && @response_handler || nil,
         max_completion_tokens: 2000, # we should really set this dynamically, based on the model, to the max
         stream_options: config[:streaming] && { include_usage: true } || nil,
-        response_format: { type: "text" },
+        response_format: config[:json] ? { type: "json_object" } : { type: "text" },
         tools: @assistant.language_model.supports_tools? && Toolbox.tools || nil,
       }.compact.merge(config[:params] || {})
     }

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -22,6 +22,34 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     assert_equal "Javascript popState", conversation.reload.title
   end
 
+  test "claude conversations are titled through the same intent path" do
+    conversation = conversations(:hello_claude)
+
+    TestClient::Anthropic.stub :text, "{\"topic\":\"Claude Summary\"}" do
+      AutotitleConversationJob.perform_now(conversation.id)
+    end
+
+    assert_equal "Claude Summary", conversation.reload.title
+  end
+
+  test "gemini conversations are titled through the same intent path" do
+    conversation = conversations(:gemini_conversation)
+
+    TestClient::Gemini.stub :text, "{\"topic\":\"Gemini Summary\"}" do
+      AutotitleConversationJob.perform_now(conversation.id)
+    end
+
+    assert_equal "Gemini Summary", conversation.reload.title
+  end
+
+  test "the job source stays provider-blind" do
+    source = File.read(Rails.root.join("app/jobs/autotitle_conversation_job.rb"))
+
+    [".scan(", ".driver ==", ".class =="].each do |needle|
+      refute_includes source, needle
+    end
+  end
+
   test "the topic is not set if the conversation has no messages" do
     conversation = users(:keith).conversations.create!(assistant: assistants(:samantha))
     conversation.update!(updated_at: Time.current) # update is what triggers the callback

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -76,7 +76,11 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     numeric_topic: "{\"topic\":42}",
     array_topic: "{\"topic\":[\"a\",\"b\"]}",
     object_topic: "{\"topic\":{\"k\":\"v\"}}",
-    not_json: "not json at all"
+    not_json: "not json at all",
+    null_literal: "null",
+    true_literal: "true",
+    false_literal: "false",
+    hash_payload: { "topic" => 42 }
   }
 
   test "unusable replies keep the prior title instead of raising" do
@@ -84,13 +88,18 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     conversation.update!(title: nil)
 
     UNUSABLE_REPLIES.each do |label, reply|
+      warnings = []
       begin
-        TestClient::OpenAI.stub :text, reply do
-          AutotitleConversationJob.perform_now(conversation.id)
+        Rails.logger.stub :warn, ->(message) { warnings << message } do
+          TestClient::OpenAI.stub :text, reply do
+            AutotitleConversationJob.perform_now(conversation.id)
+          end
         end
       rescue StandardError => e
         flunk("case #{label} raised #{e.class}: #{e.message}")
       end
+      assert_equal 1, warnings.length, "case #{label} should warn exactly once, got #{warnings.inspect}"
+      assert_includes warnings.first, conversation.id.to_s, "case #{label} warning should carry the conversation id"
       assert_nil conversation.reload.title, "case #{label} should leave the title untouched"
     end
   end

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -87,6 +87,26 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     assert_equal "Twin Title", conversation.reload.title
   end
 
+  test "provider network failures degrade to a warning instead of dead-lettering" do
+    conversation = conversations(:greeting)
+    conversation.update!(title: nil)
+
+    failing_class = Class.new(TestClient::OpenAI) do
+      define_method(:chat) { |**args| raise Faraday::ConnectionFailed, "connection refused" }
+    end
+
+    warnings = []
+    AIBackend::OpenAI.stub :client, failing_class do
+      Rails.logger.stub :warn, ->(message) { warnings << message } do
+        AutotitleConversationJob.perform_now(conversation.id)
+      end
+    end
+
+    assert_equal 1, warnings.length
+    assert_includes warnings.first, conversation.id.to_s
+    assert_nil conversation.reload.title
+  end
+
   UNUSABLE_REPLIES = {
     empty_string: "",
     whitespace_only: "   ",

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -67,6 +67,49 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     assert_equal "Already Named", conversation.reload.title
   end
 
+  UNUSABLE_REPLIES = {
+    empty_string: "",
+    whitespace_only: "   ",
+    plain_prose: "Here is a perfectly fine prose answer.",
+    missing_key: "{}",
+    blank_topic_value: "{\"topic\":\"\"}",
+    numeric_topic: "{\"topic\":42}",
+    array_topic: "{\"topic\":[\"a\",\"b\"]}",
+    object_topic: "{\"topic\":{\"k\":\"v\"}}",
+    not_json: "not json at all"
+  }
+
+  test "unusable replies keep the prior title instead of raising" do
+    conversation = conversations(:greeting)
+    conversation.update!(title: nil)
+
+    UNUSABLE_REPLIES.each do |label, reply|
+      begin
+        TestClient::OpenAI.stub :text, reply do
+          AutotitleConversationJob.perform_now(conversation.id)
+        end
+      rescue StandardError => e
+        flunk("case #{label} raised #{e.class}: #{e.message}")
+      end
+      assert_nil conversation.reload.title, "case #{label} should leave the title untouched"
+    end
+  end
+
+  test "safety-blocked gemini replies keep the prior title too" do
+    conversation = conversations(:gemini_conversation)
+    conversation.update!(title: nil)
+
+    TestClient::Gemini.blocked = true
+
+    assert_nothing_raised do
+      AutotitleConversationJob.perform_now(conversation.id)
+    end
+
+    assert_nil conversation.reload.title
+  ensure
+    TestClient::Gemini.blocked = false
+  end
+
   test "the topic is not set if the conversation has no messages" do
     conversation = users(:keith).conversations.create!(assistant: assistants(:samantha))
     conversation.update!(updated_at: Time.current) # update is what triggers the callback

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -107,6 +107,32 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     assert_nil conversation.reload.title
   end
 
+  test "a stalled provider call times out instead of pinning the worker" do
+    conversation = conversations(:greeting)
+    conversation.update!(title: nil)
+
+    slow_class = Class.new(TestClient::OpenAI) do
+      define_singleton_method(:text) { "{\"topic\":\"Late Reply\"}" }
+
+      define_method(:chat) do |**args|
+        sleep 0.3
+        super(**args)
+      end
+    end
+
+    warnings = []
+    AIBackend::OpenAI.stub :client, slow_class do
+      AIBackend::OpenAI.stub :oneoff_timeout_seconds, 0.05 do
+        Rails.logger.stub :warn, ->(message) { warnings << message } do
+          AutotitleConversationJob.perform_now(conversation.id)
+        end
+      end
+    end
+
+    assert_nil conversation.reload.title
+    assert warnings.any? { |w| w.include?("Provider failure") }, "expected a provider-failure warning, got #{warnings.inspect}"
+  end
+
   UNUSABLE_REPLIES = {
     empty_string: "",
     whitespace_only: "   ",

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class AutotitleConversationJobTest < ActiveJob::TestCase
   test "sets conversation title automatically when there are two messages" do
     conversation = conversations(:greeting)
+    conversation.update!(title: nil)
 
     TestClient::OpenAI.stub :text, "{\"topic\":\"Hear me\"}" do
       AutotitleConversationJob.perform_now(conversation.id)
@@ -14,6 +15,7 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
   test "sets conversation title automatically even if there is only one message" do
     conversation = conversations(:javascript)
     conversation.latest_message_for_version(:latest).destroy!
+    conversation.update!(title: nil)
 
     TestClient::OpenAI.stub :text, "{\"topic\":\"Javascript popState\"}" do
       AutotitleConversationJob.perform_now(conversation.id)
@@ -24,6 +26,7 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
 
   test "claude conversations are titled through the same intent path" do
     conversation = conversations(:hello_claude)
+    conversation.update!(title: nil)
 
     TestClient::Anthropic.stub :text, "{\"topic\":\"Claude Summary\"}" do
       AutotitleConversationJob.perform_now(conversation.id)
@@ -34,6 +37,7 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
 
   test "gemini conversations are titled through the same intent path" do
     conversation = conversations(:gemini_conversation)
+    conversation.update!(title: nil)
 
     TestClient::Gemini.stub :text, "{\"topic\":\"Gemini Summary\"}" do
       AutotitleConversationJob.perform_now(conversation.id)
@@ -48,6 +52,19 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     [".scan(", ".driver ==", ".class =="].each do |needle|
       refute_includes source, needle
     end
+  end
+
+  test "a titled conversation never reaches the provider again" do
+    conversation = conversations(:greeting)
+    conversation.update!(title: "Already Named")
+
+    assert_nothing_raised do
+      TestClient::OpenAI.stub :text, -> { raise "provider reached" } do
+        AutotitleConversationJob.perform_now(conversation.id)
+      end
+    end
+
+    assert_equal "Already Named", conversation.reload.title
   end
 
   test "the topic is not set if the conversation has no messages" do

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -67,6 +67,26 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     assert_equal "Already Named", conversation.reload.title
   end
 
+  test "a title landing during the provider call survives the write" do
+    conversation = conversations(:greeting)
+    conversation.update!(title: nil)
+
+    twin_class = Class.new(TestClient::OpenAI) do
+      define_singleton_method(:text) { "{\"topic\":\"Ladder Topic\"}" }
+
+      define_method(:chat) do |**args|
+        conversation.update!(title: "Twin Title")
+        super(**args)
+      end
+    end
+
+    AIBackend::OpenAI.stub :client, twin_class do
+      AutotitleConversationJob.perform_now(conversation.id)
+    end
+
+    assert_equal "Twin Title", conversation.reload.title
+  end
+
   UNUSABLE_REPLIES = {
     empty_string: "",
     whitespace_only: "   ",

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -441,8 +441,16 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
     assert response.dig("content", 0, "text").present?
   end
 
+  test "json intent suffix coerces mechanism without promising a topic schema" do
+    @anthropic.send(:set_client_config, { instructions: "Extract a topic.", messages: [], json: true })
+    suffix = @anthropic.instance_variable_get(:@client_config)[:system].split("\n\n").last
+
+    assert_includes suffix, "ONLY valid JSON"
+    refute_includes suffix, "topic"
+  end
+
   test "one-off with json intent appends the exact suffix to both system slots and never sends response_format" do
-    suffix = "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content. Your entire response should be exactly: {\"topic\": \"Your 2-4 word summary here\"}"
+    suffix = "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content."
 
     TestClient::Anthropic.stub :text, "{\"topic\":\"Claude Notes\"}" do
       reply = @anthropic.get_oneoff_message("Extract a topic.", ["Here is chat text."], json: true)

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -429,4 +429,14 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
     test_file.close
     test_file.unlink
   end
+
+  test "one-off messages call records arguments and returns a diggable envelope" do
+    response = TestClient::Anthropic.new(access_token: "abc").messages(
+      model: "claude-x", parameters: { system: "be terse" }
+    )
+
+    assert_instance_of Hash, response
+    assert_equal "be terse", TestClient::Anthropic.messages_args.dig(:parameters, :system)
+    assert response.dig("content", 0, "text").present?
+  end
 end

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -439,4 +439,38 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
     assert_equal "be terse", TestClient::Anthropic.messages_args.dig(:parameters, :system)
     assert response.dig("content", 0, "text").present?
   end
+
+  test "one-off with json intent appends the exact suffix to both system slots and never sends response_format" do
+    suffix = "\n\nIMPORTANT: You must respond with ONLY valid JSON. Do not include any explanatory text, markdown formatting, or other content. Your entire response should be exactly: {\"topic\": \"Your 2-4 word summary here\"}"
+
+    TestClient::Anthropic.stub :text, "{\"topic\":\"Claude Notes\"}" do
+      reply = @anthropic.get_oneoff_message("Extract a topic.", ["Here is chat text."], json: true)
+      args = TestClient::Anthropic.messages_args
+
+      assert_equal "Claude Notes", JSON.parse(reply)["topic"]
+      assert args[:system].end_with?(suffix)
+      assert args.dig(:parameters, :system).end_with?(suffix)
+      assert_equal args[:system], args.dig(:parameters, :system), "outer and inner system slots carry identical bytes"
+      assert_nil args[:response_format]
+      assert_nil args.dig(:parameters, :response_format)
+    end
+  end
+
+  test "one-off without json intent leaves instructions unsuffixed while params strip persists" do
+    TestClient::Anthropic.stub :text, "plain answer" do
+      reply = @anthropic.get_oneoff_message(
+        "Just answer.",
+        ["some text"],
+        { model: "claude-override", response_format: { type: "json_object" } }
+      )
+      args = TestClient::Anthropic.messages_args
+
+      assert_not args[:system].end_with?("ONLY valid JSON")
+      assert_not args.dig(:parameters, :system).end_with?("ONLY valid JSON")
+      assert_includes args[:system], "Just answer."
+      assert_nil args.dig(:parameters, :response_format), "foreign keys stay stripped from transmitted parameters"
+      assert_equal "claude-override", args.dig(:parameters, :model), "explicit caller params still win"
+      assert_equal "plain answer", reply
+    end
+  end
 end

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -13,6 +13,7 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
       @conversation.latest_message_for_version(:latest)
     )
     TestClient::Anthropic.new(access_token: "abc")
+    TestClient::Anthropic.reset_recordings!
   end
 
   test "initializing client works" do

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -281,6 +281,27 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
     { "candidates" => [{ "content" => { "role" => "model", "parts" => [{ "text" => text }] } }] }
   end
 
+  test "one-off generate_content records its payload and answers a candidates-shaped hash" do
+    client = TestClient::Gemini.new({})
+    payload = { contents: { role: "user", parts: { text: "Hello!" } }, system_instruction: "be terse" }
+
+    response = client.generate_content(payload)
+
+    assert_equal payload, TestClient::Gemini.payload
+    assert response.dig("candidates", 0, "content", "parts", 0, "text").present?
+  end
+
+  test "generate_content honors a safety-block toggle and stays dig-safe" do
+    TestClient::Gemini.blocked = true
+
+    response = TestClient::Gemini.new({}).generate_content({ contents: {} })
+
+    assert_nil response.dig("candidates", 0, "content", "parts", 0, "text")
+    assert_equal "SAFETY", response.dig("promptFeedback", "blockReason")
+  ensure
+    TestClient::Gemini.blocked = false
+  end
+
   def streamed_function_call(name, args)
     { "candidates" => [{ "content" => { "role" => "model",
       "parts" => [{ "functionCall" => { "name" => name, "args" => args }, "thoughtSignature" => "sig-abc" }] } }] }

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -15,10 +15,6 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
     TestClient::Gemini.new(access_token: "abc")
   end
 
-  test "initializing client works" do
-    assert @gemini.client.present?
-  end
-
   test "one-off get_oneoff_message with json intent requests the json mime type" do
     TestClient::Gemini.stub :text, "{\"topic\":\"Gemini Tips\"}" do
       payload = @gemini.get_oneoff_message("Extract a topic.", ["Here is chat text."], json: true)
@@ -36,12 +32,50 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
     refute TestClient::Gemini.payload.key?(:generation_config)
   end
 
+  test "explicit caller generation_config still wins over json intent" do
+    TestClient::Gemini.stub :text, "{}" do
+      @gemini.get_oneoff_message(
+        "Try to get JSON.",
+        ["some text"],
+        { generation_config: { response_mime_type: "text/plain" } },
+        json: true
+      )
+
+      assert_equal({ response_mime_type: "text/plain" }, TestClient::Gemini.payload[:generation_config])
+    end
+  end
+
   test "one-off get_oneoff_message with json intent through a safety-blocked reply returns nil" do
     TestClient::Gemini.blocked = true
 
     assert_nil @gemini.get_oneoff_message("Extract a topic.", ["chat text"], json: true)
   ensure
     TestClient::Gemini.blocked = false
+  end
+
+  test "one-off generate_content records its payload and answers a candidates-shaped hash" do
+    client = TestClient::Gemini.new({})
+    payload = { contents: { role: "user", parts: { text: "Hello!" } }, system_instruction: "be terse" }
+
+    response = client.generate_content(payload)
+
+    assert_equal payload, TestClient::Gemini.payload
+    assert response.dig("candidates", 0, "content", "parts", 0, "text").present?
+  end
+
+  test "generate_content honors a safety-block toggle and stays dig-safe" do
+    TestClient::Gemini.blocked = true
+
+    response = TestClient::Gemini.new({}).generate_content({ contents: {} })
+
+    assert_nil response.dig("candidates", 0, "content", "parts", 0, "text")
+    assert_equal "SAFETY", response.dig("promptFeedback", "blockReason")
+  ensure
+    TestClient::Gemini.blocked = false
+  end
+
+  test "initializing client works" do
+    assert @gemini.client.present?
   end
 
   test "preceding_conversation_messages constructs a proper response and pivots on images" do
@@ -304,27 +338,6 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
 
   def streamed_text(text)
     { "candidates" => [{ "content" => { "role" => "model", "parts" => [{ "text" => text }] } }] }
-  end
-
-  test "one-off generate_content records its payload and answers a candidates-shaped hash" do
-    client = TestClient::Gemini.new({})
-    payload = { contents: { role: "user", parts: { text: "Hello!" } }, system_instruction: "be terse" }
-
-    response = client.generate_content(payload)
-
-    assert_equal payload, TestClient::Gemini.payload
-    assert response.dig("candidates", 0, "content", "parts", 0, "text").present?
-  end
-
-  test "generate_content honors a safety-block toggle and stays dig-safe" do
-    TestClient::Gemini.blocked = true
-
-    response = TestClient::Gemini.new({}).generate_content({ contents: {} })
-
-    assert_nil response.dig("candidates", 0, "content", "parts", 0, "text")
-    assert_equal "SAFETY", response.dig("promptFeedback", "blockReason")
-  ensure
-    TestClient::Gemini.blocked = false
   end
 
   def streamed_function_call(name, args)

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -19,6 +19,31 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
     assert @gemini.client.present?
   end
 
+  test "one-off get_oneoff_message with json intent requests the json mime type" do
+    TestClient::Gemini.stub :text, "{\"topic\":\"Gemini Tips\"}" do
+      payload = @gemini.get_oneoff_message("Extract a topic.", ["Here is chat text."], json: true)
+
+      assert_equal({ response_mime_type: "application/json" }, TestClient::Gemini.payload[:generation_config])
+      assert_equal({ role: "user", parts: { text: "Here is chat text." } }, TestClient::Gemini.payload[:contents])
+      assert_equal "Gemini Tips", JSON.parse(payload)["topic"]
+    end
+  end
+
+  test "one-off get_oneoff_message without json intent omits generation_config" do
+    @gemini.get_oneoff_message("plain", ["text"])
+
+    assert_equal [ :system_instruction, :contents ], TestClient::Gemini.payload.keys
+    refute TestClient::Gemini.payload.key?(:generation_config)
+  end
+
+  test "one-off get_oneoff_message with json intent through a safety-blocked reply returns nil" do
+    TestClient::Gemini.blocked = true
+
+    assert_nil @gemini.get_oneoff_message("Extract a topic.", ["chat text"], json: true)
+  ensure
+    TestClient::Gemini.blocked = false
+  end
+
   test "preceding_conversation_messages constructs a proper response and pivots on images" do
     conversation = conversations(:attachments)
     assistant = assistants(:keith_claude35)

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -13,6 +13,7 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
       @conversation.latest_message_for_version(:latest)
     )
     TestClient::Gemini.new(access_token: "abc")
+    TestClient::Gemini.reset_recordings!
   end
 
   test "one-off get_oneoff_message with json intent requests the json mime type" do

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -70,6 +70,20 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
     end
   end
 
+  test "a direct OpenAI subclass inherits json intent untouched" do
+    subclass = Class.new(AIBackend::OpenAI)
+    instance = subclass.new(users(:keith), @assistant, @conversation, @conversation.latest_message_for_version(:latest))
+
+    TestClient::OpenAI.stub :text, "{\"topic\":\"Inherited\"}" do
+      reply = instance.get_oneoff_message("Extract a topic.", ["Here is chat text."], json: true)
+
+      params = TestClient::OpenAI.parameters
+      assert_equal({ type: "json_object" }, params[:response_format])
+      assert_equal @assistant.language_model.api_name, params[:model]
+      assert_equal "Inherited", JSON.parse(reply)["topic"]
+    end
+  end
+
   test "stream_next_conversation_message works to stream text and uses model from assistant" do
     assert_not_equal @assistant, @conversation.assistant, "Should force this next message to use a different assistant so these don't match"
 

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -12,10 +12,15 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
       @conversation.latest_message_for_version(:latest)
     )
     TestClient::OpenAI.new(access_token: "abc")
+    TestClient::OpenAI.reset_recordings!
   end
 
   test "initializing client works" do
     assert @openai.client.present?
+  end
+
+  test "recordings start clean in every example" do
+    assert_nil TestClient::OpenAI.parameters
   end
 
   test "openai url is properly set" do

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -70,6 +70,29 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
     end
   end
 
+  test "one-off provider calls are bounded in time" do
+    slow_class = Class.new(TestClient::OpenAI) do
+      define_method(:chat) do |**args|
+        sleep 0.3
+        super(**args)
+      end
+    end
+
+    AIBackend::OpenAI.stub :client, slow_class do
+      AIBackend::OpenAI.stub :oneoff_timeout_seconds, 0.05 do
+        assert_equal 0.05, AIBackend::OpenAI.oneoff_timeout_seconds, "stub must apply"
+
+        openai = AIBackend::OpenAI.new(users(:keith), @assistant, @conversation, @conversation.latest_message_for_version(:latest))
+
+        error = assert_raises(Timeout::Error) do
+          openai.get_oneoff_message("hi", ["there"])
+        end
+
+        assert_includes error.message, "execution expired"
+      end
+    end
+  end
+
   test "a direct OpenAI subclass inherits json intent untouched" do
     subclass = Class.new(AIBackend::OpenAI)
     instance = subclass.new(users(:keith), @assistant, @conversation, @conversation.latest_message_for_version(:latest))

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -32,9 +32,41 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
 
   test "get_oneoff_message with response_format of json returns a hash" do
     TestClient::OpenAI.stub :text, "{\"response\":\"yes\"}" do
-      response = @openai.get_oneoff_message("Reply with the JSON { response: 'yes' }", ["Give me the reply."], response_format: { type: "json_object" } )
+      response = @openai.get_oneoff_message("Reply with the JSON { response: 'yes' }", ["Give me the reply."], { response_format: { type: "json_object" } })
       assert_equal({"response"=>"yes"}, JSON.parse(response))
       assert_equal({:type=>"json_object"}, TestClient::OpenAI.parameters[:response_format])
+    end
+  end
+
+  test "get_oneoff_message with intent shapes the exact expected request" do
+    TestClient::OpenAI.stub :text, "{\"topic\":\"Rails collection counter\"}" do
+      @openai.get_oneoff_message("Extract a topic.", ["Here is chat text."], json: true)
+
+      params = TestClient::OpenAI.parameters
+
+      assert_equal @assistant.language_model.api_name, params[:model]
+      assert_equal({ type: "json_object" }, params[:response_format])
+      assert_equal 2000, params[:max_completion_tokens]
+      assert_nil params[:stream]
+      assert_nil params[:stream_options]
+      assert_not params.key?(:tools), "supports_tools is forced off in setup"
+      assert_equal 2, params[:messages].length
+      assert_equal "system", params[:messages][0][:role]
+      assert_includes params[:messages][0][:content], "Extract a topic."
+      assert_equal({ role: "user", content: "Here is chat text." }, params[:messages][1])
+    end
+  end
+
+  test "explicit caller response_format still wins over internal intent" do
+    TestClient::OpenAI.stub :text, "{}" do
+      @openai.get_oneoff_message(
+        "Try to get JSON.",
+        ["some text"],
+        { response_format: { type: "text" } },
+        json: true
+      )
+
+      assert_equal({ type: "text" }, TestClient::OpenAI.parameters[:response_format])
     end
   end
 

--- a/test/support/test_client/anthropic.rb
+++ b/test/support/test_client/anthropic.rb
@@ -25,10 +25,15 @@ module TestClient
       {:city=>"Austin", :state=>"TX", :country=>"US"}.to_json
     end
 
+    def self.messages_args
+      @@messages_args
+    end
+
     # This response is a valid example response from the API.
     #
     # Stub this method to respond with something more specific if needed.
     def messages(**args)
+      @@messages_args = args
       model = args.dig(:model) || "no model"
       system_message = args.dig(:system)
       tools = args.dig(:parameters, :tools)
@@ -64,7 +69,7 @@ module TestClient
           "stop_reason"=>"end_turn",
           "stop_sequence"=>nil,
           "usage"=>{"input_tokens"=>10, "output_tokens"=>19}
-        }.dig("content", 0, "text")
+        }
       end
     end
 

--- a/test/support/test_client/anthropic.rb
+++ b/test/support/test_client/anthropic.rb
@@ -29,6 +29,10 @@ module TestClient
       @@messages_args
     end
 
+    def self.reset_recordings!
+      @@messages_args = nil
+    end
+
     # This response is a valid example response from the API.
     #
     # Stub this method to respond with something more specific if needed.

--- a/test/support/test_client/gemini.rb
+++ b/test/support/test_client/gemini.rb
@@ -19,6 +19,43 @@ module TestClient
       "EqIBAdHtim9pbmc9dGhvdWdodF9zaWduYXR1cmU"
     end
 
+    def self.payload
+      @@payload
+    end
+
+    def self.blocked
+      @@blocked ||= false
+    end
+
+    def self.blocked=(value)
+      @@blocked = value
+    end
+
+    def generate_content(args)
+      @@payload = args
+
+      if self.class.blocked
+        return { "promptFeedback" => { "blockReason" => "SAFETY" } }
+      end
+
+      text = self.class.text || default_text(args.dig(:system_instruction))
+
+      {
+        "candidates" =>
+          [{"content"=>
+            {"role"=>"model",
+              "parts"=>[{"text"=> text}]},
+            "finishReason"=>"STOP"}],
+        "usageMetadata"=>{"promptTokenCount"=>1037, "candidatesTokenCount"=>31, "totalTokenCount"=>1068}
+      }
+    end
+
+    private
+
+    def default_text(system_message)
+      "Hello this is a model with instruction #{system_message.to_s.inspect}! How can I assist you today?"
+    end
+
     # This response is a valid example response from the API.
     #
     # Stub this method to respond with something more specific if needed.

--- a/test/support/test_client/gemini.rb
+++ b/test/support/test_client/gemini.rb
@@ -12,6 +12,11 @@ module TestClient
         @@payload
       end
 
+      def reset_recordings!
+        @@payload = nil
+        self.blocked = false
+      end
+
       def text
         nil
       end

--- a/test/support/test_client/gemini.rb
+++ b/test/support/test_client/gemini.rb
@@ -1,34 +1,36 @@
 module TestClient
   class Gemini
+    USAGE_METADATA = { "promptTokenCount" => 1037, "candidatesTokenCount" => 31, "totalTokenCount" => 1068 }.freeze
+
     def initialize(args)
     end
 
-    def self.text
-      nil
-    end
+    class << self
+      attr_accessor :blocked
 
-    def self.function
-      raise "Attempting to return a function response but .function method is not stubbed."
-    end
+      def payload
+        @@payload
+      end
 
-    def self.arguments
-      { "city" => "Austin", "state" => "TX", "country" => "US" }
-    end
+      def text
+        nil
+      end
 
-    def self.thought_signature
-      "EqIBAdHtim9pbmc9dGhvdWdodF9zaWduYXR1cmU"
-    end
+      def function
+        raise "Attempting to return a function response but .function method is not stubbed."
+      end
 
-    def self.payload
-      @@payload
-    end
+      def arguments
+        { "city" => "Austin", "state" => "TX", "country" => "US" }
+      end
 
-    def self.blocked
-      @@blocked ||= false
-    end
+      def thought_signature
+        "EqIBAdHtim9pbmc9dGhvdWdodF9zaWduYXR1cmU"
+      end
 
-    def self.blocked=(value)
-      @@blocked = value
+      def default_text(system_message)
+        "Hello this is a model with instruction #{system_message.to_s.inspect}! How can I assist you today?"
+      end
     end
 
     def generate_content(args)
@@ -38,7 +40,7 @@ module TestClient
         return { "promptFeedback" => { "blockReason" => "SAFETY" } }
       end
 
-      text = self.class.text || default_text(args.dig(:system_instruction))
+      text = self.class.text || self.class.default_text(args.dig(:system_instruction))
 
       {
         "candidates" =>
@@ -46,14 +48,8 @@ module TestClient
             {"role"=>"model",
               "parts"=>[{"text"=> text}]},
             "finishReason"=>"STOP"}],
-        "usageMetadata"=>{"promptTokenCount"=>1037, "candidatesTokenCount"=>31, "totalTokenCount"=>1068}
+        "usageMetadata"=> USAGE_METADATA
       }
-    end
-
-    private
-
-    def default_text(system_message)
-      "Hello this is a model with instruction #{system_message.to_s.inspect}! How can I assist you today?"
     end
 
     # This response is a valid example response from the API.
@@ -69,13 +65,13 @@ module TestClient
         [{"content"=>
           {"role"=>"model",
             "parts"=>
-            [{"text"=> self.class.text || "Hello this is a model with instruction #{system_message.to_s.inspect}! How can I assist you today?"}]},
+            [{"text"=> self.class.text || self.class.default_text(system_message)}]},
           "safetyRatings"=>
           [{"category"=>"HARM_CATEGORY_HARASSMENT", "probability"=>"NEGLIGIBLE"},
             {"category"=>"HARM_CATEGORY_HATE_SPEECH", "probability"=>"NEGLIGIBLE"},
             {"category"=>"HARM_CATEGORY_SEXUALLY_EXPLICIT", "probability"=>"NEGLIGIBLE"},
             {"category"=>"HARM_CATEGORY_DANGEROUS_CONTENT", "probability"=>"NEGLIGIBLE"}]}],
-      "usageMetadata"=>{"promptTokenCount"=>1037, "candidatesTokenCount"=>31, "totalTokenCount"=>1068}
+      "usageMetadata"=>USAGE_METADATA
       }]
     end
 
@@ -92,7 +88,7 @@ module TestClient
             },
             "thoughtSignature"=> self.class.thought_signature}]},
           "finishReason"=>"STOP"}],
-      "usageMetadata"=>{"promptTokenCount"=>1037, "candidatesTokenCount"=>31, "totalTokenCount"=>1068}
+      "usageMetadata"=>USAGE_METADATA
       }]
     end
   end

--- a/test/support/test_client/open_ai.rb
+++ b/test/support/test_client/open_ai.rb
@@ -26,6 +26,13 @@ module TestClient
       @@parameters
     end
 
+    def self.reset_recordings!
+      @@model = nil
+      @@instruction = nil
+      @@parameters = nil
+      Images.parameters = nil
+    end
+
     def self.api_oneoff_response
       {
         "id"=>"chatcmpl-A0ZcGrOn1iO5bUgDVFMEj7pX6ZB9A",


### PR DESCRIPTION
## Make conversation titles provider-blind

Groundwork for [#740](https://github.com/AllYourBot/hostedgpt/issues/740) — gives the RubyLLM migration a clean seam for titles ([#775](https://github.com/AllYourBot/hostedgpt/pull/775) Phase 2+), the same treatment images got in #780.

## Summary

`AutotitleConversationJob` picked request parameters by comparing `ai_backend.class ==` against three concrete classes and appended an Anthropic-only prompt suffix by string-comparing the driver, provider policy living as conditionals inside a job. Titles now flow through one seam:

- `get_oneoff_message` gains a trailing `json:` keyword, threaded like `streaming:`. The job makes one call; the class branches, per-provider param literals, driver checks, and the dead regex-scrape fallback are deleted.
- `AIBackend::OpenAI` folds `response_format: { type: "json_object" }` into its parameters when intent is set, before the caller-params merge. Explicit parameters still win last. Any backend extending OpenAI inherits this with zero extra code, pinned by a direct-subclass test.
- `AIBackend::Gemini` injects `generation_config` inside its existing override; `AIBackend::Anthropic` appends a mechanism-only "ONLY valid JSON" coercion to its system slots internally, sends no request param, and leaves the reply schema to the caller: the title prompt already demonstrates it, and OpenAI/Gemini never carried a suffix.
- Duplicate-spend guard: a conversation that already has a title exits before any provider call. Rapid consecutive touches no longer double-bill.
- Graceful failure: a reply that can't yield a non-blank-String topic (blank, prose-wrapped, malformed, wrong shape, safety-blocked) warns with the conversation id and keeps the prior title. Provider network failures and stalls (one-off calls bounded at 30s) degrade the same way. Titles are cosmetic — they should never be queue failures.
- `TestClient` doubles now record received arguments and answer dig-able envelopes, so the Anthropic and Gemini one-off paths, previously untestable, are covered — including a first Anthropic one-off test.
- Behavior is preserved: the refactor commits are wire-identical per provider, with request shapes pinned by recorded arguments. The one deliberate wire change, in the final commit, trims Anthropic's suffix to mechanism-only, matching OpenAI and Gemini, which never carried a schema suffix.
- Every commit is green on its own (full suite verified at each), so any improvement commit can be reverted independently.

## Follow-ups

- Routing titles through per-user backend choices and the RubyLLM implementation arrive with #775 — this PR builds the slot they plug into: its one-off override should adopt the trailing `json:` keyword when that phase lands (heads-up posted on the PR).
- New backends extending the OpenAI dialect inherit the json handling automatically; the subclass test pins that guarantee.

_NOTE: The reason there are a ton of commits is to make it easier for me to review because AI loves giant commits that make a bunch of changes, and give a vague description._