### PR TITLE
feat(rubyllm): generate images via Context#paint behind use_ruby_llm flag

### DIFF
--- a/app/services/ai_backend/ruby_llm.rb
+++ b/app/services/ai_backend/ruby_llm.rb
@@ -5,6 +5,8 @@ class AIBackend::RubyLLM < AIBackend
   class ConfigurationError < AIBackend::ConfigurationError; end
   class ToolCallIntercepted < StandardError; end
 
+  IMAGE_MODEL = "gpt-image-1"
+
   CONFIGURATION_ERRORS = [
     ::RubyLLM::UnauthorizedError, ::RubyLLM::ConfigurationError,
     ::RubyLLM::BadRequestError, ::RubyLLM::ForbiddenError,
@@ -56,6 +58,33 @@ class AIBackend::RubyLLM < AIBackend
     end
   rescue ::Faraday::Error => e
     "Error: #{e.message}"
+  end
+
+  # Image generation: the flag routes here via api_service.ai_backend instead
+  # of the base AIBackend → AIBackend::OpenAI delegation. Image generation
+  # always rides the user's OpenAI service (even when the chat backend is
+  # Anthropic/Gemini) — same provider, different client. The flag-off path
+  # keeps using AIBackend::OpenAI.generate_image until Phase 7.
+  def self.generate_image(prompt:, user:)
+    # Uses name "OpenAI" to avoid picking up Groq (also driver: :openai).
+    openai_service = user.api_services.find_by(name: "OpenAI", driver: :openai)
+    token = openai_service&.effective_token
+
+    if openai_service.nil? || token.blank?
+      current_backend = Current.message&.assistant&.language_model&.api_service&.name || "current AI backend"
+      raise "OpenAI API key not found. Image generation requires an OpenAI API key. Please configure your OpenAI API key in Settings > API Services to use image generation with #{current_backend}."
+    end
+
+    context = client.context { |c| c.openai_api_key = token }
+    image = context.paint(
+      prompt,
+      model: IMAGE_MODEL,
+      provider: :openai,
+      assume_model_exists: true,
+      size: "1024x1024",
+    )
+
+    { b64_json: image.data, model: IMAGE_MODEL }
   end
 
   def initialize(user, assistant, conversation = nil, message = nil)

--- a/test/services/toolbox/image_ruby_llm_test.rb
+++ b/test/services/toolbox/image_ruby_llm_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class Toolbox::ImageRubyLLMTest < ActiveSupport::TestCase
+  setup do
+    @tool = Toolbox::Image.new
+    @prompt = "A cartoon image of a cat"
+  end
+
+  teardown do
+    TestClient::RubyLLM::ContextDouble.reset_recordings!
+  end
+
+  test "flag on: generate_an_image paints through RubyLLM with the user's OpenAI key" do
+    stub_features(use_ruby_llm: true) do
+      Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
+        result = @tool.generate_an_image(image_generation_prompt_s: @prompt)
+
+        recorded = TestClient::RubyLLM::ContextDouble.last_paint_call
+        assert_equal @prompt, recorded[:prompt]
+        assert_equal "abc-secret", recorded[:openai_api_key]
+        assert_equal "gpt-image-1", recorded[:kwargs][:model]
+        assert_equal :openai, recorded[:kwargs][:provider]
+        assert_equal "1024x1024", recorded[:kwargs][:size]
+
+        assert_equal @prompt, result[:prompt_given]
+        assert_equal "RUBYLLM_BASE64_IMAGE_DATA", result[:json_of_generated_image]
+        assert_includes result[:note_to_assistant], "image"
+        assert_equal "Image created by tool using OpenAI model gpt-image-1", result[:message_to_user]
+      end
+    end
+  end
+
+  test "flag on: an Anthropic assistant still generates the image through the user's OpenAI service" do
+    stub_features(use_ruby_llm: true) do
+      anthropic_message = messages(:image_generation_tool_call).dup
+      anthropic_message.assistant = assistants(:keith_claude3)
+
+      Current.set(user: users(:keith), message: anthropic_message) do
+        result = @tool.generate_an_image(image_generation_prompt_s: @prompt)
+
+        assert_equal "RUBYLLM_BASE64_IMAGE_DATA", result[:json_of_generated_image]
+        assert_equal "Image created by tool using OpenAI model gpt-image-1", result[:message_to_user]
+      end
+    end
+  end
+
+  test "flag on: a Groq service (also driver openai) is not mistaken for the OpenAI image service" do
+    stub_features(use_ruby_llm: true) do
+      users(:keith).api_services.where(name: "OpenAI").update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      users(:keith).reload # drop the memoized api_services association so soft-deletes are visible
+
+      Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
+        error = assert_raises(RuntimeError) { @tool.generate_an_image(image_generation_prompt_s: @prompt) }
+        assert_includes error.message, "OpenAI API key not found"
+      end
+    end
+  end
+
+  test "flag on: generate_an_image raises when the OpenAI service exists but has no token" do
+    stub_features(use_ruby_llm: true, default_llm_keys: false) do
+      api_services(:keith_openai_service).update!(token: nil)
+
+      Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
+        error = assert_raises(RuntimeError) { @tool.generate_an_image(image_generation_prompt_s: @prompt) }
+        assert_includes error.message, "OpenAI API key not found"
+      end
+    end
+  end
+
+  test "flag on: generate_an_image surfaces the backend error when no OpenAI service is configured" do
+    stub_features(use_ruby_llm: true) do
+      users(:keith).api_services.update_all(deleted_at: Time.current) # rubocop:disable Rails/SkipsModelValidations
+      users(:keith).reload # drop the memoized api_services association so soft-deletes are visible
+
+      Current.set(user: users(:keith), message: messages(:image_generation_tool_call)) do
+        error = assert_raises(RuntimeError) { @tool.generate_an_image(image_generation_prompt_s: @prompt) }
+        assert_includes error.message, "OpenAI API key not found"
+      end
+    end
+  end
+end

--- a/test/support/test_client/ruby_llm.rb
+++ b/test/support/test_client/ruby_llm.rb
@@ -142,6 +142,30 @@ module TestClient
     class ContextDouble
       attr_accessor :openai_api_key, :anthropic_api_key, :gemini_api_key,
         :openai_api_base, :anthropic_api_base, :gemini_api_base
+
+      # Mirrors the real RubyLLM::Context#paint: records the call and returns an
+      # Image-shaped double. Used to exercise AIBackend::RubyLLM.generate_image.
+      def paint(prompt, **kwargs)
+        raise self.class.paint_error_to_raise if self.class.paint_error_to_raise
+
+        self.class.last_paint_call = { prompt: prompt, kwargs: kwargs, openai_api_key: openai_api_key }
+        OpenStruct.new(data: self.class.image_data, url: self.class.image_url, mime_type: "image/png")
+      end
+
+      class << self
+        attr_accessor :image_url, :paint_error_to_raise, :last_paint_call
+
+        def image_data
+          @image_data || "RUBYLLM_BASE64_IMAGE_DATA"
+        end
+
+        def reset_recordings!
+          @last_paint_call = nil
+          @image_data = nil
+          @image_url = nil
+          @paint_error_to_raise = nil
+        end
+      end
     end
 
     def self.context(&block)


### PR DESCRIPTION
## RubyLLM image generation behind the `use_ruby_llm` flag

Completes the optional Phase 6 item skipped in #775: `AIBackend::RubyLLM.generate_image` wraps a keyed `RubyLLM.context.paint` instead of inheriting the #780 delegation to `AIBackend::OpenAI.generate_image`. Same `{ b64_json:, model: }` contract and dispatch seam — flag off keeps the ruby-openai path byte-identical.

### Related PRs

- **#775** — completes its optional Phase 6 item
- **#797 (provider-identity-dispatch)** — both directions:
  - #797 scopes the old path to the canonical OpenAI URL; this branch keeps the name-based lookup, so reconcile both to URL-based selection when #797 merges
  - Until #797 lands, its stored per-backend choices are inert at dispatch, so image-gen routing here follows only the `use_ruby_llm` flag.

### Known trade-off (deferred to #797)

A renamed OpenAI service keeps image gen flag-off but gets the "OpenAI API key not found" error flag-on. The URL-based reconciliation above resolves it.

### Testing

- `bin/rails test`: 912 runs, 0 failures; old-path tests untouched.
- Live dogfood: image generated via a Claude chat; `images/generations` POST confirmed.
- Phase 7 (if implemented) can remove `ruby-openai`.