### PR TITLE
Groq backend error contract

### DIFF
--- a/app/jobs/autotitle_conversation_job.rb
+++ b/app/jobs/autotitle_conversation_job.rb
@@ -27,9 +27,7 @@ class AutotitleConversationJob < ApplicationJob
     @conversation.update!(title: topic)
   rescue Faraday::Error,
          ::Timeout::Error,
-         ::OpenAI::ConfigurationError,
-         ::Anthropic::ConfigurationError,
-         ::Gemini::Errors::ConfigurationError => e
+         AIBackend::ConfigurationError => e
     Rails.logger.warn("[AutotitleConversationJob] Provider failure for conversation #{@conversation.id}: #{e.class}")
     true
   end

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -1,8 +1,6 @@
 include ActionView::RecordIdentifier
 require "nokogiri/xml/node"
 
-class ::Gemini::Errors::ConfigurationError < ::Gemini::Errors::GeminiError; end
-
 class GetNextAIMessageJob < ApplicationJob
   include ActionView::Helpers::RenderingHelper
   class ResponseCancelled < StandardError; end
@@ -64,23 +62,8 @@ class GetNextAIMessageJob < ApplicationJob
     Rails.logger.info "\n### Response cancelled in GetNextAIMessageJob(#{message_id})" unless Rails.env.test?
     wrap_up_the_message
     return true
-  rescue OpenAI::ConfigurationError => e
-    name = @assistant.language_model.api_service.name
-    if name == "OpenAI"
-      set_openai_error
-    elsif name == "Groq"
-      set_groq_error
-    else
-      set_generic_error(name)
-    end
-    wrap_up_the_failed_message
-    return true
-  rescue Anthropic::ConfigurationError => e
-    set_anthropic_error
-    wrap_up_the_failed_message
-    return true
-  rescue Gemini::Errors::ConfigurationError => e
-    set_generic_error("Gemini")
+  rescue AIBackend::ConfigurationError => e
+    @message.content_text = ai_backend.key_error_message
     wrap_up_the_failed_message
     return true
   rescue Faraday::ParsingError => e
@@ -92,7 +75,9 @@ class GetNextAIMessageJob < ApplicationJob
     wrap_up_the_failed_message
     return true
   rescue Faraday::TooManyRequestsError => e
-    set_billing_error
+    service = ai_backend.to_s.split("::").second
+    @message.content_text = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
+      "#{service} so go here #{ai_backend.billing_url} and add a credit card, or if you already have one review your billing plan.)"
     wrap_up_the_failed_message
     return true
   rescue WaitForPrevious
@@ -138,26 +123,6 @@ class GetNextAIMessageJob < ApplicationJob
 
   private
 
-  def set_openai_error
-    @message.content_text = "(You need to enter a valid API key for OpenAI to use GPT. Click your Profile in the bottom " +
-      "left and then Settings and then **API Services**. You will find OpenAI Key instructions.)"
-  end
-
-  def set_groq_error
-    @message.content_text = "(You need to enter a valid API key for Groq to use Llama. Click your Profile in the bottom " +
-      "left and then Settings and then **API Services**. You will find Groq Key instructions.)"
-  end
-
-  def set_generic_error(name)
-    @message.content_text = "(There is a configuration error with the #{name} API Service. Maybe you have an invalid API key? Click your Profile in the bottom " +
-      "left and then Settings and then **API Services**. You will find #{name} there.)"
-  end
-
-  def set_anthropic_error
-    @message.content_text = "(You need to enter a valid API key for Anthropic to use Claude. Click your Profile in the bottom " +
-      "left and then Settings and then **API Services**. You will find Anthropic Key instructions.)"
-  end
-
   def set_response_error
     @message.content_text = "(I received a blank response. It's possible your API key is invalid, has expired, or the AI servers may be " +
       "experiencing trouble. Try again or ensure your API key is valid. You can change your API key by clicking your Profile in the bottom " +
@@ -168,22 +133,6 @@ class GetNextAIMessageJob < ApplicationJob
     @message.content_text = "(I received a unexpected response from the API after retrying 3 times, \"#{text}\". The AI servers may be experiencing trouble. " +
       "Try again later or if you keep getting this error ensure your API key is valid and you haven't run out of funds with your AI service.\n\n" +
       "It's also helpful if you report this to the app developers at: https://github.com/allyourbot/hostedgpt/discussions)\n\n:#{msg}"
-  end
-
-  def set_billing_error
-    service = ai_backend.to_s.split("::").second
-    url = case service
-    when "OpenAI"
-      "https://platform.openai.com/account/billing/overview"
-    when "Anthropic"
-      "https://console.anthropic.com/settings/plans"
-    when "Gemini"
-      "https://aistudio.google.com/app/apikey"
-    else
-      "https://platform.openai.com/account/billing/overview"
-    end
-    @message.content_text = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
-      "#{service} so go here #{url} and add a credit card, or if you already have one review your billing plan.)"
   end
 
   def wrap_up_the_failed_message

--- a/app/jobs/get_next_ai_message_job.rb
+++ b/app/jobs/get_next_ai_message_job.rb
@@ -62,11 +62,11 @@ class GetNextAIMessageJob < ApplicationJob
     Rails.logger.info "\n### Response cancelled in GetNextAIMessageJob(#{message_id})" unless Rails.env.test?
     wrap_up_the_message
     return true
-  rescue AIBackend::ConfigurationError => e
+  rescue AIBackend::ConfigurationError
     @message.content_text = ai_backend.key_error_message
     wrap_up_the_failed_message
     return true
-  rescue Faraday::ParsingError => e
+  rescue Faraday::ParsingError
     set_response_error
     wrap_up_the_failed_message
     return true
@@ -74,8 +74,8 @@ class GetNextAIMessageJob < ApplicationJob
     @message.content_text = "I experienced a connection error. #{e.message}"
     wrap_up_the_failed_message
     return true
-  rescue Faraday::TooManyRequestsError => e
-    service = ai_backend.to_s.split("::").second
+  rescue Faraday::TooManyRequestsError
+    service = ai_backend.name.demodulize
     @message.content_text = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
       "#{service} so go here #{ai_backend.billing_url} and add a credit card, or if you already have one review your billing plan.)"
     wrap_up_the_failed_message

--- a/app/models/api_service.rb
+++ b/app/models/api_service.rb
@@ -24,13 +24,14 @@ class APIService < ApplicationRecord
   scope :ordered, -> { order(:name) }
 
   def ai_backend
-    case driver
-    when "openai"
-      AIBackend::OpenAI
-    when "anthropic"
+    if driver == "openai" && url == URL_GROQ
+      AIBackend::Groq
+    elsif driver == "anthropic"
       AIBackend::Anthropic
-    when "gemini"
+    elsif driver == "gemini"
       AIBackend::Gemini
+    elsif driver == "openai"
+      AIBackend::OpenAI
     end
   end
 

--- a/app/models/api_service.rb
+++ b/app/models/api_service.rb
@@ -35,7 +35,7 @@ class APIService < ApplicationRecord
   end
 
   def requires_token?
-    [URL_OPEN_AI, URL_ANTHROPIC, URL_GEMINI, URL_BRAVE].include?(url) # other services may require it but we don't always know
+    [URL_OPEN_AI, URL_ANTHROPIC, URL_GEMINI, URL_BRAVE, URL_GROQ].include?(url) # other services may require it but we don't always know
   end
 
   def logo_filename

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -25,8 +25,7 @@ class LanguageModel < ApplicationRecord
   end
 
   def supports_tools?
-    attributes["supports_tools"] &&
-      api_service.name != "Groq" # TODO: Remove this short circuit once I can debug tool use with Groq
+    attributes["supports_tools"] && api_service.ai_backend.supports_tools?
   end
 
   def logo_filename

--- a/app/models/language_model.rb
+++ b/app/models/language_model.rb
@@ -25,7 +25,7 @@ class LanguageModel < ApplicationRecord
   end
 
   def supports_tools?
-    attributes["supports_tools"] && api_service.ai_backend.supports_tools?
+    attributes["supports_tools"] && api_service.ai_backend&.supports_tools?
   end
 
   def logo_filename

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -3,6 +3,8 @@ require "timeout"
 class AIBackend
   include Utilities, Tools
 
+  class ConfigurationError < StandardError; end
+
   attr :client
 
   def self.oneoff_timeout_seconds
@@ -111,7 +113,7 @@ class AIBackend
   end
 
   def configuration_error
-    raise NotImplementedError
+    AIBackend::ConfigurationError
   end
 
   def set_client_config(config)

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -9,6 +9,14 @@ class AIBackend
     30
   end
 
+  def self.key_error_message
+    "(There is a configuration error with this API Service. Maybe you have an invalid API key? " +
+      "Click your Profile in the bottom left and then Settings and then **API Services**.)"
+  end
+
+  def self.billing_url
+  end
+
   def initialize(user, assistant, conversation = nil, message = nil)
     @user = user
     @assistant = assistant

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -62,8 +62,8 @@ class AIBackend
 
     begin
       response = @client.send(client_method_name, ** @client_config)
-    rescue ::Faraday::UnauthorizedError => e
-      raise configuration_error
+    rescue ::Faraday::UnauthorizedError
+      raise AIBackend::ConfigurationError
     end
 
     if @stream_response_tool_calls.present?
@@ -110,10 +110,6 @@ class AIBackend
 
   def client_method_name
     raise NotImplementedError
-  end
-
-  def configuration_error
-    AIBackend::ConfigurationError
   end
 
   def set_client_config(config)

--- a/app/services/ai_backend.rb
+++ b/app/services/ai_backend.rb
@@ -17,6 +17,12 @@ class AIBackend
   def self.billing_url
   end
 
+  # New backends: override this to deny tool calls — a backend whose tool
+  # support is not yet proven should pin it to false.
+  def self.supports_tools?
+    true
+  end
+
   def initialize(user, assistant, conversation = nil, message = nil)
     @user = user
     @assistant = assistant

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -51,10 +51,10 @@ class AIBackend::Anthropic < AIBackend
       raise AIBackend::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
       Rails.logger.info "Connecting to Anthropic API server at #{assistant.api_service.url} with access token of length #{assistant.api_service.effective_token.to_s.length}"
       @client = self.class.client.new(uri_base: assistant.api_service.url, access_token: assistant.api_service.effective_token)
-    rescue ::Anthropic::ConfigurationError => e
+    rescue ::Anthropic::ConfigurationError
       # The gem raises its own class for a nil token when it falls back to its
       # configuration getter, which custom-URL services reach because they are
-      # not in the requires_token? gate. Translate it to the unified error.
+      # not in the requires_token? gate.
       raise AIBackend::ConfigurationError
     rescue ::Faraday::UnauthorizedError => e
       raise AIBackend::ConfigurationError
@@ -130,10 +130,6 @@ class AIBackend::Anthropic < AIBackend
 
   def client_method_name
     :messages
-  end
-
-  def configuration_error
-    AIBackend::ConfigurationError
   end
 
   def set_client_config(config)

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -48,11 +48,16 @@ class AIBackend::Anthropic < AIBackend
   def initialize(user, assistant, conversation = nil, message = nil)
     super(user, assistant, conversation, message)
     begin
-      raise ::Anthropic::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
+      raise AIBackend::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
       Rails.logger.info "Connecting to Anthropic API server at #{assistant.api_service.url} with access token of length #{assistant.api_service.effective_token.to_s.length}"
       @client = self.class.client.new(uri_base: assistant.api_service.url, access_token: assistant.api_service.effective_token)
+    rescue ::Anthropic::ConfigurationError => e
+      # The gem raises its own class for a nil token when it falls back to its
+      # configuration getter, which custom-URL services reach because they are
+      # not in the requires_token? gate. Translate it to the unified error.
+      raise AIBackend::ConfigurationError
     rescue ::Faraday::UnauthorizedError => e
-      raise ::Anthropic::ConfigurationError
+      raise AIBackend::ConfigurationError
     end
   end
 
@@ -128,7 +133,7 @@ class AIBackend::Anthropic < AIBackend
   end
 
   def configuration_error
-    ::Anthropic::ConfigurationError
+    AIBackend::ConfigurationError
   end
 
   def set_client_config(config)
@@ -188,7 +193,7 @@ class AIBackend::Anthropic < AIBackend
     rescue ::GetNextAIMessageJob::ResponseCancelled => e
       raise e
     rescue ::Faraday::UnauthorizedError => e
-      raise ::Anthropic::ConfigurationError
+      raise AIBackend::ConfigurationError
     rescue => e
       Rails.logger.info "\nUnhandled error in AIBackend::Anthropic response handler: #{e.message}"
     end

--- a/app/services/ai_backend/anthropic.rb
+++ b/app/services/ai_backend/anthropic.rb
@@ -36,6 +36,15 @@ class AIBackend::Anthropic < AIBackend
     "Error: #{e.message}"
   end
 
+  def self.key_error_message
+    "(You need to enter a valid API key for Anthropic to use Claude. Click your Profile in the bottom " +
+      "left and then Settings and then **API Services**. You will find Anthropic Key instructions.)"
+  end
+
+  def self.billing_url
+    "https://console.anthropic.com/settings/plans"
+  end
+
   def initialize(user, assistant, conversation = nil, message = nil)
     super(user, assistant, conversation, message)
     begin

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -47,7 +47,7 @@ class AIBackend::Gemini < AIBackend
   def initialize(user, assistant, conversation = nil, message = nil)
     super(user, assistant, conversation, message)
     begin
-      raise configuration_error if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
+      raise AIBackend::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
       Rails.logger.info "Connecting to Gemini API server at #{assistant.api_service.url} with access token of length #{assistant.api_service.effective_token.to_s.length}"
       @client = self.class.client.new(
         credentials: {
@@ -61,7 +61,7 @@ class AIBackend::Gemini < AIBackend
         }
       )
     rescue ::Faraday::UnauthorizedError, ::Faraday::BadRequestError => e
-      raise configuration_error
+      raise AIBackend::ConfigurationError
     end
   end
 
@@ -110,7 +110,7 @@ class AIBackend::Gemini < AIBackend
       end
     rescue ::Faraday::UnauthorizedError, ::Faraday::BadRequestError => e
       Rails.logger.error "Gemini rejected the request: #{e.try(:response)&.dig(:body) || e.message}"
-      raise configuration_error
+      raise AIBackend::ConfigurationError
     end
 
     return format_parallel_tool_calls(@stream_response_tool_calls) if @stream_response_tool_calls.present?

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -1,6 +1,5 @@
 class AIBackend::Gemini < AIBackend
   include Tools
-  class ::Gemini::Errors::ConfigurationError < ::Gemini::Errors::GeminiError; end
 
   # Rails system tests don't seem to allow mocking because the server and the
   # test are in separate processes.
@@ -71,7 +70,7 @@ class AIBackend::Gemini < AIBackend
   end
 
   def configuration_error
-    ::Gemini::Errors::ConfigurationError
+    AIBackend::ConfigurationError
   end
 
   def set_client_config(config)

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -69,10 +69,6 @@ class AIBackend::Gemini < AIBackend
     :stream_generate_content
   end
 
-  def configuration_error
-    AIBackend::ConfigurationError
-  end
-
   def set_client_config(config)
     super(config)
 

--- a/app/services/ai_backend/gemini.rb
+++ b/app/services/ai_backend/gemini.rb
@@ -36,6 +36,15 @@ class AIBackend::Gemini < AIBackend
     "Error: #{e.message}"
   end
 
+  def self.key_error_message
+    "(There is a configuration error with the Gemini API Service. Maybe you have an invalid API key? " +
+      "Click your Profile in the bottom left and then Settings and then **API Services**. You will find Gemini there.)"
+  end
+
+  def self.billing_url
+    "https://aistudio.google.com/app/apikey"
+  end
+
   def initialize(user, assistant, conversation = nil, message = nil)
     super(user, assistant, conversation, message)
     begin

--- a/app/services/ai_backend/groq.rb
+++ b/app/services/ai_backend/groq.rb
@@ -1,0 +1,23 @@
+# The first Backend to inherit from another Backend. Groq speaks the OpenAI
+# wire dialect, so it rides AIBackend::OpenAI and overrides only its Error
+# contract and tools policy.
+#
+# @note tool calls are pinned false until this app's tool loop is debugged
+#   against Groq. This is a deliberate hold, not a judgment on the provider.
+# @todo elevate to its own driver (enum value + URL_GROQ row migration, the
+#   AddBrave pattern) or its own client (community gems) once Groq needs
+#   anything outside OpenAI compatibility
+class AIBackend::Groq < AIBackend::OpenAI
+  def self.key_error_message
+    "(You need to enter a valid API key for Groq to use Llama. Click your Profile in the bottom " +
+      "left and then Settings and then **API Services**. You will find Groq Key instructions.)"
+  end
+
+  def self.billing_url
+    "https://console.groq.com/keys"
+  end
+
+  def self.supports_tools?
+    false
+  end
+end

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -73,11 +73,11 @@ class AIBackend::OpenAI < AIBackend
   def initialize(user, assistant, conversation = nil, message = nil)
     super(user, assistant, conversation, message)
     begin
-      raise ::OpenAI::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
+      raise AIBackend::ConfigurationError if assistant.api_service.requires_token? && assistant.api_service.effective_token.blank?
       Rails.logger.info "Connecting to OpenAI API server at #{assistant.api_service.url} with access token of length #{assistant.api_service.effective_token.to_s.length}"
       @client = self.class.client.new(uri_base: assistant.api_service.url, access_token: assistant.api_service.effective_token, api_version: "")
     rescue ::Faraday::UnauthorizedError
-      raise ::OpenAI::ConfigurationError
+      raise AIBackend::ConfigurationError
     end
   end
 
@@ -88,7 +88,7 @@ class AIBackend::OpenAI < AIBackend
   end
 
   def configuration_error
-    ::OpenAI::ConfigurationError
+    AIBackend::ConfigurationError
   end
 
   def set_client_config(config)
@@ -134,7 +134,7 @@ class AIBackend::OpenAI < AIBackend
     rescue ::GetNextAIMessageJob::ResponseCancelled => e
       raise e
     rescue ::Faraday::UnauthorizedError => e
-      raise OpenAI::ConfigurationError
+      raise AIBackend::ConfigurationError
     rescue => e
       Rails.logger.info "\nUnhandled error in AIBackend::OpenAI response handler: #{e.message}"
       Rails.logger.info e.backtrace.join("\n")

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -87,10 +87,6 @@ class AIBackend::OpenAI < AIBackend
     :chat
   end
 
-  def configuration_error
-    AIBackend::ConfigurationError
-  end
-
   def set_client_config(config)
     super(config)
 

--- a/app/services/ai_backend/open_ai.rb
+++ b/app/services/ai_backend/open_ai.rb
@@ -61,6 +61,15 @@ class AIBackend::OpenAI < AIBackend
     { b64_json: b64_json, model: IMAGE_MODEL }
   end
 
+  def self.key_error_message
+    "(You need to enter a valid API key for OpenAI to use GPT. Click your Profile in the bottom " +
+      "left and then Settings and then **API Services**. You will find OpenAI Key instructions.)"
+  end
+
+  def self.billing_url
+    "https://platform.openai.com/account/billing/overview"
+  end
+
   def initialize(user, assistant, conversation = nil, message = nil)
     super(user, assistant, conversation, message)
     begin

--- a/test/fixtures/assistants.yml
+++ b/test/fixtures/assistants.yml
@@ -52,6 +52,15 @@ keith_gemini:
   instructions:
   tools: []
 
+keith_groq:
+  user: keith
+  slug: groq-llama-3
+  language_model: llama_3_3_70b_versatile
+  name: Groq Llama 3.3
+  description: Groq's Llama 3.3 70B
+  instructions:
+  tools: []
+
 
 rob_gpt4:
   user: rob

--- a/test/fixtures/conversations.yml
+++ b/test/fixtures/conversations.yml
@@ -40,6 +40,11 @@ gemini_conversation:
   title: Meeting Gemini
   last_assistant_message: hello_gemini
 
+hello_groq:
+  user: keith
+  assistant: keith_groq
+  title: Meeting Groq
+
 debugging:
   user: rob
   assistant: rob_gpt4
@@ -47,6 +52,12 @@ debugging:
   last_assistant_message: filter_map_example
   input_token_total_count: 12
   output_token_total_count: 36
+
+alpaca_conversation:
+  user: taylor
+  assistant: alpaca_asst
+  title: Meeting Alpaca
+
 
 #  0.1
 #  1.1

--- a/test/fixtures/language_models.yml
+++ b/test/fixtures/language_models.yml
@@ -292,3 +292,12 @@ gemini_flash_1_5:
   api_service: keith_gemini_service
   supports_images: true
   supports_tools: false
+
+llama_3_3_70b_versatile:
+  position: 24
+  user: keith
+  name: Llama 3.3 70B Versatile 128k
+  api_name: llama-3.3-70b-versatile
+  api_service: keith_groq_service
+  supports_images: false
+  supports_tools: true

--- a/test/jobs/autotitle_conversation_job_test.rb
+++ b/test/jobs/autotitle_conversation_job_test.rb
@@ -107,6 +107,22 @@ class AutotitleConversationJobTest < ActiveJob::TestCase
     assert_nil conversation.reload.title
   end
 
+  test "provider configuration errors degrade to a warning instead of dead-lettering" do
+    conversation = conversations(:greeting)
+    conversation.update!(title: nil)
+
+    warnings = []
+    AIBackend::OpenAI.stub_any_instance :get_oneoff_message, -> (*) { raise AIBackend::ConfigurationError } do
+      Rails.logger.stub :warn, ->(message) { warnings << message } do
+        assert AutotitleConversationJob.perform_now(conversation.id)
+      end
+    end
+
+    assert_equal 1, warnings.length
+    assert_includes warnings.first, conversation.id.to_s
+    assert_nil conversation.reload.title
+  end
+
   test "a stalled provider call times out instead of pinning the worker" do
     conversation = conversations(:greeting)
     conversation.update!(title: nil)

--- a/test/jobs/get_next_ai_message_job_anthropic_test.rb
+++ b/test/jobs/get_next_ai_message_job_anthropic_test.rb
@@ -42,8 +42,10 @@ class GetNextAIMessageJobAnthropicTest < ActiveJob::TestCase
       api_service = @conversation.assistant.language_model.api_service
       api_service.update!(token: "")
 
-      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @conversation.assistant.id)
-      assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for Anthropic"
+      assert_no_enqueued_jobs only: GetNextAIMessageJob do
+        assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @conversation.assistant.id)
+      end
+      assert_equal AIBackend::Anthropic.key_error_message, @conversation.latest_message_for_version(:latest).content_text
     end
   end
 

--- a/test/jobs/get_next_ai_message_job_gemini_test.rb
+++ b/test/jobs/get_next_ai_message_job_gemini_test.rb
@@ -79,8 +79,10 @@ class GetNextAIMessageJobGeminiTest < ActiveJob::TestCase
     api_service = @assistant.language_model.api_service
     api_service.update!(token: "")
 
-    assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
-    assert_includes @conversation.latest_message_for_version(:latest).content_text, "There is a configuration error with the Gemini API Service"
+    assert_no_enqueued_jobs only: GetNextAIMessageJob do
+      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+    end
+    assert_equal AIBackend::Gemini.key_error_message, @conversation.latest_message_for_version(:latest).content_text
   end
 
   test "when API response key is missing, a nice error message is displayed" do

--- a/test/jobs/get_next_ai_message_job_groq_test.rb
+++ b/test/jobs/get_next_ai_message_job_groq_test.rb
@@ -39,21 +39,6 @@ class GetNextAIMessageJobGroqTest < ActiveJob::TestCase
     end
   end
 
-  test "a Gemini configuration error renders the Gemini backend copy" do
-    conversation = conversations(:gemini_conversation)
-    conversation.messages.create! role: :user, content_text: "Still there?", assistant: conversation.assistant
-    message = conversation.latest_message_for_version(:latest)
-
-    api_service = conversation.assistant.language_model.api_service
-    api_service.update!(token: "")
-
-    assert_no_enqueued_jobs only: GetNextAIMessageJob do
-      assert GetNextAIMessageJob.perform_now(conversation.user.id, message.id, conversation.assistant.id)
-    end
-
-    assert_equal AIBackend::Gemini.key_error_message, conversation.latest_message_for_version(:latest).content_text
-  end
-
   test "a blank Groq key fails fast instead of making a doomed provider call" do
     stub_features(default_llm_keys: false) do
       @assistant.language_model.api_service.update!(token: "")

--- a/test/jobs/get_next_ai_message_job_groq_test.rb
+++ b/test/jobs/get_next_ai_message_job_groq_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class GetNextAIMessageJobGroqTest < ActiveJob::TestCase
+  setup do
+    @conversation = conversations(:hello_groq)
+    @user = @conversation.user
+    @assistant = @conversation.assistant
+    @conversation.messages.create! role: :user, content_text: "Still there?", assistant: @assistant
+    @message = @conversation.latest_message_for_version(:latest)
+  end
+
+  test "the job rescues one unified configuration error with no per-provider remnants" do
+    source = File.read(Rails.root.join("app/jobs/get_next_ai_message_job.rb"))
+
+    ["set_openai_error", "set_groq_error", "set_anthropic_error", "set_billing_error",
+     "set_generic_error", "name ==", "OpenAI::ConfigurationError", "Anthropic::ConfigurationError",
+     "Gemini::Errors::ConfigurationError", "when \"OpenAI\"", "when \"Anthropic\"", "when \"Gemini\""].each do |remnant|
+      refute_includes source, remnant, "the job should not contain the per-provider remnant #{remnant.inspect}"
+    end
+
+    assert_includes source, "AIBackend::ConfigurationError", "the job should rescue the unified configuration error"
+  end
+
+  test "a renamed OpenAI service still renders the canonical OpenAI key error" do
+    conversation = conversations(:greeting)
+    conversation.messages.create! role: :user, content_text: "Still there?", assistant: conversation.assistant
+    message = conversation.latest_message_for_version(:latest)
+
+    stub_features(default_llm_keys: false) do
+      api_service = conversation.assistant.language_model.api_service
+      api_service.update!(name: "My GPT Proxy", token: "")
+
+      assert_no_enqueued_jobs only: GetNextAIMessageJob do
+        assert GetNextAIMessageJob.perform_now(conversation.user.id, message.id, conversation.assistant.id)
+      end
+
+      assert_equal AIBackend::OpenAI.key_error_message, conversation.latest_message_for_version(:latest).content_text
+      assert message.reload.failed?, "The message should have been marked failed so a Retry button is offered"
+    end
+  end
+
+  test "a Gemini configuration error renders the Gemini backend copy" do
+    conversation = conversations(:gemini_conversation)
+    conversation.messages.create! role: :user, content_text: "Still there?", assistant: conversation.assistant
+    message = conversation.latest_message_for_version(:latest)
+
+    api_service = conversation.assistant.language_model.api_service
+    api_service.update!(token: "")
+
+    assert_no_enqueued_jobs only: GetNextAIMessageJob do
+      assert GetNextAIMessageJob.perform_now(conversation.user.id, message.id, conversation.assistant.id)
+    end
+
+    assert_equal AIBackend::Gemini.key_error_message, conversation.latest_message_for_version(:latest).content_text
+  end
+
+  test "a quota error on a Groq row renders today's template with the OpenAI fallthrough" do
+    TestClient::OpenAI.stub_any_instance :chat, -> (*) { raise Faraday::TooManyRequestsError, "quota exceeded" } do
+      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+    end
+
+    expected = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
+      "OpenAI so go here https://platform.openai.com/account/billing/overview and add a credit card, or if you already have one review your billing plan.)"
+    assert_equal expected, @message.reload.content_text
+    assert @message.failed?, "The message should have been marked failed so a Retry button is offered"
+  end
+
+  test "a custom-URL anthropic service with a nil token has the gem's own error translated to the unified one" do
+    assistant = assistants(:alpaca_asst)
+
+    api_service = assistant.language_model.api_service
+    api_service.update!(token: "")
+
+    TestClient::Anthropic.stub :new, -> (*) { raise ::Anthropic::ConfigurationError, "access_token is required" } do
+      error = assert_raise(AIBackend::ConfigurationError) do
+        AIBackend::Anthropic.new(assistant.user, assistant)
+      end
+      assert_kind_of AIBackend::ConfigurationError, error
+    end
+  end
+end

--- a/test/jobs/get_next_ai_message_job_groq_test.rb
+++ b/test/jobs/get_next_ai_message_job_groq_test.rb
@@ -62,9 +62,9 @@ class GetNextAIMessageJobGroqTest < ActiveJob::TestCase
         assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
       end
 
-      # Dispatch still routes Groq rows to the OpenAI backend until the
-      # pair-first dispatch lands, so the copy is OpenAI's until then.
-      assert_equal AIBackend::OpenAI.key_error_message, @conversation.latest_message_for_version(:latest).content_text
+      # Dispatch now routes Groq rows to their own backend, so the copy and
+      # billing URL are Groq's.
+      assert_equal AIBackend::Groq.key_error_message, @conversation.latest_message_for_version(:latest).content_text
       assert @message.reload.failed?, "The message should have been marked failed so a Retry button is offered"
       assert_equal 0, @message.reload.input_token_count.to_i + @message.reload.output_token_count.to_i
     end
@@ -99,14 +99,30 @@ class GetNextAIMessageJobGroqTest < ActiveJob::TestCase
     end
   end
 
-  test "a quota error on a Groq row renders today's template with the OpenAI fallthrough" do
+  test "a quota error on a Groq row renders Groq copy with Groq's keys URL" do
     TestClient::OpenAI.stub_any_instance :chat, -> (*) { raise Faraday::TooManyRequestsError, "quota exceeded" } do
       assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
     end
 
     expected = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
-      "OpenAI so go here https://platform.openai.com/account/billing/overview and add a credit card, or if you already have one review your billing plan.)"
+      "Groq so go here https://console.groq.com/keys and add a credit card, or if you already have one review your billing plan.)"
     assert_equal expected, @message.reload.content_text
     assert @message.failed?, "The message should have been marked failed so a Retry button is offered"
+  end
+
+  test "a renamed Groq service still gets Groq's copy, keys URL, and tools policy" do
+    @assistant.language_model.api_service.update!(name: "My Fast Llama")
+
+    assert_equal AIBackend::Groq.key_error_message, @assistant.language_model.ai_backend.key_error_message
+    assert_equal "https://console.groq.com/keys", @assistant.language_model.ai_backend.billing_url
+    refute @assistant.language_model.supports_tools?
+  end
+
+  test "a Groq model with backfilled tool support stays denied through the model" do
+    # The 2024 supports_tools backfill set true on groq/llama rows in existing
+    # databases; the backend policy keeps them denied regardless.
+    @assistant.language_model.update!(supports_tools: true)
+
+    refute @assistant.language_model.supports_tools?
   end
 end

--- a/test/jobs/get_next_ai_message_job_groq_test.rb
+++ b/test/jobs/get_next_ai_message_job_groq_test.rb
@@ -54,15 +54,35 @@ class GetNextAIMessageJobGroqTest < ActiveJob::TestCase
     assert_equal AIBackend::Gemini.key_error_message, conversation.latest_message_for_version(:latest).content_text
   end
 
-  test "a quota error on a Groq row renders today's template with the OpenAI fallthrough" do
-    TestClient::OpenAI.stub_any_instance :chat, -> (*) { raise Faraday::TooManyRequestsError, "quota exceeded" } do
-      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+  test "a blank Groq key fails fast instead of making a doomed provider call" do
+    stub_features(default_llm_keys: false) do
+      @assistant.language_model.api_service.update!(token: "")
+
+      assert_no_enqueued_jobs only: GetNextAIMessageJob do
+        assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+      end
+
+      # Dispatch still routes Groq rows to the OpenAI backend until the
+      # pair-first dispatch lands, so the copy is OpenAI's until then.
+      assert_equal AIBackend::OpenAI.key_error_message, @conversation.latest_message_for_version(:latest).content_text
+      assert @message.reload.failed?, "The message should have been marked failed so a Retry button is offered"
+      assert_equal 0, @message.reload.input_token_count.to_i + @message.reload.output_token_count.to_i
+    end
+  end
+
+  test "a blank Groq key skips title generation before any provider call" do
+    conversation = conversations(:hello_groq)
+    conversation.update!(title: nil)
+
+    stub_features(default_llm_keys: false) do
+      conversation.assistant.language_model.api_service.update!(token: "")
+
+      assert_no_enqueued_jobs only: AutotitleConversationJob do
+        refute AutotitleConversationJob.perform_now(conversation.id)
+      end
     end
 
-    expected = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
-      "OpenAI so go here https://platform.openai.com/account/billing/overview and add a credit card, or if you already have one review your billing plan.)"
-    assert_equal expected, @message.reload.content_text
-    assert @message.failed?, "The message should have been marked failed so a Retry button is offered"
+    assert_nil conversation.reload.title
   end
 
   test "a custom-URL anthropic service with a nil token has the gem's own error translated to the unified one" do
@@ -77,5 +97,16 @@ class GetNextAIMessageJobGroqTest < ActiveJob::TestCase
       end
       assert_kind_of AIBackend::ConfigurationError, error
     end
+  end
+
+  test "a quota error on a Groq row renders today's template with the OpenAI fallthrough" do
+    TestClient::OpenAI.stub_any_instance :chat, -> (*) { raise Faraday::TooManyRequestsError, "quota exceeded" } do
+      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+    end
+
+    expected = "(I received a quota error. Try again and if you still get this error then your API key is probably valid, but you may need to adding billing details. You are using " +
+      "OpenAI so go here https://platform.openai.com/account/billing/overview and add a credit card, or if you already have one review your billing plan.)"
+    assert_equal expected, @message.reload.content_text
+    assert @message.failed?, "The message should have been marked failed so a Retry button is offered"
   end
 end

--- a/test/jobs/get_next_ai_message_job_openai_test.rb
+++ b/test/jobs/get_next_ai_message_job_openai_test.rb
@@ -141,8 +141,10 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
       api_service = @assistant.language_model.api_service
       api_service.update!(token: "")
 
-      assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
-      assert_includes @conversation.latest_message_for_version(:latest).content_text, "need to enter a valid API key for OpenAI"
+      assert_no_enqueued_jobs only: GetNextAIMessageJob do
+        assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+      end
+      assert_equal AIBackend::OpenAI.key_error_message, @conversation.latest_message_for_version(:latest).content_text
       assert @message.reload.failed?, "The message should have been marked failed so a Retry button is offered"
     end
   end

--- a/test/jobs/get_next_ai_message_job_openai_test.rb
+++ b/test/jobs/get_next_ai_message_job_openai_test.rb
@@ -149,6 +149,17 @@ class GetNextAIMessageJobOpenaiTest < ActiveJob::TestCase
     end
   end
 
+  test "a mid-stream 401 renders the backend's key error without retrying" do
+    TestClient::OpenAI.stub_any_instance :chat, -> (*) { raise Faraday::UnauthorizedError, "401" } do
+      assert_no_enqueued_jobs only: GetNextAIMessageJob do
+        assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)
+      end
+    end
+
+    assert_equal AIBackend::OpenAI.key_error_message, @conversation.latest_message_for_version(:latest).content_text
+    assert @message.reload.failed?, "The message should have been marked failed so a Retry button is offered"
+  end
+
   test "when API response key is missing, a nice error message is displayed and the message is marked failed" do
     TestClient::OpenAI.stub :text, "" do
       assert GetNextAIMessageJob.perform_now(@user.id, @message.id, @assistant.id)

--- a/test/models/api_service_test.rb
+++ b/test/models/api_service_test.rb
@@ -58,6 +58,7 @@ class APIServiceTest < ActiveSupport::TestCase
     assert_equal AIBackend::Groq, language_models(:llama_3_3_70b_versatile).ai_backend
     assert_equal AIBackend::Anthropic, language_models(:alpaca).ai_backend
     assert_equal AIBackend::Anthropic, language_models(:claude_best).ai_backend
+    assert_equal AIBackend::Gemini, language_models(:gemini_flash_1_5).ai_backend
   end
 
   test "openai-dialect services with custom URLs keep the OpenAI backend" do

--- a/test/models/api_service_test.rb
+++ b/test/models/api_service_test.rb
@@ -53,6 +53,17 @@ class APIServiceTest < ActiveSupport::TestCase
     assert_equal AIBackend::Anthropic, language_models(:claude_best).ai_backend
   end
 
+  test "backends resolve by driver, with Groq picked by the driver and URL pair" do
+    assert_equal AIBackend::OpenAI, language_models(:gpt_best).ai_backend
+    assert_equal AIBackend::Groq, language_models(:llama_3_3_70b_versatile).ai_backend
+    assert_equal AIBackend::Anthropic, language_models(:alpaca).ai_backend
+    assert_equal AIBackend::Anthropic, language_models(:claude_best).ai_backend
+  end
+
+  test "openai-dialect services with custom URLs keep the OpenAI backend" do
+    assert_equal AIBackend::OpenAI, language_models(:guanaco).ai_backend
+  end
+
   test "official providers require a token and custom URLs do not" do
     assert api_services(:keith_openai_service).requires_token?
     assert api_services(:keith_groq_service).requires_token?

--- a/test/models/api_service_test.rb
+++ b/test/models/api_service_test.rb
@@ -53,6 +53,21 @@ class APIServiceTest < ActiveSupport::TestCase
     assert_equal AIBackend::Anthropic, language_models(:claude_best).ai_backend
   end
 
+  test "official providers require a token and custom URLs do not" do
+    assert api_services(:keith_openai_service).requires_token?
+    assert api_services(:keith_groq_service).requires_token?
+    refute api_services(:keith_other_service).requires_token?
+  end
+
+  test "the Test button reports a blank token for Groq services" do
+    service = api_services(:keith_groq_service)
+    service.update!(token: "")
+
+    stub_features(default_llm_keys: false) do
+      assert_equal "Error: API key (token) is blank", service.test_api_service
+    end
+  end
+
   test "both ai_backends can be specified for user models" do
     assert_equal AIBackend::Anthropic, language_models(:alpaca).ai_backend
     assert_equal AIBackend::OpenAI, language_models(:guanaco).ai_backend

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -28,6 +28,14 @@ class LanguageModelTest < ActiveSupport::TestCase
     refute model.supports_tools?
   end
 
+  test "a model on a service without a backend denies tools" do
+    brave_service = api_services(:keith_brave_service)
+    model = language_models(:gpt_4o)
+    model.update!(api_service: brave_service, supports_tools: true)
+
+    refute model.supports_tools?
+  end
+
   test "ai_backend works as a delegated attribute" do
     assert_equal AIBackend::OpenAI, language_models(:gpt_best).ai_backend
   end

--- a/test/models/language_model_test.rb
+++ b/test/models/language_model_test.rb
@@ -18,6 +18,16 @@ class LanguageModelTest < ActiveSupport::TestCase
     refute language_models(:guanaco).supports_tools?
   end
 
+  test "tools support combines the model attribute with the backend's policy" do
+    # attribute true + backend allowed -> tools sent (today's default-named behavior)
+    assert language_models(:gpt_4o).supports_tools?
+
+    # attribute false -> denied regardless of the backend's policy
+    model = language_models(:gpt_4o)
+    model.supports_tools = false
+    refute model.supports_tools?
+  end
+
   test "ai_backend works as a delegated attribute" do
     assert_equal AIBackend::OpenAI, language_models(:gpt_best).ai_backend
   end

--- a/test/services/ai_backend/anthropic_test.rb
+++ b/test/services/ai_backend/anthropic_test.rb
@@ -482,4 +482,14 @@ class AIBackend::AnthropicTest < ActiveSupport::TestCase
       assert_equal "plain answer", reply
     end
   end
+
+  test "key_error_message returns the recorded Anthropic copy" do
+    assert_equal "(You need to enter a valid API key for Anthropic to use Claude. Click your Profile in the bottom " +
+      "left and then Settings and then **API Services**. You will find Anthropic Key instructions.)",
+      AIBackend::Anthropic.key_error_message
+  end
+
+  test "billing_url returns the recorded Anthropic billing page" do
+    assert_equal "https://console.anthropic.com/settings/plans", AIBackend::Anthropic.billing_url
+  end
 end

--- a/test/services/ai_backend/gemini_test.rb
+++ b/test/services/ai_backend/gemini_test.rb
@@ -320,6 +320,16 @@ class AIBackend::GeminiTest < ActiveSupport::TestCase
     refute part.key?(:thoughtSignature), "An empty signature should be left out rather than sent as null"
   end
 
+  test "key_error_message returns the recorded Gemini copy" do
+    assert_equal "(There is a configuration error with the Gemini API Service. Maybe you have an invalid API key? " +
+      "Click your Profile in the bottom left and then Settings and then **API Services**. You will find Gemini there.)",
+      AIBackend::Gemini.key_error_message
+  end
+
+  test "billing_url returns the recorded Gemini billing page" do
+    assert_equal "https://aistudio.google.com/app/apikey", AIBackend::Gemini.billing_url
+  end
+
   private
 
   def function_call_part_in(messages)

--- a/test/services/ai_backend/groq_test.rb
+++ b/test/services/ai_backend/groq_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class AIBackendGroqTest < ActiveSupport::TestCase
+  test "key_error_message returns the recorded Groq copy" do
+    assert_equal "(You need to enter a valid API key for Groq to use Llama. Click your Profile in the bottom " +
+      "left and then Settings and then **API Services**. You will find Groq Key instructions.)",
+      AIBackend::Groq.key_error_message
+  end
+
+  test "billing_url returns the Groq keys console" do
+    assert_equal "https://console.groq.com/keys", AIBackend::Groq.billing_url
+  end
+
+  test "tools policy denies Groq" do
+    assert_not AIBackend::Groq.supports_tools?
+  end
+
+  test "tools policy allows by default on the base and flows to OpenAI through inheritance" do
+    assert AIBackend.supports_tools?
+    assert AIBackend::OpenAI.supports_tools?
+  end
+end

--- a/test/services/ai_backend/open_ai_test.rb
+++ b/test/services/ai_backend/open_ai_test.rb
@@ -272,6 +272,16 @@ class AIBackend::OpenAITest < ActiveSupport::TestCase
     assert_equal m2, messages.second
     assert_equal m3, messages.third
   end
+
+  test "key_error_message returns the recorded OpenAI copy" do
+    assert_equal "(You need to enter a valid API key for OpenAI to use GPT. Click your Profile in the bottom " +
+      "left and then Settings and then **API Services**. You will find OpenAI Key instructions.)",
+      AIBackend::OpenAI.key_error_message
+  end
+
+  test "billing_url returns the recorded OpenAI billing page" do
+    assert_equal "https://platform.openai.com/account/billing/overview", AIBackend::OpenAI.billing_url
+  end
 end
 
 class AIBackend::OpenAIImageTest < ActiveSupport::TestCase

--- a/test/services/ai_backend_test.rb
+++ b/test/services/ai_backend_test.rb
@@ -1,5 +1,13 @@
 require "test_helper"
 
 class AIBackendTest < ActiveSupport::TestCase
+  test "key_error_message returns the name-free fallback copy" do
+    assert_equal "(There is a configuration error with this API Service. Maybe you have an invalid API key? " +
+      "Click your Profile in the bottom left and then Settings and then **API Services**.)",
+      AIBackend.key_error_message
+  end
 
+  test "billing_url returns nil for the name-free base default" do
+    assert_nil AIBackend.billing_url
+  end
 end


### PR DESCRIPTION
## Give Groq its own backend

Groundwork for [#740](https://github.com/AllYourBot/hostedgpt/issues/740). Continues the provider-policy-out-of-jobs work from #780 and the title refactor, in the same shape.

## Summary

Groq services ride the OpenAI driver, so they got the OpenAI backend everywhere, and provider-specific behavior lived in other files as string comparisons against the service *name*, which users can edit. Backends now own their error facts, and Groq owns a backend:

- `AIBackend::Groq` subclasses `AIBackend::OpenAI` and carries Groq's own error contract: Llama-flavored key-error copy and `console.groq.com/keys`. This fixes the live bug where Groq users hitting quota errors (routine on Groq's free tier) were pointed at OpenAI's billing page.
- Each backend owns its error facts as class-level methods (`key_error_message`, `billing_url`) with a generic fallback on the base. `GetNextAIMessageJob` rescues one unified `AIBackend::ConfigurationError` and renders what the current backend declares; the job's per-provider copy methods, name-string branching, billing-URL case map, and the Gemini error monkey patch are deleted. Provider-blind failures (blank response, connection error) stay in the job.
- Backend selection checks the driver and canonical URL pair: a service on Groq's URL gets `AIBackend::Groq`; OpenAI services and openai-dialect custom URLs (local model servers etc.) resolve exactly as before.
- `URL_GROQ` joins the `requires_token?` allowlist, so a blank Groq key now fails fast with the friendly error at chat, at title generation, and at the settings Test button instead of a doomed provider call.
- Tool policy moves out of `LanguageModel`: the model keeps its per-model `supports_tools` attribute and asks its backend for the provider policy. Groq's backend pins the answer to denied until Groq tool use is debugged. The class comment records the two deliberately untaken future paths (a dedicated Groq SDK, with the community gems and their trade-offs, and a first-class `:groq` driver, including the data migration of existing rows and the maintainer discussion that entails).
- Behavior changes beyond Groq's own copy, stated up front: services whose name was changed, or that use a custom URL, now receive their driver backend's standard error message instead of the old message that interpolated the service name, and the tools gate now consults each backend's provider policy, so configurations that previously bypassed the name-based gate may see tool calls declined. Copy for default-named services is byte-identical; Anthropic's backend additionally translates the gem's own configuration error (raised directly for nil tokens on custom-URL services).
- Groq inherits `response_format` JSON handling from the OpenAI backend. This is pre-verified: JSON Object Mode is supported on all Groq models, and the title prompt meets its prompt requirement. The title job was publicly tested against Groq in #583.
- Every commit is green on its own (full suite verified at each), so any commit can be reverted independently.

## Follow-ups

- Groq tool support: Groq's docs say all hosted models support function calling. The backend's pinned denial stays until someone debugs this app's tool loop against Groq; the intent is recorded on the class.
- Groq still rides the `openai` driver with driver+URL dispatch; a first-class `:groq` driver (enum value, data migration, settings row) is deliberately left for a maintainer discussion. The new backend class documents this path and its migration lineage.