### PR TITLE
Fix avatar circles rendering as ovals

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,16 @@
 module ApplicationHelper
+  # Tailwind only emits classes it finds written out in full in the source, so
+  # a size must resolve to a literal "w-N h-N" rather than be interpolated as
+  # "w-#{size}" (which the scanner can't see and silently drops from the build).
+  SQUARE_SIZE_CLASSES = {
+    6  => "w-6 h-6",
+    7  => "w-7 h-7",
+    16 => "w-16 h-16",
+  }.freeze
+
+  def square_size_classes(size)
+    SQUARE_SIZE_CLASSES.fetch(size)
+  end
 
   def at_most_two_initials(initials)
     return initials if initials.nil? || initials.length <= 2
@@ -7,7 +19,7 @@ module ApplicationHelper
 
   def spinner(opts = {})
     html = <<~HTML
-      <svg class="animate-spin -ml-1 mr-3 h-#{opts[:size]} w-#{opts[:size]} #{opts[:class]}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+      <svg class="animate-spin -ml-1 mr-3 #{square_size_classes(opts[:size])} #{opts[:class]}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
       </svg>

--- a/app/views/layouts/_assistant_avatar.html.erb
+++ b/app/views/layouts/_assistant_avatar.html.erb
@@ -1,6 +1,6 @@
 <%# locals: (assistant:, size:, classes: nil) -%>
 <% initials_font_size = assistant.initials.to_s.length > 1 ? "text-[10px] tracking-tighter" : (size > 6 ? "text-sm" : "text-xs") %>
-<% shared_classes = "rounded-full w-#{size} h-#{size} #{classes}" %>
+<% shared_classes = "rounded-full #{square_size_classes(size)} #{classes}" %>
 <% logo = assistant.logo_filename %>
 
 <% if logo %>

--- a/app/views/layouts/_user_avatar.html.erb
+++ b/app/views/layouts/_user_avatar.html.erb
@@ -4,8 +4,8 @@
 <% if user.has_profile_picture? && user.profile_picture.variable? %>
   <picture
     class="
-      rounded-full
-      w-<%= size %> h-<%= size %>
+      block rounded-full
+      <%= square_size_classes(size) %>
       overflow-hidden
       border border-gray-200 dark:border-gray-600
       <%= classes %>
@@ -19,7 +19,7 @@
   <picture
     class="
       rounded-full
-      w-<%= size %> h-<%= size %>
+      <%= square_size_classes(size) %>
       bg-green-200 text-black
       flex justify-center items-center
       <%= text_size %>

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -30,6 +30,18 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "pQ", at_most_two_initials("p v Q")
   end
 
+  test "square_size_classes spells out the width and height so tailwind can find them" do
+    assert_equal "w-7 h-7", square_size_classes(7)
+  end
+
+  test "square_size_classes raises on a size tailwind would not have generated" do
+    assert_raises(KeyError) { square_size_classes(99) }
+  end
+
+  test "spinner is sized through square_size_classes" do
+    assert_includes spinner(size: 6), "w-6 h-6"
+  end
+
   # Profile picture helper tests
   test "user_avatar_image_tag returns nil when user has no profile picture" do
     user = users(:keith)


### PR DESCRIPTION
Fixes #798

## What was wrong

The avatar partials built their size classes dynamically (`w-<%= size %> h-<%= size %>`), which Tailwind's content scanner can't see. That only worked while a literal `w-7 h-7` happened to exist elsewhere in the codebase. #797 replaced the last one (a placeholder in `_settings_item`) with the `assistant_avatar` partial, so `.h-7` silently dropped out of the built CSS and the `<picture>` in the message row's flex column stretched to the row's full height — hence the ovals.

The `spinner` helper had the same latent bug: `.h-6`/`.w-6` were also missing from the build.

## Changes

- **`ApplicationHelper#square_size_classes(size)`** maps a size to a literal `"w-N h-N"` string (helpers are in Tailwind's `content` list) and uses `fetch` so an unsupported size fails loudly instead of silently breaking layout — same philosophy as `Feature`/`Setting`.
- `_user_avatar`, `_assistant_avatar`, and `spinner` use it instead of interpolating.
- **Person edit page:** the profile-picture `<picture>` is inline by default (Tailwind's preflight blockifies `img`, not `picture`). Inside the flex containers in the header and message list that's harmless, but on the person edit page its border fragmented around the block `<img>` and drew a line above and below the photo. Added `block`.
- Tests for the mapping, the loud failure, and the spinner.

## Verification

- After `tailwindcss:build`, `.h-6 .w-6 .h-7 .w-7 .h-16 .w-16` are all present (three were absent before).
- Full suite green: 930 runs, 0 failures.
- Person edit avatar measured via a throwaway system test: 100×145 `inline` before → 64×64 `block` after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
