### PR TITLE
[WIP] Add Kamal deployment support (revival of #518)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,9 @@ Dockerfile
 /config/master.key
 /config/credentials/*.key
 
+# Ignore Kamal's deploy secrets (gitignored too; must never enter a build context).
+/.kamal
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@
 /.idea/*
 /client/.idea/*
 vendor/bundle
+.kamal/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ If you set up the app outside of Docker, then run the usual `bin/rails test` and
 
 ### Understanding the Docker configuration
 
-The `Dockerfile` is set up to support three distinct situations: development, deploying to Render, and deploying to Fly. Each of these are completely separate targets which don't share any steps, they are simply in the same Dockerfile.
+The `Dockerfile` is set up to support four distinct situations: development, deploying to Render, deploying to Fly, and deploying to your own server with Kamal. The Fly, Kamal, and Render targets share some build steps: `kamal-production` is a thin child of `fly-production` (defined just below the Fly section, between `#### END of FLY ####` and `#### START of DEV ####`; see `config/deploy.yml` and the README's "Deploy the app with Kamal" section), while `render-production` must remain the last stage because Render always builds the last one.
 
 The `docker-compose.yml` is solely for development. It references the `development` build target.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,22 @@ EXPOSE 3000
 
 #### END of FLY ####
 
+#### START of KAMAL ####
+
+# Child of fly-production, not a standalone build: it inherits the lean
+# runtime image (jemalloc, YJIT, non-root user, entrypoint) instead of
+# repeating the DEV/RENDER rebuild-everything pattern. The entrypoint's
+# db:prepare branch matches the `rails server` CMD, and PORT must match
+# proxy.app_port in config/deploy.yml. render-production below must remain
+# the LAST stage.
+FROM fly-production AS kamal-production
+
+ENV PORT=8080
+
+CMD ["./bin/rails", "server", "-b", "0.0.0.0"]
+
+#### END of KAMAL ####
+
 #### START of DEV ####
 
 # RUBY_VERSION is the only thing used from anything above

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :development do
   gem "rubocop-capybara"
   gem "rubocop-minitest"
   gem "dockerfile-rails", ">= 1.6"
-  gem "kamal", "~> 2.0"
+  gem "kamal", "~> 2.12"
   gem "logcraft"
   # gem "oj" # Optional, but recommended; see the "JSON serialization" section in the README
 end

--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development do
   gem "rubocop-capybara"
   gem "rubocop-minitest"
   gem "dockerfile-rails", ">= 1.6"
+  gem "kamal", "~> 2.0"
   gem "logcraft"
   # gem "oj" # Optional, but recommended; see the "JSON serialization" section in the README
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.3.0)
     bcrypt (3.1.22)
+    bcrypt_pbkdf (1.1.2)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
     bindex (0.8.1)
@@ -141,7 +142,9 @@ GEM
       reline (>= 0.3.8)
     dockerfile-rails (1.7.10)
       rails (>= 3.0.0)
+    dotenv (3.2.0)
     drb (2.2.3)
+    ed25519 (1.4.0)
     erb (6.0.7)
     erubi (1.13.1)
     et-orbi (1.4.1)
@@ -210,6 +213,17 @@ GEM
     json (2.21.2)
     jwt (3.2.0)
       base64
+    kamal (2.12.0)
+      activesupport (>= 7.0)
+      base64 (~> 0.2)
+      bcrypt_pbkdf (~> 1.0)
+      concurrent-ruby (~> 1.2)
+      dotenv (~> 3.1)
+      ed25519 (~> 1.4)
+      net-ssh (~> 7.3)
+      sshkit (>= 1.23.0, < 2.0)
+      thor (~> 1.3)
+      zeitwerk (>= 2.6.18, < 3.0)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     little-plugger (1.1.4)
@@ -256,8 +270,13 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
+    net-scp (4.1.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
+    net-ssh (7.3.3)
     nio4r (2.7.5)
     nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -496,6 +515,13 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sshkit (1.25.1)
+      base64
+      logger
+      net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
+      net-ssh (>= 2.8.0)
+      ostruct
     standard (1.56.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -513,8 +539,6 @@ GEM
     sync (0.5.0)
     syslog (0.4.0)
       logger
-    tailwindcss-rails (2.7.9)
-      railties (>= 7.0.0)
     tailwindcss-rails (2.7.9-aarch64-linux)
       railties (>= 7.0.0)
     tailwindcss-rails (2.7.9-arm-linux)
@@ -595,6 +619,7 @@ DEPENDENCIES
   gemini-ai (~> 4.2.0)
   image_processing (~> 1.13.0)
   importmap-rails
+  kamal (~> 2.12)
   logcraft
   minitest (~> 5.0)
   minitest-retry

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This project is led by an experienced rails developer, but we're actively lookin
   - [Troubleshooting Render](#troubleshooting-render)
 - [Deploy the app on Fly.io](#deploy-the-app-on-flyio)
 - [Deploy the app on Heroku](#deploy-the-app-on-heroku)
+- [Deploy the app with Kamal](#deploy-the-app-with-kamal)
 - [Deploy on your own server](#deploy-on-your-own-server)
 - [Running locally on your computer](#running-locally-on-your-computer)
   - [Alternatively, you can run outside of Docker](#alternatively-you-can-run-outside-of-docker)]
@@ -116,6 +117,70 @@ Eligible students can apply for Heroku platform credits through [Heroku for GitH
    [![Deploy to Heroku](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/heroku/nodejs-getting-start)
 
 You may want to read about [configuring optional features](#configure-optional-features).
+
+## Deploy the app with Kamal
+
+Kamal deploys the app as a Docker container with automatic HTTPS, zero-downtime rollover, and **no accounts on any external service**: no Docker Hub, no container registry, no Redis. The only things you need are a server, a domain name, and SSH access to it.
+
+### Prerequisites
+
+- Your local machine: Ruby matching this repo's `.ruby-version` (bundler enforces it exactly) with `bundle install` run, and Docker running (Kamal builds the image and hosts a private registry locally, so the server never sees your source or credentials)
+- A Linux server with at least 2 GB RAM and 20 GB disk, **amd64** architecture (arm64 hosts work only after a one-line change, see below), Ubuntu LTS family validated
+- Inbound TCP 80 and 443 reachable from the internet. Open them at your **cloud provider's security group or edge firewall** (a host firewall alone is not enough, and Docker-published ports bypass host-firewall rules entirely)
+- A DNS A-record pointing your domain (e.g. `chat.example.com`) at the server
+- SSH access to the server (key-based auth recommended; you'll typically run as root)
+
+### One-time setup
+
+1. Generate your production secrets; each command prints a value you'll use in the next step. These guard every API key your users store in HostedGPT, so **back them up offline in encrypted form before continuing: if you lose them, all stored credentials are permanently unreadable** (recovery requires re-encrypting every stored token). **Migrating an existing HostedGPT deployment from Render or Fly?** Reuse your *original* `ACTIVE_RECORD_ENCRYPTION_*` values instead of generating fresh ones; new keys leave every stored credential permanently undecryptable.
+
+   ```
+   bin/rails secret   # → RAILS_MASTER_KEY
+   bin/rails secret   # → SECRET_KEY_BASE
+   bin/rails secret   # → ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+   bin/rails secret   # → ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+   bin/rails secret   # → ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+   bin/rails secret   # → HOSTED_DB_PASSWORD
+   ```
+
+2. Create `.kamal/secrets` in the repo root with owner-only permissions (`chmod 600 .kamal/secrets`) and these contents (paste your generated values):
+
+   ```
+   RAILS_MASTER_KEY=<value>
+   SECRET_KEY_BASE=<value>
+   ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=<value>
+   ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY=<value>
+   ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=<value>
+   HOSTED_DB_PASSWORD=<value>
+   ```
+
+   This file is gitignored and excluded from Docker builds. Never paste its contents anywhere. (No `POSTGRES_PASSWORD` entry is needed: the deploy config injects `HOSTED_DB_PASSWORD` into the database container as `POSTGRES_PASSWORD`, so the app and database can never drift.)
+3. Edit `config/deploy.yml`: set your server's IP in `servers.web` and in the `db` accessory's `host`, and your domain in `proxy.host`.
+4. Commit nothing; your edits stay local to your deployment.
+
+### Deploy
+
+```
+bundle exec kamal setup
+```
+
+That single command installs Docker on the server, starts the proxy and the Postgres database, builds the app image on your machine, transfers it, runs migrations, and brings up HostedGPT with HTTPS. First deploy takes a while: the image transfers through a tunnel from your machine to the server, so duration depends on your upload bandwidth, and your machine must stay awake throughout. Subsequent deploys are `bundle exec kamal deploy`.
+
+A few things worth knowing:
+
+- **Rolling back** needs the machine that deployed: previous images are kept on your local registry, so `bundle exec kamal rollback` works from the same machine with the registry container running. Rolling forward works from anywhere with the repo.
+- **Migrations run at container boot** and bound deploy time. For a lengthy migration, run it first via `bundle exec kamal app exec --reuse "bin/rails db:migrate"` (mirroring Fly's release-command pattern), then deploy.
+- **Base images pull anonymously from Docker Hub.** If `kamal setup` fails with a pull error on a shared IP, wait and retry; rate limits are per-IP and temporary.
+- **Never expose the database port.** The accessory has no published host port by design; if you ever add one, it must be loopback-only (`127.0.0.1:5432:5432`); Docker-published ports bypass host-firewall rules.
+- **Back up your database**: all conversations live in the Postgres data directory on the server (the `db` accessory's `data` directory under your deploy directory). Periodically dump it, encrypted, somewhere outside this repo; the dump contains every conversation:
+
+  ```
+  bundle exec kamal accessory exec db --reuse --raw -q -- "pg_dump -U hostedgpt hostedgpt_production" | gpg --encrypt --recipient you@example.com > ~/backups/hostedgpt-$(date +%F).sql.gpg
+  ```
+
+  (`--reuse` runs inside the live database container; `--raw` keeps kamal's host banners out of the dump; sanity-check the file starts with a pg_dump header.)
+
+Once it's up, you may want to read about [configuring optional features](#configure-optional-features). To run without Docker instead, follow [Deploy on your own server](#deploy-on-your-own-server).
 
 ## Deploy on your own server
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -15,7 +15,7 @@ else
     export RAILS_ENV=test
     echo "Running db:prepare"
     ./bin/rails db:prepare
-  elif echo "${1}" | grep -q "rails$" && [ "${2}" == "server" ]; then
+  elif echo "${1}" | grep -q "rails$" && [ "${2}" = "server" ]; then
     echo "Running db:prepare"
     ./bin/rails db:prepare
   else

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,0 +1,107 @@
+# Name of your application. Used to uniquely configure containers.
+service: hostedgpt
+
+# Name of the container image.
+image: my-docker-user/hostedgpt
+
+# Deploy to these servers.
+servers:
+  web:
+    - 168.192.0.1
+  # job:
+  #   hosts:
+  #     - 168.192.0.1
+  #   cmd: bin/rake solid_queue:start
+
+# Enable SSL auto certification via Let's Encrypt (and allow for multiple apps on one server).
+# Set ssl: false if using something like Cloudflare to terminate SSL (but keep host!).
+proxy:
+  ssl: true
+  host: hostedgpt.example.com
+  app_port: 8080
+
+# Credentials for your image host.
+registry:
+  # Specify the registry server, if you're not using Docker Hub
+  # server: registry.digitalocean.com / ghcr.io / ...
+  username: my-docker-user
+
+  # Always use an access token rather than real password when possible.
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+# Inject ENV variables into containers (secrets come from .kamal/secrets).
+env:
+  secret:
+    - RAILS_MASTER_KEY
+    - HOSTEDGPT_DATABASE_PASSWORD
+  clear:
+    # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
+    # When you start using multiple servers, you should split out job processing to a dedicated machine.
+    RUN_SOLID_QUEUE_IN_PUMA: true
+
+    # Set number of processes dedicated to Solid Queue (default: 1)
+    # JOB_CONCURRENCY: 3
+
+    # Set number of cores available to the application on each server (default: 1).
+    # WEB_CONCURRENCY: 2
+
+    HOSTEDGPT_FORCE_SSL: "false"
+
+    # Match this to any external database server to configure Active Record correctly
+    HOSTEDGPT_DATABASE_HOST: hostedgpt-db
+    HOSTEDGPT_DATABASE_USERNAME: postgres
+    HOSTEDGPT_PRODUCTION_DB: hostedgpt_production
+
+    # Log everything from Rails
+    RAILS_LOG_LEVEL: debug
+
+# Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
+# "bin/kamal logs -r job" will tail logs from the first server in the job section.
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell: app exec --interactive --reuse "bash"
+  logs: app logs -f
+  dbc: app exec --interactive --reuse "bin/rails dbconsole"
+
+# Use a persistent storage volume for sqlite database files and local Active Storage files.
+# Recommended to change this to a mounted volume path that is backed up off server.
+volumes:
+  - "hostedgpt_storage:/rails/storage"
+
+# Bridge fingerprinted assets, like JS and CSS, between versions to avoid
+# hitting 404 on in-flight requests. Combines all files from new and old
+# version inside the asset_path.
+asset_path: /rails/public/assets
+
+# Configure the image builder.
+builder:
+  arch: amd64
+
+# # Build image via remote server (useful for faster amd64 builds on arm64 computers)
+# remote: ssh://docker@docker-builder-server
+#
+# # Pass arguments and secrets to the Docker build process
+# args:
+#   RUBY_VERSION: ruby-3.3.5
+# secrets:
+#   - GITHUB_TOKEN
+#   - RAILS_MASTER_KEY
+
+# Use a different ssh user than root
+# ssh:
+#   user: deploy
+
+# Use accessory services (secrets come from .kamal/secrets).
+accessories:
+  db:
+    image: postgres:16
+    host: 168.192.0.1
+    # port: 5432
+    env:
+      clear:
+        POSTGRES_DB: hostedgpt_production
+      secret:
+        - POSTGRES_PASSWORD
+    directories:
+      - data:/var/lib/postgresql/data

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -1,107 +1,118 @@
+# Deploy HostedGPT to your own server with Kamal 2.12.
+#
+# All secrets come from .kamal/secrets (gitignored; see the README's
+# "Deploy the app with Kamal" section for the exact contents to write).
+# The registry is local to the deployer's machine: no Docker Hub or GHCR
+# account is required anywhere in this flow.
+
 # Name of your application. Used to uniquely configure containers.
 service: hostedgpt
 
-# Name of the container image.
-image: my-docker-user/hostedgpt
+# Name of the container image (pushed to the local registry; no account).
+image: hostedgpt
 
-# Deploy to these servers.
+# Deploy to these servers. Replace with your server's IP or hostname.
 servers:
   web:
-    - 168.192.0.1
+    - 192.0.2.1
+  # Split job processing out to a dedicated host when you scale beyond one
+  # server (escape hatch; untested):
   # job:
   #   hosts:
-  #     - 168.192.0.1
-  #   cmd: bin/rake solid_queue:start
+  #     - 192.0.2.1
+  #   cmd: bin/jobs
 
-# Enable SSL auto certification via Let's Encrypt (and allow for multiple apps on one server).
-# Set ssl: false if using something like Cloudflare to terminate SSL (but keep host!).
+# kamal-proxy terminates TLS (automatic Let's Encrypt for the host below)
+# and forwards X-Forwarded-Proto so Rails' force_ssl does not redirect-loop.
+# The /up health check is exempt from the redirect on the Rails side.
 proxy:
   ssl: true
   host: hostedgpt.example.com
   app_port: 8080
+  forward_headers: true
 
-# Credentials for your image host.
+# The image is pushed to a registry Kamal starts on the deployer's machine;
+# the target server pulls it through a temporary SSH tunnel during deploy.
+# No registry account is created or required. The postgres and kamal-proxy
+# base images are pulled anonymously from Docker Hub (availability, not
+# account, dependency).
 registry:
-  # Specify the registry server, if you're not using Docker Hub
-  # server: registry.digitalocean.com / ghcr.io / ...
-  username: my-docker-user
-
-  # Always use an access token rather than real password when possible.
-  password:
-    - KAMAL_REGISTRY_PASSWORD
+  server: localhost:5555
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 env:
-  secret:
-    - RAILS_MASTER_KEY
-    - HOSTEDGPT_DATABASE_PASSWORD
   clear:
-    # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
-    # When you start using multiple servers, you should split out job processing to a dedicated machine.
+    # Run the Solid Queue Supervisor inside the web server's Puma process.
+    # When you start using multiple servers, split out job processing to a
+    # dedicated machine (see the commented `job` role above).
     RUN_SOLID_QUEUE_IN_PUMA: true
 
-    # Set number of processes dedicated to Solid Queue (default: 1)
-    # JOB_CONCURRENCY: 3
+    # Rails reads its secret_key_base and ActiveRecord-encryption keys from
+    # these ENV values instead of a credentials file (the render.yaml-proven
+    # contract for this app). Values are generated once via `bin/rails secret`.
+    CONFIGURE_ACTIVE_RECORD_ENCRYPTION_FROM_ENV: true
 
-    # Set number of cores available to the application on each server (default: 1).
-    # WEB_CONCURRENCY: 2
+    # Database connection for the accessory below. The hostname is the
+    # accessory's container name (`<service>-<accessory>`; Kamal sets no
+    # network aliases).
+    HOSTED_DB_HOST: hostedgpt-db
+    HOSTED_DB_USERNAME: hostedgpt
+    HOSTED_DB_NAME: hostedgpt
 
-    HOSTEDGPT_FORCE_SSL: "false"
+    # `rails server` below reads PORT; must match proxy.app_port.
+    PORT: 8080
 
-    # Match this to any external database server to configure Active Record correctly
-    HOSTEDGPT_DATABASE_HOST: hostedgpt-db
-    HOSTEDGPT_DATABASE_USERNAME: postgres
-    HOSTEDGPT_PRODUCTION_DB: hostedgpt_production
+  secret:
+    - RAILS_MASTER_KEY
+    - SECRET_KEY_BASE
+    - ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+    - ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+    - ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+    - HOSTED_DB_PASSWORD
 
-    # Log everything from Rails
-    RAILS_LOG_LEVEL: debug
+  # Alternative to the HOSTED_DB_* family: a single connection string.
+  # If you switch to it, list it under `secret` (never `clear`); the URL
+  # embeds the database password.
+  # secret:
+  #   - DATABASE_URL
 
-# Aliases are triggered with "bin/kamal <alias>". You can overwrite arguments on invocation:
-# "bin/kamal logs -r job" will tail logs from the first server in the job section.
+# Aliases are triggered with `bin/kamal <alias>`.
 aliases:
   console: app exec --interactive --reuse "bin/rails console"
   shell: app exec --interactive --reuse "bash"
   logs: app logs -f
   dbc: app exec --interactive --reuse "bin/rails dbconsole"
 
-# Use a persistent storage volume for sqlite database files and local Active Storage files.
-# Recommended to change this to a mounted volume path that is backed up off server.
+# Persistent storage for Active Storage uploads inside the app container.
 volumes:
   - "hostedgpt_storage:/rails/storage"
 
-# Bridge fingerprinted assets, like JS and CSS, between versions to avoid
-# hitting 404 on in-flight requests. Combines all files from new and old
-# version inside the asset_path.
+# Bridge fingerprinted assets between versions to avoid 404s mid-deploy.
 asset_path: /rails/public/assets
 
-# Configure the image builder.
+# Configure the image builder: the kamal-production Dockerfile stage
+# (child of fly-production), built for amd64 servers. On an arm64 server,
+# change arch accordingly (untested).
 builder:
   arch: amd64
-
-# # Build image via remote server (useful for faster amd64 builds on arm64 computers)
-# remote: ssh://docker@docker-builder-server
-#
-# # Pass arguments and secrets to the Docker build process
-# args:
-#   RUBY_VERSION: ruby-3.3.5
-# secrets:
-#   - GITHUB_TOKEN
-#   - RAILS_MASTER_KEY
+  target: kamal-production
 
 # Use a different ssh user than root
 # ssh:
 #   user: deploy
 
-# Use accessory services (secrets come from .kamal/secrets).
+# The Postgres accessory. Its container name (`hostedgpt-db`) is the hostname
+# the app connects to via HOSTED_DB_HOST. Data persists in a named host
+# directory, and that directory is your database; back it up (see README).
 accessories:
   db:
     image: postgres:16
-    host: 168.192.0.1
-    # port: 5432
-    env:
-      clear:
-        POSTGRES_DB: hostedgpt_production
-      secret:
-        - POSTGRES_PASSWORD
+    host: 192.0.2.1
     directories:
       - data:/var/lib/postgresql/data
+    env:
+      clear:
+        POSTGRES_USER: hostedgpt
+        POSTGRES_DB: hostedgpt_production
+      secret:
+        - POSTGRES_PASSWORD:HOSTED_DB_PASSWORD

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,10 @@ Rails.application.configure do
   config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Required for Kamal (config/deploy.yml): kamal-proxy's deploy healthcheck
+  # polls /up over plain HTTP inside the server, and force_ssl would redirect
+  # it, failing every deploy.
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new($stdout)

--- a/test/deployment_config_test.rb
+++ b/test/deployment_config_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+require "yaml"
+
+class DeploymentConfigTest < ActiveSupport::TestCase
+  test "deploy.yml uses the current HOSTED_DB_* env family" do
+    config = YAML.load_file(Rails.root.join("config/deploy.yml"))
+    clear = config.dig("env", "clear")
+
+    assert clear["HOSTED_DB_HOST"], "the HOSTED_DB_* env family must be present"
+    assert clear["HOSTED_DB_USERNAME"], "the HOSTED_DB_* env family must be present"
+    assert clear["HOSTED_DB_NAME"], "the HOSTED_DB_* env family must be present"
+    assert_not_includes File.read(Rails.root.join("config/deploy.yml")), "HOSTEDGPT_",
+      "config/deploy.yml must not reference the deprecated HOSTEDGPT_* env family"
+  end
+
+  test "deploy.yml accessory publishes no database port by any mechanism" do
+    config = YAML.load_file(Rails.root.join("config/deploy.yml"))
+    accessory = config.dig("accessories", "db")
+
+    assert accessory, "the db accessory must be declared"
+    assert_nil accessory["port"], "the Postgres accessory must not publish a host port"
+    assert_nil accessory["ports"], "the Postgres accessory must not publish host ports"
+    assert_not accessory["options"].to_s.match?(/publish|ports/),
+      "the Postgres accessory must not publish ports via docker options either"
+  end
+
+  test "deploy.yml accessory hostname matches Kamal's container-name rule" do
+    config = YAML.load_file(Rails.root.join("config/deploy.yml"))
+    service = config["service"]
+    assert config.key?("accessories"), "the db accessory must be declared for HOSTED_DB_HOST to resolve"
+
+    # Kamal sets no network aliases: an accessory resolves by its container
+    # name, which is "<service>-<accessory name>".
+    config["accessories"].each do |name, _|
+      assert_equal "#{service}-#{name}", config.dig("env", "clear", "HOSTED_DB_HOST"),
+        "HOSTED_DB_HOST must be the accessory's container name (Kamal sets no network aliases)"
+    end
+  end
+
+  test "app port agrees across deploy.yml and the Dockerfile stage" do
+    config = YAML.load_file(Rails.root.join("config/deploy.yml"))
+    app_port = config.dig("proxy", "app_port")
+
+    assert_equal app_port, config.dig("env", "clear", "PORT"),
+      "the app container's PORT must match proxy.app_port or the healthcheck fails"
+    dockerfile_env_port = File.read(Rails.root.join("Dockerfile"))
+      .lines.grep(/^ENV PORT=/).first
+    assert_equal "PORT=#{app_port}", dockerfile_env_port&.strip&.delete_prefix("ENV "),
+      "the kamal-production stage's ENV PORT must match proxy.app_port"
+  end
+
+  test "builder target names a real Dockerfile stage, with kamal-production after fly-production and render-production last" do
+    config = YAML.load_file(Rails.root.join("config/deploy.yml"))
+    stages = File.read(Rails.root.join("Dockerfile"))
+      .lines.grep(/^FROM /)
+    stage_names = stages.map { |line| line.split(/ as /i).last.strip }
+    parents = stages.to_h { |line|
+      _, parent, name = line.match(/^FROM\s+(\S+)\s+AS\s+(\S+)/).to_a
+      [name, parent]
+    }.compact
+
+    target = config.dig("builder", "target")
+    assert_includes stage_names, target,
+      "builder.target must name a Dockerfile stage that exists"
+    assert_equal "fly-production", parents["kamal-production"],
+      "kamal-production must be a child of fly-production or it loses the built gems, app code, user, and ENTRYPOINT"
+    assert stage_names.index("kamal-production") > stage_names.index("fly-production"),
+      "kamal-production must come after fly-production"
+    assert_equal "render-production", stage_names.last,
+      "render-production must remain the final Dockerfile stage (Render builds the last stage)"
+  end
+
+  test "docker-entrypoint uses a POSIX-compatible equality test for the server branch" do
+    content = File.read(Rails.root.join("bin/docker-entrypoint"))
+    assert_match(/\[\s+"\$\{2\}"\s+=\s+"server"\s+\]/, content,
+      "the server-arg test must use `=` (dash, the production base image's /bin/sh, rejects `==`, which silently skips db:prepare)")
+    assert_not content.match?(/==\s+"server"/),
+      "no branch may test the server arg with == (dash rejects it)"
+  end
+
+  test "dockerignore excludes the kamal secrets directory" do
+    active_lines = File.read(Rails.root.join(".dockerignore"))
+      .lines.map(&:strip).reject { |line| line.empty? || line.start_with?("#") }
+
+    assert_includes active_lines, "/.kamal",
+      ".kamal/secrets must never enter a Docker build context"
+  end
+
+  test "production keeps force_ssl with the /up health-check redirect exemption" do
+    active_lines = File.read(Rails.root.join("config/environments/production.rb"))
+      .lines.map(&:strip).reject { |line| line.empty? || line.start_with?("#") }
+
+    assert_includes active_lines, "config.force_ssl = true"
+    assert_includes active_lines,
+      'config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }',
+      "the /up exemption must be active (uncommented) so kamal-proxy's healthcheck succeeds over HTTP"
+  end
+
+  test "kamal secrets file is not tracked" do
+    tracked = `git ls-files .kamal`.strip
+    assert_empty tracked, ".kamal/secrets holds deployment secrets and must never be committed"
+  end
+end


### PR DESCRIPTION
**Work In Progress.** The series is complete and fully verified locally. What remains before this leaves WIP: a live validation run on a clean amd64 Ubuntu server, and maintainer feedback on the approach. Nobody has been pinged yet; no announcement comments or mentions exist on purpose until the validation record lands.

### Add Kamal deployment support (revival of #518)

This revives #518, Dr Nic Williams' Kamal deployment PR from October 2024, onto current main. The first two commits are Dr Nic Williams' originals, rebased with cherry-pick provenance (`-x`); the modernization commits that adapt that deploy.yml and Dockerfile work carry `Co-authored-by:` trailers crediting Dr Nic Williams. In the original review thread, duckworth reported hostedgpt running under Kamal in production on this image family. Their only issue, the `/up` healthcheck hitting the force_ssl redirect, is fixed in this series. This aims to close #161 when merged, subject to maintainer confirmation of the close criteria (asked when this leaves WIP).

#### Summary

One-command self-hosting: `bundle exec kamal setup` takes a fresh Ubuntu server to HTTPS HostedGPT with zero-downtime rollover, automatic Let's Encrypt via kamal-proxy, and migrations run at container boot. There are no accounts on any external service: no Docker Hub or GHCR account, no Redis (Solid Queue runs in Puma).

- **`config/deploy.yml` (new), modernized for Kamal 2.12** (gem pinned to the validated 2.12 line). The image registry is local to the deployer's machine (`localhost:5555`); the target server pulls it through a temporary SSH tunnel during deploy. The postgres 16 accessory is named `db`, so it resolves by container name as `hostedgpt-db` (Kamal sets no network aliases), and it publishes no host port by design, since Docker-published ports bypass host-firewall rules.
- **Secrets via `.kamal/secrets`** (gitignored and dockerignored, asserted untracked by test): the `HOSTED_DB_*` env family plus `CONFIGURE_ACTIVE_RECORD_ENCRYPTION_FROM_ENV: true`. This is the same secrets contract `render.yaml` already proves out for this app, so migrating from Render reuses the original `ACTIVE_RECORD_ENCRYPTION_*` values and stored credentials stay decryptable. Not Rails credentials: the revived original unlocked `credentials.yml.enc` with `RAILS_MASTER_KEY`; this replaces that with the ENV contract.
- **`kamal-production` Dockerfile stage**, a child of `fly-production`: it inherits the lean runtime image (jemalloc, YJIT, multi-stage, non-root) without disturbing the existing Fly/Render targets, and `render-production` remains the final stage so Render builds are untouched.
- **POSIX fix in `bin/docker-entrypoint`** (`==` → `=`): dash, the production base image's `/bin/sh`, rejects `==`, so the original entrypoint silently never ran `db:prepare`. A test now pins it.
- **`/up` force_ssl exemption** in `config/environments/production.rb`: kamal-proxy's healthcheck probes over HTTP and Rails no longer redirects it (duckworth's issue). `force_ssl` itself stays on; the revived branch disabled it app-wide, this is the scoped fix.
- **README: "Deploy the app with Kamal"** joins the existing deploy sections (Render, Fly.io, Heroku, own server): prerequisites, secret generation with an offline-backup warning, the one-time `.kamal/secrets` setup, `kamal setup`/`deploy`/`rollback`, a database backup recipe, and the arm64 caveat. The existing `Deploy on your own server` section keeps its heading and content untouched; the new section links to it for a no-Docker path.

#### Live validation

This PR stays WIP until `kamal setup` is confirmed working on real servers. To try it, follow [Deploy the app with Kamal](https://github.com/strivedi183/hostedgpt/blob/revive-kamal-deployment/README.md#deploy-the-app-with-kamal) on this branch, then report the outcome: provider, distro, arch, what worked, what didn't. Known-untested: arm64 (set `builder.arch: arm64` in `config/deploy.yml`) and non-Ubuntu distros. The authors will run the same validation on a clean amd64 Ubuntu VPS before this leaves WIP.
